### PR TITLE
Move pr review to github runners (not self hosted)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -6,7 +6,7 @@ on:
   issue_comment:
 jobs:
   pr-review:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     if: ${{ github.event.sender.type != 'Bot' }}
     permissions:
       issues: write


### PR DESCRIPTION
### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Switch to GitHub-hosted runners

- Update workflow runner to ubuntu-latest


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Workflow pr-review.yml"] -- "change runner" --> B["runs-on: ubuntu-latest"]
  A -- "remove self-hosted labels" --> C["use GitHub-hosted runner"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-review.yml</strong><dd><code>Move pr-review job to GitHub-hosted runner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-review.yml

<ul><li>Replace self-hosted runner labels with ubuntu-latest<br> <li> Keep job name, triggers, and permissions unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/Interactive-AI-Labs/interactive-cli/pull/30/files#diff-ee9bf7bbe9abf7b72c579b32d4e5fad5de41d3ba6ee351c5d10c43e805bfc475">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

