### PR TITLE
fix(integrations): forward catalog endpoint_url in create-from-catalog

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.32.0"
+current_version = "0.32.1"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/integrations.go
+++ b/cmd/integrations.go
@@ -301,6 +301,23 @@ Examples:
 	return cmd
 }
 
+// catalogEndpointURL returns the canonical endpoint of a catalog entry, which
+// the backend requires when creating a connection from the catalog.
+func catalogEndpointURL(entries []clients.McpCatalogEntry, catalogID string) (string, error) {
+	for _, e := range entries {
+		if e.ID == catalogID {
+			if strings.TrimSpace(e.EndpointURL) == "" {
+				return "", fmt.Errorf(
+					"catalog entry %q has no managed endpoint; use 'create-custom' with --endpoint-url",
+					catalogID,
+				)
+			}
+			return e.EndpointURL, nil
+		}
+	}
+	return "", fmt.Errorf("catalog entry %q not found; see 'iai integrations catalog'", catalogID)
+}
+
 func makeIntegrationsCreateFromCatalogCmd() *cobra.Command {
 	var (
 		catalogID       string
@@ -347,12 +364,24 @@ Examples:
 				return err
 			}
 
+			// The backend requires the canonical endpoint_url even for catalog
+			// connections (it verifies it matches the entry), so forward it.
+			catalogData, err := apiClient.ListMcpCatalog(cmd.Context(), pCtx.orgId, pCtx.projectId)
+			if err != nil {
+				return err
+			}
+			endpointURL, err := catalogEndpointURL(catalogData.Entries, catalogID)
+			if err != nil {
+				return err
+			}
+
 			body := clients.McpConnectionCreateBody{
 				Type:        "platform",
 				CatalogID:   catalogID,
 				Name:        name,
 				Slug:        slug,
 				Description: description,
+				EndpointURL: endpointURL,
 				AuthType:    authType,
 				Credential:  cred,
 			}

--- a/cmd/integrations_test.go
+++ b/cmd/integrations_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
 	"github.com/spf13/cobra"
 )
 
@@ -87,6 +88,28 @@ func TestIntegrationsEmptyArgGuards(t *testing.T) {
 				t.Fatalf("got %v, want error containing %q", err, tc.want)
 			}
 		})
+	}
+}
+
+func TestCatalogEndpointURL(t *testing.T) {
+	entries := []clients.McpCatalogEntry{
+		{ID: "kiwi", EndpointURL: "https://mcp.kiwi.com/"},
+		{ID: "selfhosted", EndpointURL: ""},
+	}
+
+	got, err := catalogEndpointURL(entries, "kiwi")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "https://mcp.kiwi.com/" {
+		t.Fatalf("got %q, want kiwi endpoint", got)
+	}
+
+	if _, err := catalogEndpointURL(entries, "missing"); err == nil {
+		t.Fatal("expected error for unknown catalog id")
+	}
+	if _, err := catalogEndpointURL(entries, "selfhosted"); err == nil {
+		t.Fatal("expected error for entry without a managed endpoint")
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	version            = "0.32.0"
+	version            = "0.32.1"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second


### PR DESCRIPTION
`iai integrations create-from-catalog` failed for **every** catalog entry with `endpoint_url is required` — it never sent the field, but the backend requires the canonical endpoint even for catalog connections (and verifies it matches the entry, `mcp_connections.py` create handler).

**Fix:** look up the catalog entry by `--catalog-id` and forward its `endpoint_url` in the create body. Added `catalogEndpointURL` (+ unit test) which also errors clearly on an unknown id or a self-hosted entry with no managed endpoint.

**Verified end-to-end:** built + installed locally, then `create-from-catalog kiwi --catalog-id kiwi --auth-type none` now connects, verifies against the live Kiwi MCP server (protocol `2025-06-18`), and discovers its tools.

Includes the **`0.32.0 → 0.32.1`** bump so merging cuts `v0.32.1` via `auto-tag`.