### PR TITLE
DEV-672: Add compatibility matrix, schema versioning, and schema pretty-printer

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.28.2"
+current_version = "0.28.2-beta.1"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -41,6 +41,11 @@ var (
 	agentStackId string
 )
 
+var (
+	agentSchemaVersion string
+	agentSchemaJSON    bool
+)
+
 var agentsCmd = &cobra.Command{
 	Use:     "agents",
 	Aliases: []string{"agent"},
@@ -54,10 +59,17 @@ var agentCreateCmd = &cobra.Command{
 	Short: "Create an agent in a project",
 	Long: `Create an agent in a specific project.
 
-The --file flag takes a YAML file matching the agent_config schema — run
-'iai agents schema' to see the expected shape. Pass the agent name as the
-positional argument and id/version/env/secrets/endpoint/schedule via flags;
-do not include them inside the file.
+The --file flag takes a YAML file matching the agent_config schema. Pass the
+agent name as the positional argument and id/version/env/secrets/endpoint/schedule
+via flags; do not include them inside the file.
+
+The config schema depends on the agent version. Run
+'iai agents compatibility-matrix' to find which schema version applies, then
+'iai agents schema --schema-version <schema>' to see the expected fields.
+
+Routines and policies referenced in the config must already exist in the project
+and should be validated against the matching schema version (see --schema-version
+on their create/update commands).
 
 Examples:
   iai agents create chat-agent --id interactive-agent --version 0.0.1 --file agent-config.yaml
@@ -119,9 +131,15 @@ var agentUpdateCmd = &cobra.Command{
 Only the flags you pass are applied; everything else is left at its current
 value.
 
---file takes a YAML file matching the agent_config schema — run
-'iai agents schema' to see the expected shape — and replaces the entire agent
-config in full when provided (no per-field merge).
+--file takes a YAML file matching the agent_config schema and replaces the
+entire agent config in full when provided (no per-field merge). The config
+schema depends on the agent version — run 'iai agents compatibility-matrix'
+to find which schema version applies, then 'iai agents schema --schema-version <schema>'
+to see the expected fields.
+
+When upgrading to a new agent version with a different schema, update your
+routines and policies first using --schema-version on their create/update
+commands, then update the agent with the new config and version.
 
 Lists (--env, --secret) replace the entire current list when provided — pass
 every value you want to keep.
@@ -467,10 +485,17 @@ Examples:
 var agentSchemaCmd = &cobra.Command{
 	Use:   "schema",
 	Short: "Display the JSON Schema for agent configuration",
-	Long: `Fetch and display the current JSON Schema for the agent_config block.
+	Long: `Fetch and display the JSON Schema for the agent_config block.
+
+Defaults to the latest schema version. Use --schema-version to fetch a specific
+version (run 'iai agents compatibility-matrix' to see available versions).
+
+Use --json for the raw JSON Schema output.
 
 Examples:
-  iai agents schema`,
+  iai agents schema
+  iai agents schema --schema-version 2.1.0
+  iai agents schema --json`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
@@ -485,20 +510,59 @@ Examples:
 			return err
 		}
 
-		result, err := apiClient.GetAgentSchema(cmd.Context())
+		result, err := apiClient.GetAgentSchema(cmd.Context(), agentSchemaVersion)
 		if err != nil {
 			return err
 		}
 
-		fmt.Fprintf(out, "Schema version: %s\n\n", result.SchemaVersion)
-
-		var indented bytes.Buffer
-		if err := json.Indent(&indented, result.Schema, "", "  "); err != nil {
-			return fmt.Errorf("failed to format schema: %w", err)
+		if agentSchemaJSON {
+			fmt.Fprintf(out, "Schema version: %s\n\n", result.SchemaVersion)
+			var indented bytes.Buffer
+			if err := json.Indent(&indented, result.Schema, "", "  "); err != nil {
+				return fmt.Errorf("failed to format schema: %w", err)
+			}
+			fmt.Fprintln(out, indented.String())
+			return nil
 		}
-		fmt.Fprintln(out, indented.String())
 
-		return nil
+		return output.PrintSchemaPretty(out, result.Schema, result.SchemaVersion)
+	},
+}
+
+var agentCompatibilityMatrixJSON bool
+
+var agentCompatibilityMatrixCmd = &cobra.Command{
+	Use:   "compatibility-matrix",
+	Short: "Show agent version to schema version compatibility",
+	Long: `Display the compatibility matrix between agent versions and schema versions.
+
+Each agent version requires a specific config schema. Use this command to find
+the schema version for your target agent version, then run
+'iai agents schema --schema-version <schema>' to see the expected config fields.
+
+Prompt types (routines, policies, etc.) also support versioned schemas — use
+--schema-version on their create/update commands to validate against the
+matching version.
+
+By default, output is a formatted table. Use --json for machine-readable output.
+
+Examples:
+  iai agents compatibility-matrix
+  iai agents compatibility-matrix --json`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+
+		matrix, err := clients.GetAgentCompatibilityMatrix(
+			cmd.Context(),
+			hostname,
+			defaultHTTPTimeout,
+		)
+		if err != nil {
+			return err
+		}
+
+		return output.PrintCompatibilityMatrix(out, matrix, agentCompatibilityMatrixJSON)
 	},
 }
 
@@ -750,6 +814,16 @@ func init() {
 	agentPortForwardCmd.Flags().
 		IntVar(&agentPFLocalPort, "local-port", 0, "Local port to listen on (defaults to the remote port)")
 
+	// Flags for "agents schema"
+	agentSchemaCmd.Flags().
+		StringVar(&agentSchemaVersion, "schema-version", "", "Schema version to fetch (defaults to latest stable)")
+	agentSchemaCmd.Flags().
+		BoolVar(&agentSchemaJSON, "json", false, "Output raw JSON Schema instead of a formatted table")
+
+	// Flags for "agents compatibility-matrix"
+	agentCompatibilityMatrixCmd.Flags().
+		BoolVar(&agentCompatibilityMatrixJSON, "json", false, "Output raw JSON instead of a formatted table")
+
 	// Register commands
 	rootCmd.AddCommand(agentsCmd)
 	agentsCmd.AddCommand(agentCreateCmd)
@@ -764,4 +838,5 @@ func init() {
 	agentsCmd.AddCommand(agentRevisionsCmd)
 	agentsCmd.AddCommand(agentDiffCmd)
 	agentsCmd.AddCommand(agentPortForwardCmd)
+	agentsCmd.AddCommand(agentCompatibilityMatrixCmd)
 }

--- a/cmd/glossaries.go
+++ b/cmd/glossaries.go
@@ -17,6 +17,11 @@ format).`,
 Content is provided via a JSON file using the --file flag.
 Run 'iai glossaries schema' to see the current field definitions.
 
+Use --schema-version to validate against a specific schema version. This should
+match the schema version of the agent that will use this glossary (run
+'iai agents compatibility-matrix' to find it). Defaults to the latest stable
+schema version when omitted.
+
 Example (glossary.json):
   {
     "terms": {
@@ -41,6 +46,7 @@ the "production" label with --labels production.
 
 Examples:
   iai glossaries create finance-terms --file glossary.json
+  iai glossaries create finance-terms --file glossary.json --schema-version 2.1.0
   iai glossaries create finance-terms --file glossary.json --labels production
   iai glossaries create finance-terms --file glossary.json --tags domain`,
 		ListLong: `List glossary definitions in a specific project.
@@ -70,6 +76,11 @@ The previous versions are preserved and can still be accessed by version number.
 
 Run 'iai glossaries schema' to see the current field definitions.
 
+Use --schema-version to validate against a specific schema version. This should
+match the schema version of the agent that will use this glossary (run
+'iai agents compatibility-matrix' to find it). Defaults to the latest stable
+schema version when omitted.
+
 Example (glossary.json):
   {
     "terms": {
@@ -90,6 +101,7 @@ Example (glossary.json):
 
 Examples:
   iai glossaries update finance-terms --file glossary.json
+  iai glossaries update finance-terms --file glossary.json --schema-version 2.1.0
   iai glossaries update finance-terms --file glossary.json --labels production,staging`,
 		DeleteLong: `Delete a glossary definition and all its versions, or delete specific versions.
 

--- a/cmd/policies.go
+++ b/cmd/policies.go
@@ -18,6 +18,11 @@ Each prompt holds exactly one policy (flat YAML, fields at the root).
 Content is provided via a YAML file using the --file flag.
 Run 'iai policies schema' to see the current field definitions.
 
+Use --schema-version to validate against a specific schema version. This should
+match the schema version of the agent that will use this policy (run
+'iai agents compatibility-matrix' to find it). Defaults to the latest stable
+schema version when omitted.
+
 Example (policy.yaml):
   id: escalate
   name: Escalation Policy
@@ -31,6 +36,7 @@ the "production" label with --labels production.
 
 Examples:
   iai policies create safety-rules --file policy.yaml
+  iai policies create safety-rules --file policy.yaml --schema-version 2.1.0
   iai policies create safety-rules --file policy.yaml --labels production
   iai policies create safety-rules --file policy.yaml --tags compliance`,
 		ListLong: `List policies in a specific project.
@@ -61,6 +67,11 @@ The previous versions are preserved and can still be accessed by version number.
 Each prompt holds exactly one policy (flat YAML, fields at the root).
 Run 'iai policies schema' to see the current field definitions.
 
+Use --schema-version to validate against a specific schema version. This should
+match the schema version of the agent that will use this policy (run
+'iai agents compatibility-matrix' to find it). Defaults to the latest stable
+schema version when omitted.
+
 Example (policy.yaml):
   id: escalate
   name: Escalation Policy
@@ -70,6 +81,7 @@ Example (policy.yaml):
 
 Examples:
   iai policies update safety-rules --file policy.yaml
+  iai policies update safety-rules --file policy.yaml --schema-version 2.1.0
   iai policies update safety-rules --file policy.yaml --labels production,staging`,
 		DeleteLong: `Delete a policy and all its versions, or delete specific versions.
 

--- a/cmd/prompt_types.go
+++ b/cmd/prompt_types.go
@@ -72,10 +72,18 @@ func registerPromptType(ptCfg PromptTypeConfig) {
 }
 
 func makeSchemaCmd(ptCfg PromptTypeConfig) *cobra.Command {
-	return &cobra.Command{
+	var (
+		schemaVersion string
+		asJSON        bool
+	)
+
+	cmd := &cobra.Command{
 		Use:   "schema",
 		Short: fmt.Sprintf("Display the JSON Schema for %s", ptCfg.Plural),
-		Long: fmt.Sprintf(`Fetch and display the current JSON Schema for %s from the backend API.
+		Long: fmt.Sprintf(`Fetch and display the JSON Schema for %s from the backend API.
+
+Use --schema-version to request a specific schema version (defaults to latest stable).
+Use --json to output the raw JSON Schema instead of a formatted table.
 
 This is a public endpoint and does not require authentication.`, ptCfg.Plural),
 		Args: cobra.NoArgs,
@@ -83,32 +91,43 @@ This is a public endpoint and does not require authentication.`, ptCfg.Plural),
 			out := cmd.OutOrStdout()
 
 			result, err := clients.GetPromptSchema(
-				cmd.Context(), hostname, defaultHTTPTimeout, ptCfg.TypeName,
+				cmd.Context(), hostname, defaultHTTPTimeout, ptCfg.TypeName, schemaVersion,
 			)
 			if err != nil {
 				return err
 			}
 
-			fmt.Fprintf(out, "Schema version: %s\n\n", result.SchemaVersion)
+			if asJSON {
+				fmt.Fprintf(out, "Schema version: %s\n\n", result.SchemaVersion)
 
-			var indented bytes.Buffer
-			if err := json.Indent(&indented, result.Schema, "", "  "); err != nil {
-				return fmt.Errorf("failed to format schema: %w", err)
+				var indented bytes.Buffer
+				if err := json.Indent(&indented, result.Schema, "", "  "); err != nil {
+					return fmt.Errorf("failed to format schema: %w", err)
+				}
+				fmt.Fprintln(out, indented.String())
+				return nil
 			}
-			fmt.Fprintln(out, indented.String())
 
-			return nil
+			return output.PrintSchemaPretty(out, result.Schema, result.SchemaVersion)
 		},
 	}
+
+	cmd.Flags().
+		StringVar(&schemaVersion, "schema-version", "", "Schema version to fetch (defaults to latest stable)")
+	cmd.Flags().
+		BoolVar(&asJSON, "json", false, "Output raw JSON Schema instead of a formatted table")
+
+	return cmd
 }
 
 func makeCreateCmd(ptCfg PromptTypeConfig) *cobra.Command {
 	var (
-		file    string
-		labels  []string
-		tags    []string
-		project string
-		org     string
+		file          string
+		labels        []string
+		tags          []string
+		project       string
+		org           string
+		schemaVersion string
 	)
 
 	cmd := &cobra.Command{
@@ -138,10 +157,11 @@ func makeCreateCmd(ptCfg PromptTypeConfig) *cobra.Command {
 		}
 
 		payload := clients.CreatePromptBody{
-			Name:   name,
-			Prompt: string(content),
-			Labels: labels,
-			Tags:   tags,
+			Name:          name,
+			Prompt:        string(content),
+			Labels:        labels,
+			Tags:          tags,
+			SchemaVersion: schemaVersion,
 		}
 		if configBuilder != nil {
 			payload.Config = configBuilder()
@@ -169,6 +189,8 @@ func makeCreateCmd(ptCfg PromptTypeConfig) *cobra.Command {
 	cmd.Flags().
 		StringSliceVar(&labels, "labels", nil, "Labels for the prompt version (comma-separated)")
 	cmd.Flags().StringSliceVar(&tags, "tags", nil, "Tags for the prompt (comma-separated)")
+	cmd.Flags().
+		StringVar(&schemaVersion, "schema-version", "", "Schema version to validate against (defaults to latest stable)")
 	cmd.Flags().StringVarP(&project, "project", "p", "", "Project name that owns the prompts")
 	cmd.Flags().StringVarP(&org, "organization", "o", "", "Organization name that owns the project")
 
@@ -285,11 +307,12 @@ func makeGetCmd(ptCfg PromptTypeConfig) *cobra.Command {
 
 func makeUpdateCmd(ptCfg PromptTypeConfig) *cobra.Command {
 	var (
-		file    string
-		labels  []string
-		tags    []string
-		project string
-		org     string
+		file          string
+		labels        []string
+		tags          []string
+		project       string
+		org           string
+		schemaVersion string
 	)
 
 	cmd := &cobra.Command{
@@ -319,10 +342,11 @@ func makeUpdateCmd(ptCfg PromptTypeConfig) *cobra.Command {
 		}
 
 		payload := clients.CreatePromptBody{
-			Name:   name,
-			Prompt: string(content),
-			Labels: labels,
-			Tags:   tags,
+			Name:          name,
+			Prompt:        string(content),
+			Labels:        labels,
+			Tags:          tags,
+			SchemaVersion: schemaVersion,
 		}
 		if configBuilder != nil {
 			payload.Config = configBuilder()
@@ -353,6 +377,8 @@ func makeUpdateCmd(ptCfg PromptTypeConfig) *cobra.Command {
 	cmd.Flags().
 		StringSliceVar(&labels, "labels", nil, "Labels for the new prompt version (comma-separated)")
 	cmd.Flags().StringSliceVar(&tags, "tags", nil, "Tags for the prompt (comma-separated)")
+	cmd.Flags().
+		StringVar(&schemaVersion, "schema-version", "", "Schema version to validate against (defaults to latest stable)")
 	cmd.Flags().StringVarP(&project, "project", "p", "", "Project name that owns the prompts")
 	cmd.Flags().StringVarP(&org, "organization", "o", "", "Organization name that owns the project")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	version            = "0.28.2"
+	version            = "0.28.2-beta.1"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second

--- a/cmd/routines.go
+++ b/cmd/routines.go
@@ -17,6 +17,11 @@ states (YAML format).`,
 Content is provided via a YAML file using the --file flag.
 Run 'iai routines schema' to see the current field definitions.
 
+Use --schema-version to validate against a specific schema version. This should
+match the schema version of the agent that will use this routine (run
+'iai agents compatibility-matrix' to find it). Defaults to the latest stable
+schema version when omitted.
+
 Example (routine.yaml):
   title: My Routine
   conditions: When user needs help
@@ -36,6 +41,7 @@ the "production" label with --labels production.
 
 Examples:
   iai routines create onboarding-flow --file routine.yaml
+  iai routines create onboarding-flow --file routine.yaml --schema-version 2.1.0
   iai routines create onboarding-flow --file routine.yaml --labels production
   iai routines create onboarding-flow --file routine.yaml --tags v2,experimental`,
 		ListLong: `List routines in a specific project.
@@ -65,6 +71,11 @@ The previous versions are preserved and can still be accessed by version number.
 
 Run 'iai routines schema' to see the current field definitions.
 
+Use --schema-version to validate against a specific schema version. This should
+match the schema version of the agent that will use this routine (run
+'iai agents compatibility-matrix' to find it). Defaults to the latest stable
+schema version when omitted.
+
 Example (routine.yaml):
   title: My Routine
   conditions: When user needs help
@@ -80,6 +91,7 @@ Example (routine.yaml):
 
 Examples:
   iai routines update onboarding-flow --file routine.yaml
+  iai routines update onboarding-flow --file routine.yaml --schema-version 2.1.0
   iai routines update onboarding-flow --file routine.yaml --labels production,staging`,
 		DeleteLong: `Delete a routine and all its versions, or delete specific versions.
 

--- a/cmd/variables.go
+++ b/cmd/variables.go
@@ -17,6 +17,11 @@ Variables are persistent data fields that survive across conversation sessions
 Content is provided via a JSON file using the --file flag.
 Run 'iai variables schema' to see the current field definitions.
 
+Use --schema-version to validate against a specific schema version. This should
+match the schema version of the agent that will use this variable (run
+'iai agents compatibility-matrix' to find it). Defaults to the latest stable
+schema version when omitted.
+
 Example (variables.json):
   {
     "variables": {
@@ -39,6 +44,7 @@ the "production" label with --labels production.
 
 Examples:
   iai variables create session-vars --file variables.json
+  iai variables create session-vars --file variables.json --schema-version 2.1.0
   iai variables create session-vars --file variables.json --labels production
   iai variables create session-vars --file variables.json --tags core`,
 		ListLong: `List variables in a specific project.
@@ -68,6 +74,11 @@ The previous versions are preserved and can still be accessed by version number.
 
 Run 'iai variables schema' to see the current field definitions.
 
+Use --schema-version to validate against a specific schema version. This should
+match the schema version of the agent that will use this variable (run
+'iai agents compatibility-matrix' to find it). Defaults to the latest stable
+schema version when omitted.
+
 Example (variables.json):
   {
     "variables": {
@@ -86,6 +97,7 @@ Example (variables.json):
 
 Examples:
   iai variables update session-vars --file variables.json
+  iai variables update session-vars --file variables.json --schema-version 2.1.0
   iai variables update session-vars --file variables.json --labels production,staging`,
 		DeleteLong: `Delete a variable definition and all its versions, or delete specific versions.
 

--- a/docs/iai_agents.md
+++ b/docs/iai_agents.md
@@ -25,6 +25,7 @@ Manage deployment of agents to InteractiveAI projects.
 
 * [iai](iai.md)	 - InteractiveAI's CLI
 * [iai agents catalog](iai_agents_catalog.md)	 - List available agent types and versions
+* [iai agents compatibility-matrix](iai_agents_compatibility-matrix.md)	 - Show agent version to schema version compatibility
 * [iai agents create](iai_agents_create.md)	 - Create an agent in a project
 * [iai agents delete](iai_agents_delete.md)	 - Delete an agent from a project
 * [iai agents describe](iai_agents_describe.md)	 - Describe an agent in detail

--- a/docs/iai_agents_compatibility-matrix.md
+++ b/docs/iai_agents_compatibility-matrix.md
@@ -1,0 +1,46 @@
+## iai agents compatibility-matrix
+
+Show agent version to schema version compatibility
+
+### Synopsis
+
+Display the compatibility matrix between agent versions and schema versions.
+
+Each agent version requires a specific config schema. Use this command to find
+the schema version for your target agent version, then run
+'iai agents schema --schema-version <schema>' to see the expected config fields.
+
+Prompt types (routines, policies, etc.) also support versioned schemas — use
+--schema-version on their create/update commands to validate against the
+matching version.
+
+By default, output is a formatted table. Use --json for machine-readable output.
+
+Examples:
+  iai agents compatibility-matrix
+  iai agents compatibility-matrix --json
+
+```
+iai agents compatibility-matrix [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for compatibility-matrix
+      --json   Output raw JSON instead of a formatted table
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai agents](iai_agents.md)	 - Deploy AI agents with policies, routines, and tools
+

--- a/docs/iai_agents_create.md
+++ b/docs/iai_agents_create.md
@@ -6,10 +6,17 @@ Create an agent in a project
 
 Create an agent in a specific project.
 
-The --file flag takes a YAML file matching the agent_config schema — run
-'iai agents schema' to see the expected shape. Pass the agent name as the
-positional argument and id/version/env/secrets/endpoint/schedule via flags;
-do not include them inside the file.
+The --file flag takes a YAML file matching the agent_config schema. Pass the
+agent name as the positional argument and id/version/env/secrets/endpoint/schedule
+via flags; do not include them inside the file.
+
+The config schema depends on the agent version. Run
+'iai agents compatibility-matrix' to find which schema version applies, then
+'iai agents schema --schema-version <schema>' to see the expected fields.
+
+Routines and policies referenced in the config must already exist in the project
+and should be validated against the matching schema version (see --schema-version
+on their create/update commands).
 
 Examples:
   iai agents create chat-agent --id interactive-agent --version 0.0.1 --file agent-config.yaml

--- a/docs/iai_agents_schema.md
+++ b/docs/iai_agents_schema.md
@@ -4,10 +4,17 @@ Display the JSON Schema for agent configuration
 
 ### Synopsis
 
-Fetch and display the current JSON Schema for the agent_config block.
+Fetch and display the JSON Schema for the agent_config block.
+
+Defaults to the latest schema version. Use --schema-version to fetch a specific
+version (run 'iai agents compatibility-matrix' to see available versions).
+
+Use --json for the raw JSON Schema output.
 
 Examples:
   iai agents schema
+  iai agents schema --schema-version 2.1.0
+  iai agents schema --json
 
 ```
 iai agents schema [flags]
@@ -16,7 +23,9 @@ iai agents schema [flags]
 ### Options
 
 ```
-  -h, --help   help for schema
+  -h, --help                    help for schema
+      --json                    Output raw JSON Schema instead of a formatted table
+      --schema-version string   Schema version to fetch (defaults to latest stable)
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_agents_update.md
+++ b/docs/iai_agents_update.md
@@ -9,9 +9,15 @@ Update an agent in a specific project.
 Only the flags you pass are applied; everything else is left at its current
 value.
 
---file takes a YAML file matching the agent_config schema — run
-'iai agents schema' to see the expected shape — and replaces the entire agent
-config in full when provided (no per-field merge).
+--file takes a YAML file matching the agent_config schema and replaces the
+entire agent config in full when provided (no per-field merge). The config
+schema depends on the agent version — run 'iai agents compatibility-matrix'
+to find which schema version applies, then 'iai agents schema --schema-version <schema>'
+to see the expected fields.
+
+When upgrading to a new agent version with a different schema, update your
+routines and policies first using --schema-version on their create/update
+commands, then update the agent with the new config and version.
 
 Lists (--env, --secret) replace the entire current list when provided — pass
 every value you want to keep.

--- a/docs/iai_glossaries_create.md
+++ b/docs/iai_glossaries_create.md
@@ -35,12 +35,13 @@ glossary accepts any number of entries.
 ### Options
 
 ```
-      --file string           Path to the file containing the prompt content
-  -h, --help                  help for create
-      --labels strings        Labels for the prompt version (comma-separated)
-  -o, --organization string   Organization name that owns the project
-  -p, --project string        Project name that owns the prompts
-      --tags strings          Tags for the prompt (comma-separated)
+      --file string             Path to the file containing the prompt content
+  -h, --help                    help for create
+      --labels strings          Labels for the prompt version (comma-separated)
+  -o, --organization string     Organization name that owns the project
+  -p, --project string          Project name that owns the prompts
+      --schema-version string   Schema version to validate against (defaults to latest stable)
+      --tags strings            Tags for the prompt (comma-separated)
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_glossaries_schema.md
+++ b/docs/iai_glossaries_schema.md
@@ -4,7 +4,10 @@ Display the JSON Schema for glossaries
 
 ### Synopsis
 
-Fetch and display the current JSON Schema for glossaries from the backend API.
+Fetch and display the JSON Schema for glossaries from the backend API.
+
+Use --schema-version to request a specific schema version (defaults to latest stable).
+Use --json to output the raw JSON Schema instead of a formatted table.
 
 This is a public endpoint and does not require authentication.
 
@@ -15,7 +18,9 @@ iai glossaries schema [flags]
 ### Options
 
 ```
-  -h, --help   help for schema
+  -h, --help                    help for schema
+      --json                    Output raw JSON Schema instead of a formatted table
+      --schema-version string   Schema version to fetch (defaults to latest stable)
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_glossaries_update.md
+++ b/docs/iai_glossaries_update.md
@@ -37,12 +37,13 @@ glossary accepts any number of entries.
 ### Options
 
 ```
-      --file string           Path to the file containing the updated prompt content
-  -h, --help                  help for update
-      --labels strings        Labels for the new prompt version (comma-separated)
-  -o, --organization string   Organization name that owns the project
-  -p, --project string        Project name that owns the prompts
-      --tags strings          Tags for the prompt (comma-separated)
+      --file string             Path to the file containing the updated prompt content
+  -h, --help                    help for update
+      --labels strings          Labels for the new prompt version (comma-separated)
+  -o, --organization string     Organization name that owns the project
+  -p, --project string          Project name that owns the prompts
+      --schema-version string   Schema version to validate against (defaults to latest stable)
+      --tags strings            Tags for the prompt (comma-separated)
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_macros_create.md
+++ b/docs/iai_macros_create.md
@@ -19,12 +19,13 @@ No schema validation is applied — any text content is accepted.
 ### Options
 
 ```
-      --file string           Path to the file containing the prompt content
-  -h, --help                  help for create
-      --labels strings        Labels for the prompt version (comma-separated)
-  -o, --organization string   Organization name that owns the project
-  -p, --project string        Project name that owns the prompts
-      --tags strings          Tags for the prompt (comma-separated)
+      --file string             Path to the file containing the prompt content
+  -h, --help                    help for create
+      --labels strings          Labels for the prompt version (comma-separated)
+  -o, --organization string     Organization name that owns the project
+  -p, --project string          Project name that owns the prompts
+      --schema-version string   Schema version to validate against (defaults to latest stable)
+      --tags strings            Tags for the prompt (comma-separated)
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_macros_update.md
+++ b/docs/iai_macros_update.md
@@ -21,12 +21,13 @@ No schema validation is applied — any text content is accepted.
 ### Options
 
 ```
-      --file string           Path to the file containing the updated prompt content
-  -h, --help                  help for update
-      --labels strings        Labels for the new prompt version (comma-separated)
-  -o, --organization string   Organization name that owns the project
-  -p, --project string        Project name that owns the prompts
-      --tags strings          Tags for the prompt (comma-separated)
+      --file string             Path to the file containing the updated prompt content
+  -h, --help                    help for update
+      --labels strings          Labels for the new prompt version (comma-separated)
+  -o, --organization string     Organization name that owns the project
+  -p, --project string          Project name that owns the prompts
+      --schema-version string   Schema version to validate against (defaults to latest stable)
+      --tags strings            Tags for the prompt (comma-separated)
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_policies_create.md
+++ b/docs/iai_policies_create.md
@@ -25,12 +25,13 @@ criticality: HIGH
 ### Options
 
 ```
-      --file string           Path to the file containing the prompt content
-  -h, --help                  help for create
-      --labels strings        Labels for the prompt version (comma-separated)
-  -o, --organization string   Organization name that owns the project
-  -p, --project string        Project name that owns the prompts
-      --tags strings          Tags for the prompt (comma-separated)
+      --file string             Path to the file containing the prompt content
+  -h, --help                    help for create
+      --labels strings          Labels for the prompt version (comma-separated)
+  -o, --organization string     Organization name that owns the project
+  -p, --project string          Project name that owns the prompts
+      --schema-version string   Schema version to validate against (defaults to latest stable)
+      --tags strings            Tags for the prompt (comma-separated)
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_policies_schema.md
+++ b/docs/iai_policies_schema.md
@@ -4,7 +4,10 @@ Display the JSON Schema for policies
 
 ### Synopsis
 
-Fetch and display the current JSON Schema for policies from the backend API.
+Fetch and display the JSON Schema for policies from the backend API.
+
+Use --schema-version to request a specific schema version (defaults to latest stable).
+Use --json to output the raw JSON Schema instead of a formatted table.
 
 This is a public endpoint and does not require authentication.
 
@@ -15,7 +18,9 @@ iai policies schema [flags]
 ### Options
 
 ```
-  -h, --help   help for schema
+  -h, --help                    help for schema
+      --json                    Output raw JSON Schema instead of a formatted table
+      --schema-version string   Schema version to fetch (defaults to latest stable)
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_policies_update.md
+++ b/docs/iai_policies_update.md
@@ -27,12 +27,13 @@ criticality: HIGH
 ### Options
 
 ```
-      --file string           Path to the file containing the updated prompt content
-  -h, --help                  help for update
-      --labels strings        Labels for the new prompt version (comma-separated)
-  -o, --organization string   Organization name that owns the project
-  -p, --project string        Project name that owns the prompts
-      --tags strings          Tags for the prompt (comma-separated)
+      --file string             Path to the file containing the updated prompt content
+  -h, --help                    help for update
+      --labels strings          Labels for the new prompt version (comma-separated)
+  -o, --organization string     Organization name that owns the project
+  -p, --project string          Project name that owns the prompts
+      --schema-version string   Schema version to validate against (defaults to latest stable)
+      --tags strings            Tags for the prompt (comma-separated)
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_routines_create.md
+++ b/docs/iai_routines_create.md
@@ -30,12 +30,13 @@ steps:
 ### Options
 
 ```
-      --file string           Path to the file containing the prompt content
-  -h, --help                  help for create
-      --labels strings        Labels for the prompt version (comma-separated)
-  -o, --organization string   Organization name that owns the project
-  -p, --project string        Project name that owns the prompts
-      --tags strings          Tags for the prompt (comma-separated)
+      --file string             Path to the file containing the prompt content
+  -h, --help                    help for create
+      --labels strings          Labels for the prompt version (comma-separated)
+  -o, --organization string     Organization name that owns the project
+  -p, --project string          Project name that owns the prompts
+      --schema-version string   Schema version to validate against (defaults to latest stable)
+      --tags strings            Tags for the prompt (comma-separated)
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_routines_schema.md
+++ b/docs/iai_routines_schema.md
@@ -4,7 +4,10 @@ Display the JSON Schema for routines
 
 ### Synopsis
 
-Fetch and display the current JSON Schema for routines from the backend API.
+Fetch and display the JSON Schema for routines from the backend API.
+
+Use --schema-version to request a specific schema version (defaults to latest stable).
+Use --json to output the raw JSON Schema instead of a formatted table.
 
 This is a public endpoint and does not require authentication.
 
@@ -15,7 +18,9 @@ iai routines schema [flags]
 ### Options
 
 ```
-  -h, --help   help for schema
+  -h, --help                    help for schema
+      --json                    Output raw JSON Schema instead of a formatted table
+      --schema-version string   Schema version to fetch (defaults to latest stable)
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_routines_update.md
+++ b/docs/iai_routines_update.md
@@ -32,12 +32,13 @@ steps:
 ### Options
 
 ```
-      --file string           Path to the file containing the updated prompt content
-  -h, --help                  help for update
-      --labels strings        Labels for the new prompt version (comma-separated)
-  -o, --organization string   Organization name that owns the project
-  -p, --project string        Project name that owns the prompts
-      --tags strings          Tags for the prompt (comma-separated)
+      --file string             Path to the file containing the updated prompt content
+  -h, --help                    help for update
+      --labels strings          Labels for the new prompt version (comma-separated)
+  -o, --organization string     Organization name that owns the project
+  -p, --project string          Project name that owns the prompts
+      --schema-version string   Schema version to validate against (defaults to latest stable)
+      --tags strings            Tags for the prompt (comma-separated)
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_skills_create.md
+++ b/docs/iai_skills_create.md
@@ -36,14 +36,15 @@ iai skills create <name> [flags]
 ### Options
 
 ```
-      --description string    Short description of the skill (stored in config.skill.description)
-      --file string           Path to the file containing the prompt content
-  -h, --help                  help for create
-      --intents stringArray   Natural-language intent that triggers this skill — repeat the flag once per intent (stored in config.skill.intents)
-      --labels strings        Labels for the prompt version (comma-separated)
-  -o, --organization string   Organization name that owns the project
-  -p, --project string        Project name that owns the prompts
-      --tags strings          Tags for the prompt (comma-separated)
+      --description string      Short description of the skill (stored in config.skill.description)
+      --file string             Path to the file containing the prompt content
+  -h, --help                    help for create
+      --intents stringArray     Natural-language intent that triggers this skill — repeat the flag once per intent (stored in config.skill.intents)
+      --labels strings          Labels for the prompt version (comma-separated)
+  -o, --organization string     Organization name that owns the project
+  -p, --project string          Project name that owns the prompts
+      --schema-version string   Schema version to validate against (defaults to latest stable)
+      --tags strings            Tags for the prompt (comma-separated)
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_skills_update.md
+++ b/docs/iai_skills_update.md
@@ -28,14 +28,15 @@ iai skills update <name> [flags]
 ### Options
 
 ```
-      --description string    Short description of the skill (stored in config.skill.description)
-      --file string           Path to the file containing the updated prompt content
-  -h, --help                  help for update
-      --intents stringArray   Natural-language intent that triggers this skill — repeat the flag once per intent (stored in config.skill.intents)
-      --labels strings        Labels for the new prompt version (comma-separated)
-  -o, --organization string   Organization name that owns the project
-  -p, --project string        Project name that owns the prompts
-      --tags strings          Tags for the prompt (comma-separated)
+      --description string      Short description of the skill (stored in config.skill.description)
+      --file string             Path to the file containing the updated prompt content
+  -h, --help                    help for update
+      --intents stringArray     Natural-language intent that triggers this skill — repeat the flag once per intent (stored in config.skill.intents)
+      --labels strings          Labels for the new prompt version (comma-separated)
+  -o, --organization string     Organization name that owns the project
+  -p, --project string          Project name that owns the prompts
+      --schema-version string   Schema version to validate against (defaults to latest stable)
+      --tags strings            Tags for the prompt (comma-separated)
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_variables_create.md
+++ b/docs/iai_variables_create.md
@@ -33,12 +33,13 @@ the set accepts any number of variables.
 ### Options
 
 ```
-      --file string           Path to the file containing the prompt content
-  -h, --help                  help for create
-      --labels strings        Labels for the prompt version (comma-separated)
-  -o, --organization string   Organization name that owns the project
-  -p, --project string        Project name that owns the prompts
-      --tags strings          Tags for the prompt (comma-separated)
+      --file string             Path to the file containing the prompt content
+  -h, --help                    help for create
+      --labels strings          Labels for the prompt version (comma-separated)
+  -o, --organization string     Organization name that owns the project
+  -p, --project string          Project name that owns the prompts
+      --schema-version string   Schema version to validate against (defaults to latest stable)
+      --tags strings            Tags for the prompt (comma-separated)
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_variables_schema.md
+++ b/docs/iai_variables_schema.md
@@ -4,7 +4,10 @@ Display the JSON Schema for variables
 
 ### Synopsis
 
-Fetch and display the current JSON Schema for variables from the backend API.
+Fetch and display the JSON Schema for variables from the backend API.
+
+Use --schema-version to request a specific schema version (defaults to latest stable).
+Use --json to output the raw JSON Schema instead of a formatted table.
 
 This is a public endpoint and does not require authentication.
 
@@ -15,7 +18,9 @@ iai variables schema [flags]
 ### Options
 
 ```
-  -h, --help   help for schema
+  -h, --help                    help for schema
+      --json                    Output raw JSON Schema instead of a formatted table
+      --schema-version string   Schema version to fetch (defaults to latest stable)
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_variables_update.md
+++ b/docs/iai_variables_update.md
@@ -35,12 +35,13 @@ the set accepts any number of variables.
 ### Options
 
 ```
-      --file string           Path to the file containing the updated prompt content
-  -h, --help                  help for update
-      --labels strings        Labels for the new prompt version (comma-separated)
-  -o, --organization string   Organization name that owns the project
-  -p, --project string        Project name that owns the prompts
-      --tags strings          Tags for the prompt (comma-separated)
+      --file string             Path to the file containing the updated prompt content
+  -h, --help                    help for update
+      --labels strings          Labels for the new prompt version (comma-separated)
+  -o, --organization string     Organization name that owns the project
+  -p, --project string          Project name that owns the prompts
+      --schema-version string   Schema version to validate against (defaults to latest stable)
+      --tags strings            Tags for the prompt (comma-separated)
 ```
 
 ### Options inherited from parent commands

--- a/internal/clients/api_client.go
+++ b/internal/clients/api_client.go
@@ -998,15 +998,17 @@ type PromptDetail struct {
 	CreatedAt      string          `json:"createdAt"`
 	UpdatedAt      string          `json:"updatedAt"`
 	ExpectedFormat string          `json:"expectedFormat"`
+	SchemaVersion  string          `json:"schemaVersion,omitempty"`
 }
 
 type CreatePromptBody struct {
-	Name       string         `json:"name"`
-	Prompt     string         `json:"prompt"`
-	Labels     []string       `json:"labels,omitempty"`
-	Tags       []string       `json:"tags,omitempty"`
-	PromptType string         `json:"promptType,omitempty"`
-	Config     map[string]any `json:"config,omitempty"`
+	Name          string         `json:"name"`
+	Prompt        string         `json:"prompt"`
+	Labels        []string       `json:"labels,omitempty"`
+	Tags          []string       `json:"tags,omitempty"`
+	PromptType    string         `json:"promptType,omitempty"`
+	Config        map[string]any `json:"config,omitempty"`
+	SchemaVersion string         `json:"schemaVersion,omitempty"`
 }
 
 type promptAPIResponse struct {
@@ -1286,6 +1288,7 @@ func GetPromptSchema(
 	hostname string,
 	timeout time.Duration,
 	typeName string,
+	version string,
 ) (*SchemaResponse, error) {
 	u, err := url.Parse(hostname)
 	if err != nil {
@@ -1296,6 +1299,12 @@ func GetPromptSchema(
 	u.Path = decodedPath
 	u.RawPath = rawPath
 
+	if version != "" {
+		q := u.Query()
+		q.Set("schema_version", version)
+		u.RawQuery = q.Encode()
+	}
+
 	httpClient := &http.Client{Timeout: timeout}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
@@ -1304,7 +1313,7 @@ func GetPromptSchema(
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("Could not fetch schema. Ensure --hostname is correct: %w", err)
+		return nil, fmt.Errorf("could not fetch schema, ensure --hostname is correct: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -1320,6 +1329,8 @@ func GetPromptSchema(
 		return nil, fmt.Errorf("failed to fetch schema: server returned %s", resp.Status)
 	}
 
+	// Prompt schema endpoint wraps the response in a {success, data} envelope,
+	// unlike the agent schema endpoint which returns SchemaResponse directly.
 	var envelope struct {
 		Success bool           `json:"success"`
 		Data    SchemaResponse `json:"data"`
@@ -1335,19 +1346,85 @@ func GetPromptSchema(
 	return &envelope.Data, nil
 }
 
+type CompatibilityEntry struct {
+	AgentVersion  string `json:"agentVersion"`
+	SchemaVersion string `json:"schemaVersion"`
+}
+
+func GetAgentCompatibilityMatrix(
+	ctx context.Context,
+	hostname string,
+	timeout time.Duration,
+) ([]CompatibilityEntry, error) {
+	u, err := url.Parse(hostname)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse hostname: %w", err)
+	}
+	u.Path = "/api/platform/v1/agents/compatibility-matrix"
+
+	httpClient := &http.Client{Timeout: timeout}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to create compatibility-matrix request: %w",
+			err,
+		)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"could not fetch compatibility matrix, ensure --hostname is correct: %w",
+			err,
+		)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read compatibility-matrix response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if msg := ExtractServerMessage(body); msg != "" {
+			return nil, fmt.Errorf("failed to fetch compatibility matrix: %s", msg)
+		}
+		return nil, fmt.Errorf(
+			"failed to fetch compatibility matrix: server returned %s",
+			resp.Status,
+		)
+	}
+
+	var matrix []CompatibilityEntry
+	if err := json.Unmarshal(body, &matrix); err != nil {
+		return nil, fmt.Errorf(
+			"failed to decode compatibility-matrix response: %w",
+			err,
+		)
+	}
+
+	return matrix, nil
+}
+
 // GetAgentSchema fetches the JSON Schema for agent configuration from the
 // platform API. Requires authentication with prompts:read capability.
 func (c *APIClient) GetAgentSchema(
 	ctx context.Context,
+	version string,
 ) (*SchemaResponse, error) {
 	req, err := c.newRequest(ctx, http.MethodGet, "/api/platform/v1/agents/schema")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create schema request: %w", err)
 	}
+	if version != "" {
+		q := req.URL.Query()
+		q.Set("schema_version", version)
+		req.URL.RawQuery = q.Encode()
+	}
 
 	resp, err := c.do(req)
 	if err != nil {
-		return nil, fmt.Errorf("Could not fetch schema. Ensure --hostname is correct: %w", err)
+		return nil, fmt.Errorf("could not fetch schema, ensure --hostname is correct: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -1356,6 +1433,8 @@ func (c *APIClient) GetAgentSchema(
 		return nil, fmt.Errorf("failed to read schema response: %w", err)
 	}
 
+	// Agent schema endpoint returns SchemaResponse directly, without the
+	// {success, data} envelope used by the prompt schema endpoint.
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		if msg := ExtractServerMessage(body); msg != "" {
 			return nil, fmt.Errorf("failed to fetch schema: %s", msg)

--- a/internal/output/agents.go
+++ b/internal/output/agents.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -207,6 +208,31 @@ func PrintAgentVersions(out io.Writer, agentId string, versions []string) error 
 	rows := make([][]string, len(versions))
 	for i, v := range versions {
 		rows[i] = []string{v}
+	}
+
+	return PrintTable(out, headers, rows)
+}
+
+func PrintCompatibilityMatrix(
+	out io.Writer,
+	matrix []clients.CompatibilityEntry,
+	asJSON bool,
+) error {
+	if asJSON {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(matrix)
+	}
+
+	if len(matrix) == 0 {
+		fmt.Fprintln(out, "No compatibility data available.")
+		return nil
+	}
+
+	headers := []string{"AGENT VERSION", "SCHEMA VERSION"}
+	rows := make([][]string, len(matrix))
+	for i, e := range matrix {
+		rows[i] = []string{e.AgentVersion, e.SchemaVersion}
 	}
 
 	return PrintTable(out, headers, rows)

--- a/internal/output/agents_test.go
+++ b/internal/output/agents_test.go
@@ -267,6 +267,53 @@ func TestPrintAgentCatalog(t *testing.T) {
 	}
 }
 
+func TestPrintCompatibilityMatrix(t *testing.T) {
+	tests := []struct {
+		name   string
+		matrix []clients.CompatibilityEntry
+		asJSON bool
+		want   string
+	}{
+		{
+			name:   "empty matrix prints message",
+			matrix: []clients.CompatibilityEntry{},
+			want:   "No compatibility data available.\n",
+		},
+		{
+			name: "table output",
+			matrix: []clients.CompatibilityEntry{
+				{AgentVersion: "0.1.0", SchemaVersion: "1.0.0"},
+				{AgentVersion: "0.2.0", SchemaVersion: "2.0.0"},
+			},
+			want: "AGENT VERSION   SCHEMA VERSION\n" +
+				"0.1.0           1.0.0\n" +
+				"0.2.0           2.0.0\n",
+		},
+		{
+			name: "json output",
+			matrix: []clients.CompatibilityEntry{
+				{AgentVersion: "0.1.0", SchemaVersion: "1.0.0"},
+			},
+			asJSON: true,
+			want: "[\n  {\n    \"agentVersion\": \"0.1.0\",\n" +
+				"    \"schemaVersion\": \"1.0.0\"\n  }\n]\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := PrintCompatibilityMatrix(&buf, tt.matrix, tt.asJSON)
+			if err != nil {
+				t.Fatalf("PrintCompatibilityMatrix() error = %v", err)
+			}
+			if got := buf.String(); got != tt.want {
+				t.Errorf("output mismatch\ngot:\n%q\nwant:\n%q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestPrintAgentVersions(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/output/prompts.go
+++ b/internal/output/prompts.go
@@ -60,6 +60,9 @@ func PrintPromptDetail(out io.Writer, prompt *clients.PromptDetail) error {
 	if len(prompt.Tags) > 0 {
 		fmt.Fprintf(w, "Tags:\t%s\n", strings.Join(prompt.Tags, ", "))
 	}
+	if prompt.SchemaVersion != "" {
+		fmt.Fprintf(w, "Schema:\t%s\n", prompt.SchemaVersion)
+	}
 	if prompt.CreatedAt != "" {
 		fmt.Fprintf(w, "Created At:\t%s\n", LocalTime(prompt.CreatedAt))
 	}

--- a/internal/output/schema.go
+++ b/internal/output/schema.go
@@ -1,0 +1,173 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+type jsonSchema struct {
+	Title       string                `json:"title"`
+	Description string                `json:"description"`
+	Type        string                `json:"type"`
+	Properties  map[string]jsonSchema `json:"properties"`
+	Required    []string              `json:"required"`
+	Defs        map[string]jsonSchema `json:"$defs"`
+	Ref         string                `json:"$ref"`
+	Items       *jsonSchema           `json:"items"`
+	AnyOf       []jsonSchema          `json:"anyOf"`
+	Enum        []any                 `json:"enum"`
+	Default     any                   `json:"default"`
+	Const       any                   `json:"const"`
+}
+
+func PrintSchemaPretty(out io.Writer, raw json.RawMessage, version string) error {
+	var root jsonSchema
+	if err := json.Unmarshal(raw, &root); err != nil {
+		return fmt.Errorf("failed to parse schema: %w", err)
+	}
+
+	fmt.Fprintf(out, "Schema version: %s\n", version)
+	fmt.Fprintf(out, "Full documentation: https://docs.interactive.ai/schemas\n")
+
+	if err := printTypeTable(out, root, root.Defs); err != nil {
+		return err
+	}
+
+	names := make([]string, 0, len(root.Defs))
+	for name := range root.Defs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		def := root.Defs[name]
+		def.Title = name
+		if err := printTypeTable(out, def, root.Defs); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func printTypeTable(out io.Writer, s jsonSchema, defs map[string]jsonSchema) error {
+	if len(s.Properties) == 0 {
+		return nil
+	}
+
+	title := s.Title
+	if title == "" {
+		title = "Schema"
+	}
+
+	fmt.Fprintf(out, "\n%s\n", title)
+	if s.Description != "" {
+		fmt.Fprintf(out, "  %s\n", s.Description)
+	}
+	fmt.Fprintln(out)
+
+	reqSet := make(map[string]bool, len(s.Required))
+	for _, r := range s.Required {
+		reqSet[r] = true
+	}
+
+	type field struct {
+		name, typ, req, def, desc string
+	}
+
+	fields := make([]field, 0, len(s.Properties))
+	for name, prop := range s.Properties {
+		req := "no"
+		if reqSet[name] {
+			req = "yes"
+		}
+		fields = append(fields, field{
+			name: name,
+			typ:  resolveTypeName(prop, defs),
+			req:  req,
+			def:  resolveDefault(prop),
+			desc: prop.Description,
+		})
+	}
+
+	sort.Slice(fields, func(i, j int) bool {
+		if fields[i].req != fields[j].req {
+			return fields[i].req == "yes"
+		}
+		return fields[i].name < fields[j].name
+	})
+
+	headers := []string{"FIELD", "TYPE", "REQUIRED", "DEFAULT", "DESCRIPTION"}
+	rows := make([][]string, len(fields))
+	for i, f := range fields {
+		rows[i] = []string{f.name, f.typ, f.req, f.def, f.desc}
+	}
+	return PrintTable(out, headers, rows)
+}
+
+func resolveTypeName(s jsonSchema, defs map[string]jsonSchema) string {
+	if s.Ref != "" {
+		return refName(s.Ref)
+	}
+
+	if len(s.AnyOf) > 0 {
+		parts := make([]string, 0, len(s.AnyOf))
+		for _, alt := range s.AnyOf {
+			parts = append(parts, resolveTypeName(alt, defs))
+		}
+		return strings.Join(parts, " | ")
+	}
+
+	if len(s.Enum) > 0 {
+		vals := make([]string, len(s.Enum))
+		for i, v := range s.Enum {
+			vals[i] = fmt.Sprintf("%v", v)
+		}
+		return "enum(" + strings.Join(vals, ", ") + ")"
+	}
+
+	if s.Const != nil {
+		return fmt.Sprintf("const(%v)", s.Const)
+	}
+
+	if s.Type == "array" && s.Items != nil {
+		return "list[" + resolveTypeName(*s.Items, defs) + "]"
+	}
+
+	if s.Type != "" {
+		return s.Type
+	}
+
+	return "any"
+}
+
+func resolveDefault(s jsonSchema) string {
+	if s.Default == nil {
+		return "-"
+	}
+	switch v := s.Default.(type) {
+	case string:
+		return fmt.Sprintf("%q", v)
+	case bool:
+		if v {
+			return "true"
+		}
+		return "false"
+	case float64:
+		if v == float64(int(v)) {
+			return fmt.Sprintf("%d", int(v))
+		}
+		return fmt.Sprintf("%g", v)
+	default:
+		b, _ := json.Marshal(v)
+		return string(b)
+	}
+}
+
+func refName(ref string) string {
+	parts := strings.Split(ref, "/")
+	return parts[len(parts)-1]
+}

--- a/internal/output/schema_test.go
+++ b/internal/output/schema_test.go
@@ -1,0 +1,127 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestPrintSchemaPretty(t *testing.T) {
+	raw := json.RawMessage(`{
+		"title": "AgentConfig",
+		"description": "Configuration for the Interactive Agent.",
+		"type": "object",
+		"required": ["context"],
+		"properties": {
+			"llm_model": {
+				"anyOf": [
+					{"minLength": 1, "type": "string"},
+					{"type": "null"}
+				],
+				"default": null,
+				"description": "Model identifier in provider/model form."
+			},
+			"context": {
+				"$ref": "#/$defs/AgentContext"
+			},
+			"mcps": {
+				"items": {"$ref": "#/$defs/McpConfig"},
+				"type": "array"
+			}
+		},
+		"$defs": {
+			"AgentContext": {
+				"title": "AgentContext",
+				"description": "Behavioral configuration.",
+				"type": "object",
+				"required": ["description", "language"],
+				"properties": {
+					"description": {
+						"$ref": "#/$defs/PromptRef"
+					},
+					"language": {
+						"description": "Language the agent communicates in.",
+						"type": "string"
+					}
+				}
+			},
+			"McpConfig": {
+				"title": "McpConfig",
+				"description": "MCP server connection details.",
+				"type": "object",
+				"required": ["id", "hostname", "port", "transport"],
+				"properties": {
+					"id": {
+						"description": "Unique identifier.",
+						"type": "string"
+					},
+					"hostname": {
+						"description": "MCP server hostname.",
+						"type": "string"
+					},
+					"port": {
+						"type": "integer",
+						"minimum": 1,
+						"maximum": 65535
+					},
+					"transport": {
+						"enum": ["sse", "streamable-http"],
+						"type": "string"
+					}
+				}
+			},
+			"PromptRef": {
+				"title": "PromptRef",
+				"description": "A reference to a prompt at a specific version.",
+				"type": "object",
+				"required": ["id", "version"],
+				"properties": {
+					"id": {
+						"description": "Prompt identifier or slug.",
+						"type": "string"
+					},
+					"version": {
+						"anyOf": [
+							{"type": "integer"},
+							{"type": "string"}
+						],
+						"description": "Version to bind to."
+					}
+				}
+			}
+		}
+	}`)
+
+	var buf bytes.Buffer
+	err := PrintSchemaPretty(&buf, raw, "2.1.0")
+	if err != nil {
+		t.Fatalf("PrintSchemaPretty() error = %v", err)
+	}
+
+	out := buf.String()
+
+	checks := []string{
+		"Schema version: 2.1.0",
+		"AgentConfig",
+		"context",
+		"AgentContext",
+		"yes",
+		"no",
+		"list[McpConfig]",
+		"string | null",
+		"McpConfig",
+		"PromptRef",
+		"FIELD",
+		"TYPE",
+		"REQUIRED",
+		"DEFAULT",
+		"DESCRIPTION",
+	}
+
+	for _, c := range checks {
+		if !strings.Contains(out, c) {
+			t.Errorf("output missing %q\n\nfull output:\n%s", c, out)
+		}
+	}
+}


### PR DESCRIPTION

- Add `iai agents compatibility-matrix` command (table + JSON output)
- Add `--version` and `--json` flags to `iai agents schema`
- Add `--schema-version` and `--json` flags to prompt schema commands (routines, policies, glossaries, variables)
- Add `--schema-version` flag to prompt create/update commands for all typed prompt types
- Add schema pretty-printer that renders JSON Schema as typed tables with $ref, anyOf, enum, const, and array resolution
- Pass schema_version query param to prompt and agent schema endpoints
- Add schemaVersion field to CreatePromptBody for prompt create/update
- Improve help text across agent and prompt commands to document schema versioning workflow