### PR TITLE
Fix PostgreSQL version help text

### DIFF
--- a/cmd/databases.go
+++ b/cmd/databases.go
@@ -607,7 +607,7 @@ func addDatabaseResourceFlags(cmd *cobra.Command) {
 	cmd.Flags().
 		IntVar(&dbInstances, "instances", 0, "Number of PostgreSQL instances (minimum 1); values above 1 enable high availability")
 	cmd.Flags().
-		StringVar(&dbPostgresVersion, "postgres-version", "", "PostgreSQL major or major.minor version (e.g. 17, 16.4); supported range 15–17; defaults to latest if omitted")
+		StringVar(&dbPostgresVersion, "postgres-version", "", "PostgreSQL major or major.minor version (e.g. 18, 17.6); supported range 15–18; defaults to latest if omitted")
 	cmd.Flags().
 		StringVar(&dbCPU, "cpu", "", "CPU cores or millicores (e.g. 0.5, 1, 2, 500m, 1000m); max 7 vCPU (7000m)")
 	cmd.Flags().

--- a/docs/iai_databases_create.md
+++ b/docs/iai_databases_create.md
@@ -32,7 +32,7 @@ iai databases create <database_name> [flags]
       --instances int             Number of PostgreSQL instances (minimum 1); values above 1 enable high availability
       --memory string             Memory in megabytes (M) or gigabytes (G) (e.g. 512M, 1G, 2G); max 15G
   -o, --organization string       Organization name
-      --postgres-version string   PostgreSQL major or major.minor version (e.g. 17, 16.4); supported range 15–17; defaults to latest if omitted
+      --postgres-version string   PostgreSQL major or major.minor version (e.g. 18, 17.6); supported range 15–18; defaults to latest if omitted
   -p, --project string            Project name
       --stack-id string           Stack ID to assign the database to
       --storage-size string       Storage size with G unit (e.g. 20G, 100G); must be between 10G and 200G; cannot be decreased

--- a/docs/iai_databases_restore.md
+++ b/docs/iai_databases_restore.md
@@ -29,7 +29,7 @@ iai databases restore <database_name> [flags]
       --instances int             Number of PostgreSQL instances (minimum 1); values above 1 enable high availability
       --memory string             Memory in megabytes (M) or gigabytes (G) (e.g. 512M, 1G, 2G); max 15G
   -o, --organization string       Organization name
-      --postgres-version string   PostgreSQL major or major.minor version (e.g. 17, 16.4); supported range 15–17; defaults to latest if omitted
+      --postgres-version string   PostgreSQL major or major.minor version (e.g. 18, 17.6); supported range 15–18; defaults to latest if omitted
   -p, --project string            Project name
       --source-database string    Name of the database to restore from; must have backups enabled
       --stack-id string           Stack ID to assign the restored database to

--- a/docs/iai_databases_update.md
+++ b/docs/iai_databases_update.md
@@ -39,7 +39,7 @@ iai databases update <database_name> [flags]
       --instances int             Number of PostgreSQL instances (minimum 1); values above 1 enable high availability
       --memory string             Memory in megabytes (M) or gigabytes (G) (e.g. 512M, 1G, 2G); max 15G
   -o, --organization string       Organization name
-      --postgres-version string   PostgreSQL major or major.minor version (e.g. 17, 16.4); supported range 15–17; defaults to latest if omitted
+      --postgres-version string   PostgreSQL major or major.minor version (e.g. 18, 17.6); supported range 15–18; defaults to latest if omitted
   -p, --project string            Project name
       --stack-id string           Stack ID to assign the database to
       --storage-size string       Storage size with G unit (e.g. 20G, 100G); must be between 10G and 200G; cannot be decreased


### PR DESCRIPTION
## Summary
- update database --postgres-version help text to show PostgreSQL 18 support
- refresh generated database command docs

## Tests
- go test ./...