### PR TITLE
Add structured output to missing read commands

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.34.0"
+current_version = "0.34.1"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -222,7 +222,8 @@ var agentListCmd = &cobra.Command{
 
 Examples:
   iai agents list
-  iai agents list -p my-project`,
+  iai agents list -p my-project
+  iai agents list --json`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
@@ -260,7 +261,8 @@ Use --version to view a specific past version instead of the current state.
 
 Examples:
   iai agents describe my-agent
-  iai agents describe my-agent --version 3`,
+  iai agents describe my-agent --version 3
+  iai agents describe my-agent --yaml`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -37,6 +37,11 @@ var (
 	agentClearStackId  bool
 
 	agentStackId string
+
+	agentListJSON     bool
+	agentListYAML     bool
+	agentDescribeJSON bool
+	agentDescribeYAML bool
 )
 
 var (
@@ -232,6 +237,13 @@ Examples:
 			return err
 		}
 
+		if agentListJSON {
+			return output.PrintStructuredJSON(out, agents)
+		}
+		if agentListYAML {
+			return output.PrintStructuredYAML(out, agents)
+		}
+
 		return output.PrintAgentList(out, agents)
 	},
 }
@@ -270,6 +282,12 @@ Examples:
 			if err != nil {
 				return err
 			}
+			if agentDescribeJSON {
+				return output.PrintStructuredJSON(out, rev)
+			}
+			if agentDescribeYAML {
+				return output.PrintStructuredYAML(out, rev)
+			}
 			return output.PrintAgentRevision(out, rev)
 		}
 
@@ -281,6 +299,13 @@ Examples:
 		)
 		if err != nil {
 			return err
+		}
+
+		if agentDescribeJSON {
+			return output.PrintStructuredJSON(out, agent)
+		}
+		if agentDescribeYAML {
+			return output.PrintStructuredYAML(out, agent)
 		}
 
 		return output.PrintAgentDescribe(out, agent)
@@ -832,6 +857,9 @@ func init() {
 		StringVarP(&agentProject, "project", "p", "", "Project name")
 	agentListCmd.Flags().
 		StringVarP(&agentOrganization, "organization", "o", "", "Organization name")
+	agentListCmd.Flags().BoolVar(&agentListJSON, "json", false, "Output raw API response as JSON")
+	agentListCmd.Flags().BoolVar(&agentListYAML, "yaml", false, "Output raw API response as YAML")
+	agentListCmd.MarkFlagsMutuallyExclusive("json", "yaml")
 
 	// Flags for "agents describe"
 	agentDescribeCmd.Flags().
@@ -840,6 +868,11 @@ func init() {
 		StringVarP(&agentOrganization, "organization", "o", "", "Organization name")
 	agentDescribeCmd.Flags().
 		IntVar(&agentDescribeRevision, "revision", 0, "Show a specific past revision instead of the current state")
+	agentDescribeCmd.Flags().
+		BoolVar(&agentDescribeJSON, "json", false, "Output raw API response as JSON")
+	agentDescribeCmd.Flags().
+		BoolVar(&agentDescribeYAML, "yaml", false, "Output raw API response as YAML")
+	agentDescribeCmd.MarkFlagsMutuallyExclusive("json", "yaml")
 
 	// Flags for "agents delete"
 	agentDeleteCmd.Flags().

--- a/cmd/databases.go
+++ b/cmd/databases.go
@@ -17,6 +17,10 @@ import (
 var (
 	dbProject      string
 	dbOrganization string
+	dbListJSON     bool
+	dbListYAML     bool
+	dbDescribeJSON bool
+	dbDescribeYAML bool
 
 	dbInstances       int
 	dbPostgresVersion string
@@ -79,6 +83,13 @@ var dbListCmd = &cobra.Command{
 			return err
 		}
 
+		if dbListJSON {
+			return output.PrintStructuredJSON(out, databases)
+		}
+		if dbListYAML {
+			return output.PrintStructuredYAML(out, databases)
+		}
+
 		return output.PrintDatabaseList(out, databases)
 	},
 }
@@ -110,6 +121,13 @@ Examples:
 		)
 		if err != nil {
 			return err
+		}
+
+		if dbDescribeJSON {
+			return output.PrintStructuredJSON(out, db)
+		}
+		if dbDescribeYAML {
+			return output.PrintStructuredYAML(out, db)
 		}
 
 		return output.PrintDatabaseDescribe(out, db)
@@ -609,12 +627,18 @@ func init() {
 		StringVarP(&dbProject, "project", "p", "", "Project name")
 	dbListCmd.Flags().
 		StringVarP(&dbOrganization, "organization", "o", "", "Organization name")
+	dbListCmd.Flags().BoolVar(&dbListJSON, "json", false, "Output raw API response as JSON")
+	dbListCmd.Flags().BoolVar(&dbListYAML, "yaml", false, "Output raw API response as YAML")
+	dbListCmd.MarkFlagsMutuallyExclusive("json", "yaml")
 
 	// databases describe
 	dbDescribeCmd.Flags().
 		StringVarP(&dbProject, "project", "p", "", "Project name")
 	dbDescribeCmd.Flags().
 		StringVarP(&dbOrganization, "organization", "o", "", "Organization name")
+	dbDescribeCmd.Flags().BoolVar(&dbDescribeJSON, "json", false, "Output raw API response as JSON")
+	dbDescribeCmd.Flags().BoolVar(&dbDescribeYAML, "yaml", false, "Output raw API response as YAML")
+	dbDescribeCmd.MarkFlagsMutuallyExclusive("json", "yaml")
 
 	// databases create
 	dbCreateCmd.Flags().

--- a/cmd/databases.go
+++ b/cmd/databases.go
@@ -102,7 +102,8 @@ var dbDescribeCmd = &cobra.Command{
 status, and connection credentials.
 
 Examples:
-  iai databases describe my-db`,
+  iai databases describe my-db
+  iai databases describe my-db --json`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()

--- a/cmd/images.go
+++ b/cmd/images.go
@@ -26,6 +26,8 @@ var (
 	imagePushTag       string
 	imageOrganization  string
 	imageProject       string
+	imageListJSON      bool
+	imageListYAML      bool
 )
 
 var imageCmd = &cobra.Command{
@@ -53,6 +55,13 @@ var imageListCmd = &cobra.Command{
 		images, err := deployClient.ListImages(cmd.Context(), pCtx.orgId, pCtx.projectId)
 		if err != nil {
 			return err
+		}
+
+		if imageListJSON {
+			return output.PrintStructuredJSON(out, images)
+		}
+		if imageListYAML {
+			return output.PrintStructuredYAML(out, images)
 		}
 
 		return output.PrintImageList(out, images)
@@ -300,6 +309,9 @@ func init() {
 		StringVarP(&imageOrganization, "organization", "o", "", "Organization name that owns the project")
 	imageListCmd.Flags().
 		StringVarP(&imageProject, "project", "p", "", "Project name to list images for")
+	imageListCmd.Flags().BoolVar(&imageListJSON, "json", false, "Output raw API response as JSON")
+	imageListCmd.Flags().BoolVar(&imageListYAML, "yaml", false, "Output raw API response as YAML")
+	imageListCmd.MarkFlagsMutuallyExclusive("json", "yaml")
 
 	imagePushCmd.Flags().
 		StringVarP(&imagePushTag, "tag", "t", "", "Tag for the image in the fixed registry (e.g. 1.2.3)")

--- a/cmd/organizations.go
+++ b/cmd/organizations.go
@@ -9,6 +9,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	organizationsListJSON bool
+	organizationsListYAML bool
+)
+
 var organizationsCmd = &cobra.Command{
 	Use:     "organizations",
 	Aliases: []string{"organization", "org", "o"},
@@ -50,6 +55,13 @@ var organizationsListCmd = &cobra.Command{
 		selectedOrg, err := files.GetSelectedOrg(cfgDirName)
 		if err != nil {
 			return fmt.Errorf("failed to load config: %w", err)
+		}
+
+		if organizationsListJSON {
+			return output.PrintStructuredJSON(out, orgs)
+		}
+		if organizationsListYAML {
+			return output.PrintStructuredYAML(out, orgs)
 		}
 
 		return output.PrintOrganizationList(out, orgs, selectedOrg)
@@ -98,6 +110,11 @@ var organizationsSelectCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(organizationsCmd)
+	organizationsListCmd.Flags().
+		BoolVar(&organizationsListJSON, "json", false, "Output raw API response as JSON")
+	organizationsListCmd.Flags().
+		BoolVar(&organizationsListYAML, "yaml", false, "Output raw API response as YAML")
+	organizationsListCmd.MarkFlagsMutuallyExclusive("json", "yaml")
 	organizationsCmd.AddCommand(organizationsListCmd)
 	organizationsCmd.AddCommand(organizationsSelectCmd)
 }

--- a/cmd/organizations.go
+++ b/cmd/organizations.go
@@ -32,7 +32,7 @@ var organizationsListCmd = &cobra.Command{
 
 		if apiKey != "" {
 			fmt.Fprintln(
-				out,
+				cmd.ErrOrStderr(),
 				"Warning: API key authentication is ignored for organizations commands; using session cookies instead.",
 			)
 		}

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -35,7 +35,7 @@ var projectsListCmd = &cobra.Command{
 
 		if apiKey != "" {
 			fmt.Fprintln(
-				out,
+				cmd.ErrOrStderr(),
 				"Warning: API key authentication is ignored for projects commands; using session cookies instead.",
 			)
 		}

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -10,7 +10,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var projectsOrganization string
+var (
+	projectsOrganization string
+	projectsListJSON     bool
+	projectsListYAML     bool
+)
 
 var projectsCmd = &cobra.Command{
 	Use:     "projects",
@@ -65,6 +69,13 @@ var projectsListCmd = &cobra.Command{
 		selectedProject, err := files.GetSelectedProject(cfgDirName)
 		if err != nil {
 			return fmt.Errorf("failed to load config: %w", err)
+		}
+
+		if projectsListJSON {
+			return output.PrintStructuredJSON(out, projects)
+		}
+		if projectsListYAML {
+			return output.PrintStructuredYAML(out, projects)
 		}
 
 		return output.PrintProjectList(out, projects, selectedProject)
@@ -127,6 +138,11 @@ func init() {
 
 	projectsListCmd.Flags().
 		StringVarP(&projectsOrganization, "organization", "o", "", "Organization name that owns the projects")
+	projectsListCmd.Flags().
+		BoolVar(&projectsListJSON, "json", false, "Output raw API response as JSON")
+	projectsListCmd.Flags().
+		BoolVar(&projectsListYAML, "yaml", false, "Output raw API response as YAML")
+	projectsListCmd.MarkFlagsMutuallyExclusive("json", "yaml")
 	projectsSelectCmd.Flags().
 		StringVarP(&projectsOrganization, "organization", "o", "", "Organization name that owns the project")
 

--- a/cmd/replicas.go
+++ b/cmd/replicas.go
@@ -18,6 +18,10 @@ import (
 var (
 	replicasProject      string
 	replicasOrganization string
+	replicasListJSON     bool
+	replicasListYAML     bool
+	replicasDescribeJSON bool
+	replicasDescribeYAML bool
 )
 
 var replicasCmd = &cobra.Command{
@@ -61,6 +65,13 @@ var replicasListCmd = &cobra.Command{
 			return err
 		}
 
+		if replicasListJSON {
+			return output.PrintStructuredJSON(out, replicas)
+		}
+		if replicasListYAML {
+			return output.PrintStructuredYAML(out, replicas)
+		}
+
 		return output.PrintReplicaList(out, replicas)
 	},
 }
@@ -97,6 +108,13 @@ var replicasDescribeCmd = &cobra.Command{
 		)
 		if err != nil {
 			return err
+		}
+
+		if replicasDescribeJSON {
+			return output.PrintStructuredJSON(out, status)
+		}
+		if replicasDescribeYAML {
+			return output.PrintStructuredYAML(out, status)
 		}
 
 		return output.PrintReplicaDescribe(out, status)
@@ -288,12 +306,22 @@ func init() {
 		StringVarP(&replicasProject, "project", "p", "", "Project name that owns the service")
 	replicasListCmd.Flags().
 		StringVarP(&replicasOrganization, "organization", "o", "", "Organization name that owns the project")
+	replicasListCmd.Flags().
+		BoolVar(&replicasListJSON, "json", false, "Output raw API response as JSON")
+	replicasListCmd.Flags().
+		BoolVar(&replicasListYAML, "yaml", false, "Output raw API response as YAML")
+	replicasListCmd.MarkFlagsMutuallyExclusive("json", "yaml")
 
 	// Flags for "replicas describe"
 	replicasDescribeCmd.Flags().
 		StringVarP(&replicasProject, "project", "p", "", "Project name that owns the service")
 	replicasDescribeCmd.Flags().
 		StringVarP(&replicasOrganization, "organization", "o", "", "Organization name that owns the project")
+	replicasDescribeCmd.Flags().
+		BoolVar(&replicasDescribeJSON, "json", false, "Output raw API response as JSON")
+	replicasDescribeCmd.Flags().
+		BoolVar(&replicasDescribeYAML, "yaml", false, "Output raw API response as YAML")
+	replicasDescribeCmd.MarkFlagsMutuallyExclusive("json", "yaml")
 
 	// Flags for "replicas logs"
 	replicasLogsCmd.Flags().

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	version            = "0.34.0"
+	version            = "0.34.1"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second

--- a/cmd/secrets.go
+++ b/cmd/secrets.go
@@ -20,6 +20,10 @@ var (
 	secretEnvFile       string
 	secretReplaceFlag   bool
 	secretRemoveKeys    []string
+	secretsListJSON     bool
+	secretsListYAML     bool
+	secretsGetJSON      bool
+	secretsGetYAML      bool
 )
 
 var secretsCmd = &cobra.Command{
@@ -51,6 +55,13 @@ var secretsListCmd = &cobra.Command{
 		secrets, err := deployClient.ListSecrets(cmd.Context(), pCtx.orgId, pCtx.projectId)
 		if err != nil {
 			return err
+		}
+
+		if secretsListJSON {
+			return output.PrintStructuredJSON(out, secrets)
+		}
+		if secretsListYAML {
+			return output.PrintStructuredYAML(out, secrets)
 		}
 
 		return output.PrintSecretList(out, secrets)
@@ -341,6 +352,13 @@ var secretsGetCmd = &cobra.Command{
 			return fmt.Errorf("failed to get secret %q: %w", secretName, err)
 		}
 
+		if secretsGetJSON {
+			return output.PrintStructuredJSON(out, secret)
+		}
+		if secretsGetYAML {
+			return output.PrintStructuredYAML(out, secret)
+		}
+
 		return output.PrintSecretData(out, secret.Data)
 	},
 }
@@ -403,6 +421,11 @@ func init() {
 		StringVarP(&secretsProject, "project", "p", "", "Project name that owns the secrets")
 	secretsListCmd.Flags().
 		StringVarP(&secretsOrganization, "organization", "o", "", "Organization name that owns the project")
+	secretsListCmd.Flags().
+		BoolVar(&secretsListJSON, "json", false, "Output raw API response as JSON")
+	secretsListCmd.Flags().
+		BoolVar(&secretsListYAML, "yaml", false, "Output raw API response as YAML")
+	secretsListCmd.MarkFlagsMutuallyExclusive("json", "yaml")
 
 	// secrets create
 	secretsCreateCmd.Flags().
@@ -444,6 +467,9 @@ func init() {
 		StringVarP(&secretsProject, "project", "p", "", "Project name that owns the secrets")
 	secretsGetCmd.Flags().
 		StringVarP(&secretsOrganization, "organization", "o", "", "Organization name that owns the project")
+	secretsGetCmd.Flags().BoolVar(&secretsGetJSON, "json", false, "Output raw API response as JSON")
+	secretsGetCmd.Flags().BoolVar(&secretsGetYAML, "yaml", false, "Output raw API response as YAML")
+	secretsGetCmd.MarkFlagsMutuallyExclusive("json", "yaml")
 
 	// Wire up the command hierarchy
 	secretsCmd.AddCommand(

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -295,7 +295,8 @@ Use --version to view a specific past version instead of the current state.
 
 Examples:
   iai services describe my-service
-  iai services describe my-service --version 3`,
+  iai services describe my-service --version 3
+  iai services describe my-service --json`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -40,6 +40,11 @@ var (
 
 	serviceHealthcheckPath         string
 	serviceHealthcheckInitialDelay int
+
+	serviceListJSON     bool
+	serviceListYAML     bool
+	serviceDescribeJSON bool
+	serviceDescribeYAML bool
 )
 
 var (
@@ -267,6 +272,13 @@ var servListCmd = &cobra.Command{
 			return err
 		}
 
+		if serviceListJSON {
+			return output.PrintStructuredJSON(out, services)
+		}
+		if serviceListYAML {
+			return output.PrintStructuredYAML(out, services)
+		}
+
 		return output.PrintServiceList(out, services)
 	},
 }
@@ -309,6 +321,12 @@ Examples:
 			if err != nil {
 				return err
 			}
+			if serviceDescribeJSON {
+				return output.PrintStructuredJSON(out, rev)
+			}
+			if serviceDescribeYAML {
+				return output.PrintStructuredYAML(out, rev)
+			}
 			return output.PrintServiceRevision(out, rev)
 		}
 
@@ -320,6 +338,13 @@ Examples:
 		)
 		if err != nil {
 			return err
+		}
+
+		if serviceDescribeJSON {
+			return output.PrintStructuredJSON(out, service)
+		}
+		if serviceDescribeYAML {
+			return output.PrintStructuredYAML(out, service)
 		}
 
 		return output.PrintServiceDescribe(out, service)
@@ -911,6 +936,9 @@ func init() {
 		StringVarP(&serviceProject, "project", "p", "", "Project name to list services from")
 	servListCmd.Flags().
 		StringVarP(&serviceOrganization, "organization", "o", "", "Organization name that owns the project")
+	servListCmd.Flags().BoolVar(&serviceListJSON, "json", false, "Output raw API response as JSON")
+	servListCmd.Flags().BoolVar(&serviceListYAML, "yaml", false, "Output raw API response as YAML")
+	servListCmd.MarkFlagsMutuallyExclusive("json", "yaml")
 
 	// Flags for "services describe"
 	servDescribeCmd.Flags().
@@ -919,6 +947,11 @@ func init() {
 		StringVarP(&serviceOrganization, "organization", "o", "", "Organization name")
 	servDescribeCmd.Flags().
 		IntVar(&serviceDescribeRevision, "revision", 0, "Show a specific past revision instead of the current state")
+	servDescribeCmd.Flags().
+		BoolVar(&serviceDescribeJSON, "json", false, "Output raw API response as JSON")
+	servDescribeCmd.Flags().
+		BoolVar(&serviceDescribeYAML, "yaml", false, "Output raw API response as YAML")
+	servDescribeCmd.MarkFlagsMutuallyExclusive("json", "yaml")
 
 	// Flags for "services delete"
 	servDCmd.Flags().

--- a/docs/iai_agents_describe.md
+++ b/docs/iai_agents_describe.md
@@ -20,9 +20,11 @@ iai agents describe <agent_name> [flags]
 
 ```
   -h, --help                  help for describe
+      --json                  Output raw API response as JSON
   -o, --organization string   Organization name
   -p, --project string        Project name
       --revision int          Show a specific past revision instead of the current state
+      --yaml                  Output raw API response as YAML
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_agents_describe.md
+++ b/docs/iai_agents_describe.md
@@ -11,6 +11,7 @@ Use --version to view a specific past version instead of the current state.
 Examples:
   iai agents describe my-agent
   iai agents describe my-agent --version 3
+  iai agents describe my-agent --yaml
 
 ```
 iai agents describe <agent_name> [flags]

--- a/docs/iai_agents_list.md
+++ b/docs/iai_agents_list.md
@@ -9,6 +9,7 @@ List agents in a specific project.
 Examples:
   iai agents list
   iai agents list -p my-project
+  iai agents list --json
 
 ```
 iai agents list [flags]

--- a/docs/iai_agents_list.md
+++ b/docs/iai_agents_list.md
@@ -18,8 +18,10 @@ iai agents list [flags]
 
 ```
   -h, --help                  help for list
+      --json                  Output raw API response as JSON
   -o, --organization string   Organization name
   -p, --project string        Project name
+      --yaml                  Output raw API response as YAML
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_databases_describe.md
+++ b/docs/iai_databases_describe.md
@@ -18,8 +18,10 @@ iai databases describe <database_name> [flags]
 
 ```
   -h, --help                  help for describe
+      --json                  Output raw API response as JSON
   -o, --organization string   Organization name
   -p, --project string        Project name
+      --yaml                  Output raw API response as YAML
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_databases_describe.md
+++ b/docs/iai_databases_describe.md
@@ -9,6 +9,7 @@ status, and connection credentials.
 
 Examples:
   iai databases describe my-db
+  iai databases describe my-db --json
 
 ```
 iai databases describe <database_name> [flags]

--- a/docs/iai_databases_list.md
+++ b/docs/iai_databases_list.md
@@ -14,8 +14,10 @@ iai databases list [flags]
 
 ```
   -h, --help                  help for list
+      --json                  Output raw API response as JSON
   -o, --organization string   Organization name
   -p, --project string        Project name
+      --yaml                  Output raw API response as YAML
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_images_list.md
+++ b/docs/iai_images_list.md
@@ -14,8 +14,10 @@ iai images list [flags]
 
 ```
   -h, --help                  help for list
+      --json                  Output raw API response as JSON
   -o, --organization string   Organization name that owns the project
   -p, --project string        Project name to list images for
+      --yaml                  Output raw API response as YAML
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_organizations_list.md
+++ b/docs/iai_organizations_list.md
@@ -14,6 +14,8 @@ iai organizations list [flags]
 
 ```
   -h, --help   help for list
+      --json   Output raw API response as JSON
+      --yaml   Output raw API response as YAML
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_projects_list.md
+++ b/docs/iai_projects_list.md
@@ -14,7 +14,9 @@ iai projects list [flags]
 
 ```
   -h, --help                  help for list
+      --json                  Output raw API response as JSON
   -o, --organization string   Organization name that owns the projects
+      --yaml                  Output raw API response as YAML
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_replicas_describe.md
+++ b/docs/iai_replicas_describe.md
@@ -14,8 +14,10 @@ iai replicas describe <replica_name> [flags]
 
 ```
   -h, --help                  help for describe
+      --json                  Output raw API response as JSON
   -o, --organization string   Organization name that owns the project
   -p, --project string        Project name that owns the service
+      --yaml                  Output raw API response as YAML
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_replicas_list.md
+++ b/docs/iai_replicas_list.md
@@ -14,8 +14,10 @@ iai replicas list [service_name] [flags]
 
 ```
   -h, --help                  help for list
+      --json                  Output raw API response as JSON
   -o, --organization string   Organization name that owns the project
   -p, --project string        Project name that owns the service
+      --yaml                  Output raw API response as YAML
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_secrets_get.md
+++ b/docs/iai_secrets_get.md
@@ -14,8 +14,10 @@ iai secrets get <secret_name> [flags]
 
 ```
   -h, --help                  help for get
+      --json                  Output raw API response as JSON
   -o, --organization string   Organization name that owns the project
   -p, --project string        Project name that owns the secrets
+      --yaml                  Output raw API response as YAML
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_secrets_list.md
+++ b/docs/iai_secrets_list.md
@@ -14,8 +14,10 @@ iai secrets list [flags]
 
 ```
   -h, --help                  help for list
+      --json                  Output raw API response as JSON
   -o, --organization string   Organization name that owns the project
   -p, --project string        Project name that owns the secrets
+      --yaml                  Output raw API response as YAML
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_services_describe.md
+++ b/docs/iai_services_describe.md
@@ -11,6 +11,7 @@ Use --version to view a specific past version instead of the current state.
 Examples:
   iai services describe my-service
   iai services describe my-service --version 3
+  iai services describe my-service --json
 
 ```
 iai services describe <service_name> [flags]

--- a/docs/iai_services_describe.md
+++ b/docs/iai_services_describe.md
@@ -20,9 +20,11 @@ iai services describe <service_name> [flags]
 
 ```
   -h, --help                  help for describe
+      --json                  Output raw API response as JSON
   -o, --organization string   Organization name
   -p, --project string        Project name
       --revision int          Show a specific past revision instead of the current state
+      --yaml                  Output raw API response as YAML
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_services_list.md
+++ b/docs/iai_services_list.md
@@ -14,8 +14,10 @@ iai services list [flags]
 
 ```
   -h, --help                  help for list
+      --json                  Output raw API response as JSON
   -o, --organization string   Organization name that owns the project
   -p, --project string        Project name to list services from
+      --yaml                  Output raw API response as YAML
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
## Summary
- Add `--json` and `--yaml` output flags to missing list/get/describe commands.
- Use existing `output.PrintStructuredJSON` and `output.PrintStructuredYAML` helpers.
- Regenerate command docs for the updated flags.

## Commands updated
- `iai organizations list`
- `iai projects list`
- `iai agents list` / `describe`
- `iai databases list` / `describe`
- `iai images list`
- `iai replicas list` / `describe`
- `iai secrets list` / `get`
- `iai services list` / `describe`

## Validation
- `go test ./...`
- Re-scanned live list/get/describe command help: 52 checked, 0 missing `--json`/`--yaml`