### PR TITLE
CLI: fix: expand glossary and variable examples to show multiple entries

### DIFF
--- a/cmd/glossaries.go
+++ b/cmd/glossaries.go
@@ -24,9 +24,16 @@ Example (glossary.json):
         "name": "AHT",
         "description": "Average Handle Time",
         "synonyms": ["handle time"]
+      },
+      "kyc": {
+        "name": "KYC",
+        "description": "Know Your Customer",
+        "synonyms": ["identity check"]
       }
     }
   }
+
+  Add as many entries under 'terms' as you need — each key must be unique.
 
 The server automatically assigns the "latest" label to new versions. To make a
 version retrievable via the default 'get' (which resolves "production"), assign
@@ -70,9 +77,16 @@ Example (glossary.json):
         "name": "AHT",
         "description": "Average Handle Time",
         "synonyms": ["handle time"]
+      },
+      "kyc": {
+        "name": "KYC",
+        "description": "Know Your Customer",
+        "synonyms": ["identity check"]
       }
     }
   }
+
+  Add as many entries under 'terms' as you need — each key must be unique.
 
 Examples:
   iai glossaries update finance-terms --file glossary.json

--- a/cmd/templates/schema_glossaries.md
+++ b/cmd/templates/schema_glossaries.md
@@ -9,7 +9,15 @@ Run `iai glossaries schema` to see the current field definitions.
       "name": "AHT",
       "description": "Average Handle Time",
       "synonyms": ["handle time"]
+    },
+    "kyc": {
+      "name": "KYC",
+      "description": "Know Your Customer",
+      "synonyms": ["identity check"]
     }
   }
 }
 ```
+
+Each key under `terms` must be unique. Add as many terms as you need — the
+glossary accepts any number of entries.

--- a/cmd/templates/schema_variables.md
+++ b/cmd/templates/schema_variables.md
@@ -8,7 +8,14 @@ Run `iai variables schema` to see the current field definitions.
     "user_name": {
       "description": "The user's display name",
       "default_value": "Guest"
+    },
+    "is_authenticated": {
+      "description": "Whether the user has completed sign-in",
+      "default_value": false
     }
   }
 }
 ```
+
+Each key under `variables` must be unique. Add as many entries as you need —
+the set accepts any number of variables.

--- a/cmd/variables.go
+++ b/cmd/variables.go
@@ -23,9 +23,15 @@ Example (variables.json):
       "user_name": {
         "description": "The user's display name",
         "default_value": "Guest"
+      },
+      "is_authenticated": {
+        "description": "Whether the user has completed sign-in",
+        "default_value": false
       }
     }
   }
+
+  Add as many entries under 'variables' as you need — each key must be unique.
 
 The server automatically assigns the "latest" label to new versions. To make a
 version retrievable via the default 'get' (which resolves "production"), assign
@@ -68,9 +74,15 @@ Example (variables.json):
       "user_name": {
         "description": "The user's display name",
         "default_value": "Guest"
+      },
+      "is_authenticated": {
+        "description": "Whether the user has completed sign-in",
+        "default_value": false
       }
     }
   }
+
+  Add as many entries under 'variables' as you need — each key must be unique.
 
 Examples:
   iai variables update session-vars --file variables.json

--- a/docs/iai_glossaries_create.md
+++ b/docs/iai_glossaries_create.md
@@ -19,10 +19,18 @@ Run `iai glossaries schema` to see the current field definitions.
       "name": "AHT",
       "description": "Average Handle Time",
       "synonyms": ["handle time"]
+    },
+    "kyc": {
+      "name": "KYC",
+      "description": "Know Your Customer",
+      "synonyms": ["identity check"]
     }
   }
 }
 ```
+
+Each key under `terms` must be unique. Add as many terms as you need — the
+glossary accepts any number of entries.
 
 ### Options
 

--- a/docs/iai_glossaries_update.md
+++ b/docs/iai_glossaries_update.md
@@ -21,10 +21,18 @@ Run `iai glossaries schema` to see the current field definitions.
       "name": "AHT",
       "description": "Average Handle Time",
       "synonyms": ["handle time"]
+    },
+    "kyc": {
+      "name": "KYC",
+      "description": "Know Your Customer",
+      "synonyms": ["identity check"]
     }
   }
 }
 ```
+
+Each key under `terms` must be unique. Add as many terms as you need — the
+glossary accepts any number of entries.
 
 ### Options
 

--- a/docs/iai_variables_create.md
+++ b/docs/iai_variables_create.md
@@ -18,10 +18,17 @@ Run `iai variables schema` to see the current field definitions.
     "user_name": {
       "description": "The user's display name",
       "default_value": "Guest"
+    },
+    "is_authenticated": {
+      "description": "Whether the user has completed sign-in",
+      "default_value": false
     }
   }
 }
 ```
+
+Each key under `variables` must be unique. Add as many entries as you need —
+the set accepts any number of variables.
 
 ### Options
 

--- a/docs/iai_variables_update.md
+++ b/docs/iai_variables_update.md
@@ -20,10 +20,17 @@ Run `iai variables schema` to see the current field definitions.
     "user_name": {
       "description": "The user's display name",
       "default_value": "Guest"
+    },
+    "is_authenticated": {
+      "description": "Whether the user has completed sign-in",
+      "default_value": false
     }
   }
 }
 ```
+
+Each key under `variables` must be unique. Add as many entries as you need —
+the set accepts any number of variables.
 
 ### Options
 


### PR DESCRIPTION
 This PR updates the iai glossaries and iai variables long-form help (and the regenerated docs/iai_*.md) to:                                                                                    
 - show two dict-keyed entries in the example payload,                                                                                                                                          
 - include a synonyms array on each glossary term,                                                                                                                                              
 - add a one-line note that any number of entries is allowed and keys must be unique.  