### PR TITLE
feat(prompts): add `labels set` command for prompt versions

### DIFF
--- a/cmd/prompt_types.go
+++ b/cmd/prompt_types.go
@@ -60,8 +60,18 @@ func registerPromptType(ptCfg PromptTypeConfig) {
 
 	versionsCmd := makeVersionsCmd(ptCfg)
 	diffCmd := makeDiffCmd(ptCfg)
+	labelsCmd := makeLabelsCmd(ptCfg)
 
-	parentCmd.AddCommand(createCmd, listCmd, getCmd, updateCmd, deleteCmd, versionsCmd, diffCmd)
+	parentCmd.AddCommand(
+		createCmd,
+		listCmd,
+		getCmd,
+		updateCmd,
+		deleteCmd,
+		versionsCmd,
+		diffCmd,
+		labelsCmd,
+	)
 
 	if ptCfg.HasSchema {
 		schemaCmd := makeSchemaCmd(ptCfg)
@@ -532,6 +542,96 @@ Examples:
 		},
 	}
 
+	cmd.Flags().StringVarP(&project, "project", "p", "", "Project name that owns the prompts")
+	cmd.Flags().StringVarP(&org, "organization", "o", "", "Organization name that owns the project")
+
+	return cmd
+}
+
+func makeLabelsCmd(ptCfg PromptTypeConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "labels",
+		Aliases: []string{"label"},
+		Short:   fmt.Sprintf("Manage labels on %s versions", ptCfg.Plural),
+		Long: fmt.Sprintf(`Manage labels on existing %s versions.
+
+This command group reassigns labels to existing versions without creating a
+new version. Labels are unique per prompt: assigning a label to one version
+removes it from any other version that currently has it.`, ptCfg.Plural),
+	}
+
+	cmd.AddCommand(makeLabelsSetCmd(ptCfg))
+
+	return cmd
+}
+
+func makeLabelsSetCmd(ptCfg PromptTypeConfig) *cobra.Command {
+	var (
+		version int
+		labels  []string
+		project string
+		org     string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "set <name>",
+		Short: fmt.Sprintf("Set labels on a %s version", ptCfg.TypeName),
+		Long: fmt.Sprintf(
+			`Set labels on an existing %s version, identified by name and version number.
+
+Labels are unique per prompt: assigning a label to one version removes it
+from any other version that currently has it. No new version is created.
+
+Examples:
+  iai %s labels set my-%s --version 3 --labels production
+  iai %s labels set my-%s --version 1 --labels staging,canary`,
+			ptCfg.TypeName,
+			ptCfg.Plural,
+			ptCfg.TypeName,
+			ptCfg.Plural,
+			ptCfg.TypeName,
+		),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+			name := strings.TrimSpace(args[0])
+
+			pCtx, apiClient, _, err := resolveProject(cmd.Context(), org, project)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintln(out)
+			fmt.Fprintf(
+				out,
+				"Setting labels on %s %q version %d...\n",
+				ptCfg.TypeName,
+				name,
+				version,
+			)
+
+			result, err := apiClient.SetPromptLabels(
+				cmd.Context(),
+				pCtx.projectId,
+				ptCfg.RouteSegment,
+				name,
+				version,
+				labels,
+			)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintln(out)
+			return output.PrintPromptDetail(out, result)
+		},
+	}
+
+	cmd.Flags().IntVar(&version, "version", 0, "Version number to assign labels to")
+	_ = cmd.MarkFlagRequired("version")
+	cmd.Flags().
+		StringSliceVar(&labels, "labels", nil, "Labels to assign (comma-separated)")
+	_ = cmd.MarkFlagRequired("labels")
 	cmd.Flags().StringVarP(&project, "project", "p", "", "Project name that owns the prompts")
 	cmd.Flags().StringVarP(&org, "organization", "o", "", "Organization name that owns the project")
 

--- a/cmd/prompts.go
+++ b/cmd/prompts.go
@@ -36,6 +36,7 @@ types: "text" (default) and "chat".`,
 		makeGenericDeleteCmd(),
 		makeGenericVersionsCmd(),
 		makeGenericDiffCmd(),
+		makeGenericLabelsCmd(),
 	)
 
 	rootCmd.AddCommand(parentCmd)
@@ -524,6 +525,83 @@ Examples:
 		},
 	}
 
+	cmd.Flags().StringVarP(&project, "project", "p", "", "Project name that owns the prompts")
+	cmd.Flags().StringVarP(&org, "organization", "o", "", "Organization name that owns the project")
+
+	return cmd
+}
+
+func makeGenericLabelsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "labels",
+		Aliases: []string{"label"},
+		Short:   "Manage labels on prompt versions",
+		Long: `Manage labels on existing prompt versions.
+
+This command group reassigns labels to existing versions without creating a
+new version. Labels are unique per prompt: assigning a label to one version
+removes it from any other version that currently has it.`,
+	}
+
+	cmd.AddCommand(makeGenericLabelsSetCmd())
+
+	return cmd
+}
+
+func makeGenericLabelsSetCmd() *cobra.Command {
+	var (
+		version int
+		labels  []string
+		project string
+		org     string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "set <name>",
+		Short: "Set labels on a prompt version",
+		Long: `Set labels on an existing prompt version, identified by name and version number.
+
+Labels are unique per prompt: assigning a label to one version removes it
+from any other version that currently has it. No new version is created.
+
+Examples:
+  iai prompts labels set greeting --version 3 --labels production
+  iai prompts labels set greeting --version 1 --labels staging,canary`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+			name := strings.TrimSpace(args[0])
+
+			pCtx, apiClient, _, err := resolveProject(cmd.Context(), org, project)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintln(out)
+			fmt.Fprintf(out, "Setting labels on prompt %q version %d...\n", name, version)
+
+			result, err := apiClient.SetPromptLabels(
+				cmd.Context(),
+				pCtx.projectId,
+				"", // empty route segment → generic /prompts endpoint
+				name,
+				version,
+				labels,
+			)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintln(out)
+			return output.PrintPromptDetail(out, result)
+		},
+	}
+
+	cmd.Flags().IntVar(&version, "version", 0, "Version number to assign labels to")
+	_ = cmd.MarkFlagRequired("version")
+	cmd.Flags().
+		StringSliceVar(&labels, "labels", nil, "Labels to assign (comma-separated)")
+	_ = cmd.MarkFlagRequired("labels")
 	cmd.Flags().StringVarP(&project, "project", "p", "", "Project name that owns the prompts")
 	cmd.Flags().StringVarP(&org, "organization", "o", "", "Organization name that owns the project")
 

--- a/docs/iai_glossaries.md
+++ b/docs/iai_glossaries.md
@@ -31,6 +31,7 @@ format).
 * [iai glossaries delete](iai_glossaries_delete.md)	 - Delete a glossary
 * [iai glossaries describe](iai_glossaries_describe.md)	 - Describe a glossary in detail
 * [iai glossaries diff](iai_glossaries_diff.md)	 - Compare two versions of a glossary
+* [iai glossaries labels](iai_glossaries_labels.md)	 - Manage labels on glossaries versions
 * [iai glossaries list](iai_glossaries_list.md)	 - List glossaries in a project
 * [iai glossaries schema](iai_glossaries_schema.md)	 - Display the JSON Schema for glossaries
 * [iai glossaries update](iai_glossaries_update.md)	 - Update a glossary (creates a new version)

--- a/docs/iai_glossaries_labels.md
+++ b/docs/iai_glossaries_labels.md
@@ -1,0 +1,32 @@
+## iai glossaries labels
+
+Manage labels on glossaries versions
+
+### Synopsis
+
+Manage labels on existing glossaries versions.
+
+This command group reassigns labels to existing versions without creating a
+new version. Labels are unique per prompt: assigning a label to one version
+removes it from any other version that currently has it.
+
+### Options
+
+```
+  -h, --help   help for labels
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai glossaries](iai_glossaries.md)	 - Domain vocabularies for consistent term interpretation
+* [iai glossaries labels set](iai_glossaries_labels_set.md)	 - Set labels on a glossary version
+

--- a/docs/iai_glossaries_labels_set.md
+++ b/docs/iai_glossaries_labels_set.md
@@ -1,0 +1,42 @@
+## iai glossaries labels set
+
+Set labels on a glossary version
+
+### Synopsis
+
+Set labels on an existing glossary version, identified by name and version number.
+
+Labels are unique per prompt: assigning a label to one version removes it
+from any other version that currently has it. No new version is created.
+
+Examples:
+  iai glossaries labels set my-glossary --version 3 --labels production
+  iai glossaries labels set my-glossary --version 1 --labels staging,canary
+
+```
+iai glossaries labels set <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help                  help for set
+      --labels strings        Labels to assign (comma-separated)
+  -o, --organization string   Organization name that owns the project
+  -p, --project string        Project name that owns the prompts
+      --version int           Version number to assign labels to
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai glossaries labels](iai_glossaries_labels.md)	 - Manage labels on glossaries versions
+

--- a/docs/iai_macros.md
+++ b/docs/iai_macros.md
@@ -31,6 +31,7 @@ No schema validation is applied — any text content is accepted.
 * [iai macros delete](iai_macros_delete.md)	 - Delete a macro
 * [iai macros describe](iai_macros_describe.md)	 - Describe a macro in detail
 * [iai macros diff](iai_macros_diff.md)	 - Compare two versions of a macro
+* [iai macros labels](iai_macros_labels.md)	 - Manage labels on macros versions
 * [iai macros list](iai_macros_list.md)	 - List macros in a project
 * [iai macros update](iai_macros_update.md)	 - Update a macro (creates a new version)
 * [iai macros versions](iai_macros_versions.md)	 - List versions of a macro

--- a/docs/iai_macros_labels.md
+++ b/docs/iai_macros_labels.md
@@ -1,0 +1,32 @@
+## iai macros labels
+
+Manage labels on macros versions
+
+### Synopsis
+
+Manage labels on existing macros versions.
+
+This command group reassigns labels to existing versions without creating a
+new version. Labels are unique per prompt: assigning a label to one version
+removes it from any other version that currently has it.
+
+### Options
+
+```
+  -h, --help   help for labels
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai macros](iai_macros.md)	 - Pre-approved response templates used in routines
+* [iai macros labels set](iai_macros_labels_set.md)	 - Set labels on a macro version
+

--- a/docs/iai_macros_labels_set.md
+++ b/docs/iai_macros_labels_set.md
@@ -1,0 +1,42 @@
+## iai macros labels set
+
+Set labels on a macro version
+
+### Synopsis
+
+Set labels on an existing macro version, identified by name and version number.
+
+Labels are unique per prompt: assigning a label to one version removes it
+from any other version that currently has it. No new version is created.
+
+Examples:
+  iai macros labels set my-macro --version 3 --labels production
+  iai macros labels set my-macro --version 1 --labels staging,canary
+
+```
+iai macros labels set <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help                  help for set
+      --labels strings        Labels to assign (comma-separated)
+  -o, --organization string   Organization name that owns the project
+  -p, --project string        Project name that owns the prompts
+      --version int           Version number to assign labels to
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai macros labels](iai_macros_labels.md)	 - Manage labels on macros versions
+

--- a/docs/iai_policies.md
+++ b/docs/iai_policies.md
@@ -31,6 +31,7 @@ responses (YAML format).
 * [iai policies delete](iai_policies_delete.md)	 - Delete a policy
 * [iai policies describe](iai_policies_describe.md)	 - Describe a policy in detail
 * [iai policies diff](iai_policies_diff.md)	 - Compare two versions of a policy
+* [iai policies labels](iai_policies_labels.md)	 - Manage labels on policies versions
 * [iai policies list](iai_policies_list.md)	 - List policies in a project
 * [iai policies schema](iai_policies_schema.md)	 - Display the JSON Schema for policies
 * [iai policies update](iai_policies_update.md)	 - Update a policy (creates a new version)

--- a/docs/iai_policies_labels.md
+++ b/docs/iai_policies_labels.md
@@ -1,0 +1,32 @@
+## iai policies labels
+
+Manage labels on policies versions
+
+### Synopsis
+
+Manage labels on existing policies versions.
+
+This command group reassigns labels to existing versions without creating a
+new version. Labels are unique per prompt: assigning a label to one version
+removes it from any other version that currently has it.
+
+### Options
+
+```
+  -h, --help   help for labels
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai policies](iai_policies.md)	 - Single-step behavioral rules for agents
+* [iai policies labels set](iai_policies_labels_set.md)	 - Set labels on a policy version
+

--- a/docs/iai_policies_labels_set.md
+++ b/docs/iai_policies_labels_set.md
@@ -1,0 +1,42 @@
+## iai policies labels set
+
+Set labels on a policy version
+
+### Synopsis
+
+Set labels on an existing policy version, identified by name and version number.
+
+Labels are unique per prompt: assigning a label to one version removes it
+from any other version that currently has it. No new version is created.
+
+Examples:
+  iai policies labels set my-policy --version 3 --labels production
+  iai policies labels set my-policy --version 1 --labels staging,canary
+
+```
+iai policies labels set <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help                  help for set
+      --labels strings        Labels to assign (comma-separated)
+  -o, --organization string   Organization name that owns the project
+  -p, --project string        Project name that owns the prompts
+      --version int           Version number to assign labels to
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai policies labels](iai_policies_labels.md)	 - Manage labels on policies versions
+

--- a/docs/iai_prompts.md
+++ b/docs/iai_prompts.md
@@ -32,6 +32,7 @@ types: "text" (default) and "chat".
 * [iai prompts delete](iai_prompts_delete.md)	 - Delete a prompt
 * [iai prompts describe](iai_prompts_describe.md)	 - Describe a prompt in detail
 * [iai prompts diff](iai_prompts_diff.md)	 - Compare two versions of a prompt
+* [iai prompts labels](iai_prompts_labels.md)	 - Manage labels on prompt versions
 * [iai prompts list](iai_prompts_list.md)	 - List prompts in a project
 * [iai prompts update](iai_prompts_update.md)	 - Update a prompt (creates a new version)
 * [iai prompts versions](iai_prompts_versions.md)	 - List versions of a prompt

--- a/docs/iai_prompts_labels.md
+++ b/docs/iai_prompts_labels.md
@@ -1,0 +1,32 @@
+## iai prompts labels
+
+Manage labels on prompt versions
+
+### Synopsis
+
+Manage labels on existing prompt versions.
+
+This command group reassigns labels to existing versions without creating a
+new version. Labels are unique per prompt: assigning a label to one version
+removes it from any other version that currently has it.
+
+### Options
+
+```
+  -h, --help   help for labels
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai prompts](iai_prompts.md)	 - Versioned prompts for agents, evaluators, and guardrails
+* [iai prompts labels set](iai_prompts_labels_set.md)	 - Set labels on a prompt version
+

--- a/docs/iai_prompts_labels_set.md
+++ b/docs/iai_prompts_labels_set.md
@@ -1,0 +1,42 @@
+## iai prompts labels set
+
+Set labels on a prompt version
+
+### Synopsis
+
+Set labels on an existing prompt version, identified by name and version number.
+
+Labels are unique per prompt: assigning a label to one version removes it
+from any other version that currently has it. No new version is created.
+
+Examples:
+  iai prompts labels set greeting --version 3 --labels production
+  iai prompts labels set greeting --version 1 --labels staging,canary
+
+```
+iai prompts labels set <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help                  help for set
+      --labels strings        Labels to assign (comma-separated)
+  -o, --organization string   Organization name that owns the project
+  -p, --project string        Project name that owns the prompts
+      --version int           Version number to assign labels to
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai prompts labels](iai_prompts_labels.md)	 - Manage labels on prompt versions
+

--- a/docs/iai_routines.md
+++ b/docs/iai_routines.md
@@ -31,6 +31,7 @@ states (YAML format).
 * [iai routines delete](iai_routines_delete.md)	 - Delete a routine
 * [iai routines describe](iai_routines_describe.md)	 - Describe a routine in detail
 * [iai routines diff](iai_routines_diff.md)	 - Compare two versions of a routine
+* [iai routines labels](iai_routines_labels.md)	 - Manage labels on routines versions
 * [iai routines list](iai_routines_list.md)	 - List routines in a project
 * [iai routines schema](iai_routines_schema.md)	 - Display the JSON Schema for routines
 * [iai routines update](iai_routines_update.md)	 - Update a routine (creates a new version)

--- a/docs/iai_routines_labels.md
+++ b/docs/iai_routines_labels.md
@@ -1,0 +1,32 @@
+## iai routines labels
+
+Manage labels on routines versions
+
+### Synopsis
+
+Manage labels on existing routines versions.
+
+This command group reassigns labels to existing versions without creating a
+new version. Labels are unique per prompt: assigning a label to one version
+removes it from any other version that currently has it.
+
+### Options
+
+```
+  -h, --help   help for labels
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai routines](iai_routines.md)	 - Multi-step behavioral processes for agents
+* [iai routines labels set](iai_routines_labels_set.md)	 - Set labels on a routine version
+

--- a/docs/iai_routines_labels_set.md
+++ b/docs/iai_routines_labels_set.md
@@ -1,0 +1,42 @@
+## iai routines labels set
+
+Set labels on a routine version
+
+### Synopsis
+
+Set labels on an existing routine version, identified by name and version number.
+
+Labels are unique per prompt: assigning a label to one version removes it
+from any other version that currently has it. No new version is created.
+
+Examples:
+  iai routines labels set my-routine --version 3 --labels production
+  iai routines labels set my-routine --version 1 --labels staging,canary
+
+```
+iai routines labels set <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help                  help for set
+      --labels strings        Labels to assign (comma-separated)
+  -o, --organization string   Organization name that owns the project
+  -p, --project string        Project name that owns the prompts
+      --version int           Version number to assign labels to
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai routines labels](iai_routines_labels.md)	 - Manage labels on routines versions
+

--- a/docs/iai_skills.md
+++ b/docs/iai_skills.md
@@ -37,6 +37,7 @@ the Copilot uses to route incoming queries to the right skill at runtime.
 * [iai skills delete](iai_skills_delete.md)	 - Delete a skill
 * [iai skills describe](iai_skills_describe.md)	 - Describe a skill in detail
 * [iai skills diff](iai_skills_diff.md)	 - Compare two versions of a skill
+* [iai skills labels](iai_skills_labels.md)	 - Manage labels on skills versions
 * [iai skills list](iai_skills_list.md)	 - List skills in a project
 * [iai skills update](iai_skills_update.md)	 - Update a skill (creates a new version)
 * [iai skills versions](iai_skills_versions.md)	 - List versions of a skill

--- a/docs/iai_skills_labels.md
+++ b/docs/iai_skills_labels.md
@@ -1,0 +1,32 @@
+## iai skills labels
+
+Manage labels on skills versions
+
+### Synopsis
+
+Manage labels on existing skills versions.
+
+This command group reassigns labels to existing versions without creating a
+new version. Labels are unique per prompt: assigning a label to one version
+removes it from any other version that currently has it.
+
+### Options
+
+```
+  -h, --help   help for labels
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai skills](iai_skills.md)	 - Manage Interactive Copilot skills (not to be confused with context items that configure the Interactive Agent)
+* [iai skills labels set](iai_skills_labels_set.md)	 - Set labels on a skill version
+

--- a/docs/iai_skills_labels_set.md
+++ b/docs/iai_skills_labels_set.md
@@ -1,0 +1,42 @@
+## iai skills labels set
+
+Set labels on a skill version
+
+### Synopsis
+
+Set labels on an existing skill version, identified by name and version number.
+
+Labels are unique per prompt: assigning a label to one version removes it
+from any other version that currently has it. No new version is created.
+
+Examples:
+  iai skills labels set my-skill --version 3 --labels production
+  iai skills labels set my-skill --version 1 --labels staging,canary
+
+```
+iai skills labels set <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help                  help for set
+      --labels strings        Labels to assign (comma-separated)
+  -o, --organization string   Organization name that owns the project
+  -p, --project string        Project name that owns the prompts
+      --version int           Version number to assign labels to
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai skills labels](iai_skills_labels.md)	 - Manage labels on skills versions
+

--- a/docs/iai_variables.md
+++ b/docs/iai_variables.md
@@ -31,6 +31,7 @@ Variables are persistent data fields that survive across conversation sessions
 * [iai variables delete](iai_variables_delete.md)	 - Delete a variable
 * [iai variables describe](iai_variables_describe.md)	 - Describe a variable in detail
 * [iai variables diff](iai_variables_diff.md)	 - Compare two versions of a variable
+* [iai variables labels](iai_variables_labels.md)	 - Manage labels on variables versions
 * [iai variables list](iai_variables_list.md)	 - List variables in a project
 * [iai variables schema](iai_variables_schema.md)	 - Display the JSON Schema for variables
 * [iai variables update](iai_variables_update.md)	 - Update a variable (creates a new version)

--- a/docs/iai_variables_labels.md
+++ b/docs/iai_variables_labels.md
@@ -1,0 +1,32 @@
+## iai variables labels
+
+Manage labels on variables versions
+
+### Synopsis
+
+Manage labels on existing variables versions.
+
+This command group reassigns labels to existing versions without creating a
+new version. Labels are unique per prompt: assigning a label to one version
+removes it from any other version that currently has it.
+
+### Options
+
+```
+  -h, --help   help for labels
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai variables](iai_variables.md)	 - Contextual attributes referenced in policies and routines
+* [iai variables labels set](iai_variables_labels_set.md)	 - Set labels on a variable version
+

--- a/docs/iai_variables_labels_set.md
+++ b/docs/iai_variables_labels_set.md
@@ -1,0 +1,42 @@
+## iai variables labels set
+
+Set labels on a variable version
+
+### Synopsis
+
+Set labels on an existing variable version, identified by name and version number.
+
+Labels are unique per prompt: assigning a label to one version removes it
+from any other version that currently has it. No new version is created.
+
+Examples:
+  iai variables labels set my-variable --version 3 --labels production
+  iai variables labels set my-variable --version 1 --labels staging,canary
+
+```
+iai variables labels set <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help                  help for set
+      --labels strings        Labels to assign (comma-separated)
+  -o, --organization string   Organization name that owns the project
+  -p, --project string        Project name that owns the prompts
+      --version int           Version number to assign labels to
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai variables labels](iai_variables_labels.md)	 - Manage labels on variables versions
+

--- a/internal/clients/api_client.go
+++ b/internal/clients/api_client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -1009,6 +1010,10 @@ type CreatePromptBody struct {
 	Config     map[string]any `json:"config,omitempty"`
 }
 
+type SetLabelsBody struct {
+	NewLabels []string `json:"newLabels"`
+}
+
 type promptAPIResponse struct {
 	Success bool            `json:"success"`
 	Data    json.RawMessage `json:"data"`
@@ -1272,6 +1277,65 @@ func (c *APIClient) DeletePrompt(
 	}
 
 	return nil
+}
+
+func (c *APIClient) SetPromptLabels(
+	ctx context.Context,
+	projectId, routeSegment, name string,
+	version int,
+	labels []string,
+) (*PromptDetail, error) {
+	body := SetLabelsBody{NewLabels: labels}
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode request body: %w", err)
+	}
+
+	path := promptBasePath(
+		projectId,
+		routeSegment,
+	) + "/" + url.PathEscape(
+		name,
+	) + "/versions/" + strconv.Itoa(
+		version,
+	)
+	req, err := c.newRequest(ctx, http.MethodPatch, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("prompt label update request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if msg := ExtractServerMessage(respBody); msg != "" {
+			return nil, fmt.Errorf("%s", msg)
+		}
+		return nil, fmt.Errorf("prompt label update failed with status %s", resp.Status)
+	}
+
+	var envelope promptAPIResponse
+	if err := json.Unmarshal(respBody, &envelope); err != nil {
+		return nil, fmt.Errorf("failed to decode prompt response: %w", err)
+	}
+
+	var result PromptDetail
+	if err := json.Unmarshal(envelope.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to decode prompt data: %w", err)
+	}
+
+	return &result, nil
 }
 
 type SchemaResponse struct {

--- a/internal/clients/api_client.go
+++ b/internal/clients/api_client.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -1291,12 +1290,10 @@ func (c *APIClient) SetPromptLabels(
 		return nil, fmt.Errorf("failed to encode request body: %w", err)
 	}
 
-	path := promptBasePath(
-		projectId,
-		routeSegment,
-	) + "/" + url.PathEscape(
-		name,
-	) + "/versions/" + strconv.Itoa(
+	path := fmt.Sprintf(
+		"%s/%s/versions/%d",
+		promptBasePath(projectId, routeSegment),
+		url.PathEscape(name),
 		version,
 	)
 	req, err := c.newRequest(ctx, http.MethodPatch, path)

--- a/internal/clients/api_client_test.go
+++ b/internal/clients/api_client_test.go
@@ -617,6 +617,201 @@ func TestAPIClientListMetricsDailySuccess(t *testing.T) {
 	}
 }
 
+func TestAPIClientSetPromptLabelsGenericPath(t *testing.T) {
+	var capturedBody SetLabelsBody
+	var capturedContentType string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("method = %s, want PATCH", r.Method)
+		}
+		if r.URL.Path != "/api/platform/v1/projects/proj-1/prompts/my-prompt/versions/3" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		capturedContentType = r.Header.Get("Content-Type")
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &capturedBody); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(
+			w,
+			`{"success":true,"data":{"id":"p-1","name":"my-prompt","type":"text","version":3,"projectId":"proj-1","labels":["production"]}}`,
+		)
+	}))
+	defer server.Close()
+
+	client, err := NewAPIClient(
+		server.URL,
+		5*time.Second,
+		"",
+		"",
+		[]*http.Cookie{{Name: "session", Value: "abc"}},
+	)
+	if err != nil {
+		t.Fatalf("NewAPIClient() error = %v", err)
+	}
+
+	result, err := client.SetPromptLabels(
+		context.Background(),
+		"proj-1",
+		"",
+		"my-prompt",
+		3,
+		[]string{"production"},
+	)
+	if err != nil {
+		t.Fatalf("SetPromptLabels() error = %v", err)
+	}
+	if result == nil || result.Name != "my-prompt" || result.Version != 3 {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+	if len(capturedBody.NewLabels) != 1 || capturedBody.NewLabels[0] != "production" {
+		t.Fatalf("captured body = %#v, want newLabels=[production]", capturedBody)
+	}
+	if capturedContentType != "application/json" {
+		t.Fatalf("content-type = %q, want application/json", capturedContentType)
+	}
+}
+
+func TestAPIClientSetPromptLabelsTypedPath(t *testing.T) {
+	var capturedBody SetLabelsBody
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("method = %s, want PATCH", r.Method)
+		}
+		if r.URL.Path != "/api/platform/v1/projects/proj-1/prompts/routines/morning-routine/versions/7" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &capturedBody); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(
+			w,
+			`{"success":true,"data":{"id":"p-2","name":"morning-routine","type":"routine","version":7,"projectId":"proj-1","labels":["staging","canary"]}}`,
+		)
+	}))
+	defer server.Close()
+
+	client, err := NewAPIClient(
+		server.URL,
+		5*time.Second,
+		"",
+		"",
+		[]*http.Cookie{{Name: "session", Value: "abc"}},
+	)
+	if err != nil {
+		t.Fatalf("NewAPIClient() error = %v", err)
+	}
+
+	result, err := client.SetPromptLabels(
+		context.Background(),
+		"proj-1",
+		"routines",
+		"morning-routine",
+		7,
+		[]string{"staging", "canary"},
+	)
+	if err != nil {
+		t.Fatalf("SetPromptLabels() error = %v", err)
+	}
+	if result == nil || result.Version != 7 {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+	if len(capturedBody.NewLabels) != 2 ||
+		capturedBody.NewLabels[0] != "staging" ||
+		capturedBody.NewLabels[1] != "canary" {
+		t.Fatalf("captured body = %#v, want newLabels=[staging canary]", capturedBody)
+	}
+}
+
+func TestAPIClientSetPromptLabelsRequestBodyContainsNewLabelsKey(t *testing.T) {
+	var rawBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(
+			w,
+			`{"success":true,"data":{"id":"p-3","name":"my-prompt","version":1,"projectId":"proj-1"}}`,
+		)
+	}))
+	defer server.Close()
+
+	client, err := NewAPIClient(
+		server.URL,
+		5*time.Second,
+		"",
+		"",
+		[]*http.Cookie{{Name: "session", Value: "abc"}},
+	)
+	if err != nil {
+		t.Fatalf("NewAPIClient() error = %v", err)
+	}
+
+	_, err = client.SetPromptLabels(
+		context.Background(),
+		"proj-1",
+		"",
+		"my-prompt",
+		1,
+		[]string{"production", "stable"},
+	)
+	if err != nil {
+		t.Fatalf("SetPromptLabels() error = %v", err)
+	}
+
+	if !strings.Contains(string(rawBody), `"newLabels"`) {
+		t.Fatalf("request body %q does not contain newLabels key", string(rawBody))
+	}
+	if !strings.Contains(string(rawBody), `"production"`) {
+		t.Fatalf("request body %q does not contain production label", string(rawBody))
+	}
+	if !strings.Contains(string(rawBody), `"stable"`) {
+		t.Fatalf("request body %q does not contain stable label", string(rawBody))
+	}
+}
+
+func TestAPIClientSetPromptLabelsReturnsServerMessage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(
+			w,
+			`{"success":false,"error":{"message":"prompt version not found"}}`,
+		)
+	}))
+	defer server.Close()
+
+	client, err := NewAPIClient(
+		server.URL,
+		5*time.Second,
+		"",
+		"",
+		[]*http.Cookie{{Name: "session", Value: "abc"}},
+	)
+	if err != nil {
+		t.Fatalf("NewAPIClient() error = %v", err)
+	}
+
+	_, err = client.SetPromptLabels(
+		context.Background(),
+		"proj-1",
+		"",
+		"missing",
+		999,
+		[]string{"production"},
+	)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "prompt version not found") {
+		t.Fatalf("error = %v, want extracted server message", err)
+	}
+}
+
 func TestAPIClientListMetricsDailyReturnsServerMessage(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)


### PR DESCRIPTION
## Summary

  Adds `iai <type> labels set <name> --version N --labels ...` for promoting an existing prompt version to a label without  creating a duplicate version. Wires into existing backend `PATCH .../versions/{version}` endpoints — **no backend changes**.

  Supersedes #97 (open since 2026-04-01, marked conflicting after the `cmd/prompts.go` / `cmd/prompt_types.go` rename + the addition of `describe`/`diff`/`versions` subcommands). Same feature, clean re-implementation against current `main`.

  ## Coverage

  All 7 prompt surfaces:
  - Generic: `iai prompts labels set <name>`
  - Typed (via `registerPromptType()`): `routines`, `policies`, `glossaries`, `variables`, `macros`, `skills`

  Note: `agents` is no longer wired through `registerPromptType()` (moved to the deployment-operator path in #104), so it's not in scope.

  ## Usage

  ```bash
  iai prompts labels set greeting --version 3 --labels production
  iai routines labels set my-routine --version 1 --labels staging,canary
  iai skills labels set my-skill --version 2 --labels production
  ```

  Labels are unique per prompt — assigning a label to one version atomically removes it from any other version that had it (server-side guarantee).

  ## Changes

  - **`internal/clients/api_client.go`** — new `SetLabelsBody` struct + `SetPromptLabels` method following the same 
  `newRequest` + manual marshal + envelope-unwrap pattern as `CreatePrompt`. 4 focused tests in `api_client_test.go` 
  covering generic + typed paths, body shape, and server-message surfacing on non-2xx.
  - **`cmd/prompt_types.go`** — adds `makeLabelsCmd(ptCfg)` (bare parent group with `label` alias) and
  `makeLabelsSetCmd(ptCfg)`, wired into `registerPromptType()` alongside `versionsCmd` / `diffCmd`. All 6 typed commands
  inherit automatically.
  - **`cmd/prompts.go`** — `makeGenericLabelsCmd()` / `makeGenericLabelsSetCmd()` for the generic prompts command.
  - **`docs/`** — 14 new auto-generated doc files (`*_labels.md`, `*_labels_set.md` for all 7 surfaces) + 7 updated parent
  indexes.

  The `labels` parent is intentionally a noun group (rather than a flat `set-labels` verb) so future label operations (`add`
   / `remove` / `list`) can land under it without breaking changes.

  ## Behaviour

  - Pure passthrough: no client-side validation of `--version` or `--labels` — backend decides what's valid, consistent with every other prompt command.
  - `--version` and `--labels` are both required; missing them exits non-zero with cobra's standard required-flag error.
  - Output uses the same `output.PrintPromptDetail` renderer as `create` / `get` / `update`.