### PR TITLE
Adjust output timestamp and secret key formatting

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.30.0"
+current_version = "0.30.1"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	version            = "0.30.0"
+	version            = "0.30.1"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second

--- a/internal/output/databases_test.go
+++ b/internal/output/databases_test.go
@@ -103,7 +103,7 @@ func TestPrintDatabaseDescribe(t *testing.T) {
 				"Revision:             2\n" +
 				"Status:               Healthy\n" +
 				"Message:              All instances running\n" +
-				"Updated:              Wed, 15 Jan 2025 11:30:00 +0100\n" +
+				"Updated:              2025-01-15 11:30:00 CET\n" +
 				"PostgreSQL Version:   17\n" +
 				"Instances:            2\n" +
 				"Resources:\n" +

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -54,7 +54,7 @@ func LocalTime(s string) string {
 		"2006-01-02T15:04:05",
 	} {
 		if t, err := time.Parse(layout, s); err == nil {
-			return t.Local().Format(time.RFC1123Z)
+			return t.Local().Format("2006-01-02 15:04:05 MST")
 		}
 	}
 	return s

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -81,27 +81,27 @@ func TestLocalTime(t *testing.T) {
 		{
 			name:  "RFC3339 converts UTC to local timezone",
 			input: "2025-06-15T10:30:00Z",
-			want:  "Sun, 15 Jun 2025 12:30:00 +0200",
+			want:  "2025-06-15 12:30:00 CEST",
 		},
 		{
 			name:  "RFC3339 with offset",
 			input: "2025-06-15T10:30:00+03:00",
-			want:  "Sun, 15 Jun 2025 09:30:00 +0200",
+			want:  "2025-06-15 09:30:00 CEST",
 		},
 		{
 			name:  "RFC3339Nano",
 			input: "2025-06-15T10:30:00.123456789Z",
-			want:  "Sun, 15 Jun 2025 12:30:00 +0200",
+			want:  "2025-06-15 12:30:00 CEST",
 		},
 		{
 			name:  "microsecond precision format",
 			input: "2025-06-15T10:30:00.123456",
-			want:  "Sun, 15 Jun 2025 12:30:00 +0200",
+			want:  "2025-06-15 12:30:00 CEST",
 		},
 		{
 			name:  "bare datetime without fractional seconds",
 			input: "2025-06-15T10:30:00",
-			want:  "Sun, 15 Jun 2025 12:30:00 +0200",
+			want:  "2025-06-15 12:30:00 CEST",
 		},
 		{
 			name:  "returns original string on parse failure",

--- a/internal/output/prompts_test.go
+++ b/internal/output/prompts_test.go
@@ -38,7 +38,7 @@ func TestPrintPromptList(t *testing.T) {
 				},
 			},
 			want: "NAME              LABELS       TAGS         UPDATED\n" +
-				"welcome-message   production   onboarding   Wed, 15 Jan 2025 11:30:00 +0100\n",
+				"welcome-message   production   onboarding   2025-01-15 11:30:00 CET\n",
 		},
 		{
 			name: "multiple prompts",
@@ -59,8 +59,8 @@ func TestPrintPromptList(t *testing.T) {
 				},
 			},
 			want: "NAME         LABELS       TAGS            UPDATED\n" +
-				"escalation                compliance      Fri, 10 Jan 2025 09:00:00 +0100\n" +
-				"routing      production   core, routing   Mon, 20 Jan 2025 15:00:00 +0100\n",
+				"escalation                compliance      2025-01-10 09:00:00 CET\n" +
+				"routing      production   core, routing   2025-01-20 15:00:00 CET\n",
 		},
 		{
 			name: "truncates long labels list",
@@ -74,7 +74,7 @@ func TestPrintPromptList(t *testing.T) {
 				},
 			},
 			want: "NAME        LABELS                               TAGS   UPDATED\n" +
-				"my-prompt   production, staging, dev (+1 more)          Sat, 01 Mar 2025 13:00:00 +0100\n",
+				"my-prompt   production, staging, dev (+1 more)          2025-03-01 13:00:00 CET\n",
 		},
 		{
 			name: "folder rows display trailing slash",
@@ -92,7 +92,7 @@ func TestPrintPromptList(t *testing.T) {
 			},
 			want: "NAME         LABELS               TAGS   UPDATED\n" +
 				"team-a/                                  \n" +
-				"faq-lookup   production, latest          Sat, 01 Mar 2025 13:00:00 +0100\n",
+				"faq-lookup   production, latest          2025-03-01 13:00:00 CET\n",
 		},
 	}
 
@@ -256,8 +256,8 @@ func TestPrintPromptDetail(t *testing.T) {
 				"Version:      3\n" +
 				"Labels:       production, staging\n" +
 				"Tags:         v2, experimental\n" +
-				"Created At:   Fri, 10 Jan 2025 09:00:00 +0100\n" +
-				"Updated At:   Wed, 15 Jan 2025 11:30:00 +0100\n" +
+				"Created At:   2025-01-10 09:00:00 CET\n" +
+				"Updated At:   2025-01-15 11:30:00 CET\n" +
 				"\n" +
 				"Content:\n" +
 				"steps:\n" +

--- a/internal/output/replicas_test.go
+++ b/internal/output/replicas_test.go
@@ -34,7 +34,7 @@ func TestPrintReplicaList(t *testing.T) {
 				},
 			},
 			want: "NAME         STATUS            CPU    MEMORY   STARTED\n" +
-				"web-abc123   Running [Ready]   100m   128Mi    Mon, 01 Jan 2024 01:00:00 +0100\n",
+				"web-abc123   Running [Ready]   100m   128Mi    2024-01-01 01:00:00 CET\n",
 		},
 		{
 			name: "not-ready replica shows Not Ready",
@@ -119,7 +119,7 @@ func TestPrintReplicaDescribe(t *testing.T) {
 			want: "Name:            web-abc123\n" +
 				"Status:          Running\n" +
 				"Ready:           Yes\n" +
-				"Start Time:      Mon, 01 Jan 2024 01:00:00 +0100\n" +
+				"Start Time:      2024-01-01 01:00:00 CET\n" +
 				"Restart Count:   0\n",
 		},
 		{
@@ -143,8 +143,8 @@ func TestPrintReplicaDescribe(t *testing.T) {
 				"\nLast Termination State:\n" +
 				"  Reason:        OOMKilled\n" +
 				"  Exit Code:     137\n" +
-				"  Started At:    Mon, 01 Jan 2024 01:00:00 +0100\n" +
-				"  Finished At:   Mon, 01 Jan 2024 02:00:00 +0100\n",
+				"  Started At:    2024-01-01 01:00:00 CET\n" +
+				"  Finished At:   2024-01-01 02:00:00 CET\n",
 		},
 		{
 			name: "last termination state without timestamps",
@@ -216,18 +216,18 @@ func TestPrintReplicaDescribe(t *testing.T) {
 			want: "Name:            full-pod\n" +
 				"Status:          Running\n" +
 				"Ready:           Yes\n" +
-				"Start Time:      Sat, 01 Jun 2024 14:00:00 +0200\n" +
+				"Start Time:      2024-06-01 14:00:00 CEST\n" +
 				"Restart Count:   1\n" +
 				"\nLast Termination State:\n" +
 				"  Reason:        OOMKilled\n" +
 				"  Exit Code:     137\n" +
-				"  Finished At:   Sat, 01 Jun 2024 13:59:00 +0200\n" +
+				"  Finished At:   2024-06-01 13:59:00 CEST\n" +
 				"\nResources:\n" +
 				"  CPU:      250m\n" +
 				"  Memory:   512Mi\n" +
 				"\nEvents:\n" +
 				"TYPE      REASON       COUNT   MESSAGE                 LAST SEEN\n" +
-				"Warning   OOMKilling   1       Memory limit exceeded   Sat, 01 Jun 2024 13:59:00 +0200\n",
+				"Warning   OOMKilling   1       Memory limit exceeded   2024-06-01 13:59:00 CEST\n",
 		},
 	}
 

--- a/internal/output/secrets.go
+++ b/internal/output/secrets.go
@@ -23,7 +23,7 @@ func PrintSecretList(out io.Writer, secrets []clients.SecretInfo) error {
 			s.Name,
 			s.Type,
 			LocalTime(s.CreatedAt),
-			formatSecretKeys(s.Keys, 3),
+			formatSecretKeys(s.Keys, 2),
 		}
 	}
 

--- a/internal/output/secrets_test.go
+++ b/internal/output/secrets_test.go
@@ -51,7 +51,7 @@ func TestPrintSecretList(t *testing.T) {
 				"big-secret   database   2024-06-01   A, B (+3 more)\n",
 		},
 		{
-			name: "secret with exactly 3 keys shows all",
+			name: "secret with exactly 3 keys truncates to 2 visible",
 			secrets: []clients.SecretInfo{
 				{
 					Name:      "three-keys",

--- a/internal/output/secrets_test.go
+++ b/internal/output/secrets_test.go
@@ -29,52 +29,52 @@ func TestPrintSecretList(t *testing.T) {
 			secrets: []clients.SecretInfo{
 				{
 					Name:      "db-creds",
-					Type:      "Opaque",
+					Type:      "project",
 					CreatedAt: "2024-01-01",
 					Keys:      []string{"USER", "PASS"},
 				},
 			},
-			want: "NAME       TYPE     CREATED      KEYS\n" +
-				"db-creds   Opaque   2024-01-01   USER, PASS\n",
+			want: "NAME       TYPE      CREATED      KEYS\n" +
+				"db-creds   project   2024-01-01   USER, PASS\n",
 		},
 		{
 			name: "secret with many keys truncates",
 			secrets: []clients.SecretInfo{
 				{
 					Name:      "big-secret",
-					Type:      "Opaque",
+					Type:      "database",
 					CreatedAt: "2024-06-01",
 					Keys:      []string{"A", "B", "C", "D", "E"},
 				},
 			},
-			want: "NAME         TYPE     CREATED      KEYS\n" +
-				"big-secret   Opaque   2024-06-01   A, B, C (+2 more)\n",
+			want: "NAME         TYPE       CREATED      KEYS\n" +
+				"big-secret   database   2024-06-01   A, B (+3 more)\n",
 		},
 		{
 			name: "secret with exactly 3 keys shows all",
 			secrets: []clients.SecretInfo{
 				{
 					Name:      "three-keys",
-					Type:      "Opaque",
+					Type:      "database-superuser",
 					CreatedAt: "2024-06-01",
 					Keys:      []string{"X", "Y", "Z"},
 				},
 			},
-			want: "NAME         TYPE     CREATED      KEYS\n" +
-				"three-keys   Opaque   2024-06-01   X, Y, Z\n",
+			want: "NAME         TYPE                 CREATED      KEYS\n" +
+				"three-keys   database-superuser   2024-06-01   X, Y (+1 more)\n",
 		},
 		{
 			name: "secret with no keys shows empty",
 			secrets: []clients.SecretInfo{
 				{
 					Name:      "empty-secret",
-					Type:      "Opaque",
+					Type:      "project",
 					CreatedAt: "2024-06-01",
 					Keys:      []string{},
 				},
 			},
-			want: "NAME           TYPE     CREATED      KEYS\n" +
-				"empty-secret   Opaque   2024-06-01   \n",
+			want: "NAME           TYPE      CREATED      KEYS\n" +
+				"empty-secret   project   2024-06-01   \n",
 		},
 	}
 

--- a/internal/output/vector_stores_test.go
+++ b/internal/output/vector_stores_test.go
@@ -115,7 +115,7 @@ func TestPrintVectorStoreDescribe(t *testing.T) {
 			want: "Name:             my-store\n" +
 				"Status:           ready\n" +
 				"Engine Version:   POSTGRES_15\n" +
-				"Created At:       Wed, 15 Jan 2025 11:30:00 +0100\n" +
+				"Created At:       2025-01-15 11:30:00 CET\n" +
 				"HA:               Yes\n" +
 				"Backups:          Yes\n" +
 				"Backup Time:      03:00\n" +
@@ -176,7 +176,7 @@ func TestPrintVectorStoreDescribe(t *testing.T) {
 			want: "Name:             no-resize\n" +
 				"Status:           ready\n" +
 				"Engine Version:   POSTGRES_15\n" +
-				"Created At:       Sat, 01 Feb 2025 01:00:00 +0100\n" +
+				"Created At:       2025-02-01 01:00:00 CET\n" +
 				"HA:               No\n" +
 				"Backups:          No\n" +
 				"Secret:           no-resize-credentials\n" +


### PR DESCRIPTION
## Summary
- switch LocalTime output to a compact local timestamp format
- reduce visible secret keys in secret list output from 3 to 2
- update output tests to match the new formatting

## Testing
- go test ./...