### PR TITLE
bump: 0.31.0 → 0.31.1

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.31.0"
+current_version = "0.31.1"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	version            = "0.31.0"
+	version            = "0.31.1"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second


### PR DESCRIPTION
Cuts a release that includes the new `iai integrations` (MCP connection) commands from #135.

**Why:** #135 and #136 both bumped `0.30.1 → 0.31.0` concurrently. #136 merged first and `auto-tag` published `v0.31.0` from its commit, which does **not** contain the MCP code. #135 then merged on top, so the MCP feature is on `main` but in no release tag. This bump to `0.31.1` lets `auto-tag` publish a tag that includes it.

On merge to `main`, `auto-tag` will create **`v0.31.1`** (the `iai integrations` commands ship in it).