### PR TITLE
Throttle update notice (once/day, not in CI) and document --limit maximums

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.34.1"
+current_version = "0.34.2"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/comments.go
+++ b/cmd/comments.go
@@ -206,7 +206,7 @@ func init() {
 	commentsListCmd.Flags().
 		StringVar(&commentsListAuthorUserID, "author-user-id", "", "Filter by author user ID")
 	commentsListCmd.Flags().IntVar(&commentsListPage, "page", 1, "Page number (starts at 1)")
-	commentsListCmd.Flags().IntVar(&commentsListLimit, "limit", 0, "Items per page")
+	commentsListCmd.Flags().IntVar(&commentsListLimit, "limit", 0, "Items per page (max 100)")
 	commentsListCmd.Flags().
 		StringSliceVar(&commentsListColumns, "columns", nil, "Columns to display (comma-separated)")
 	commentsListCmd.Flags().

--- a/cmd/dataset_items.go
+++ b/cmd/dataset_items.go
@@ -262,7 +262,8 @@ func init() {
 		)
 	datasetItemsListCmd.Flags().
 		IntVar(&datasetItemsListPage, "page", 1, "Page number (starts at 1)")
-	datasetItemsListCmd.Flags().IntVar(&datasetItemsListLimit, "limit", 0, "Items per page")
+	datasetItemsListCmd.Flags().
+		IntVar(&datasetItemsListLimit, "limit", 0, "Items per page (max 100)")
 	datasetItemsListCmd.Flags().
 		StringSliceVar(&datasetItemsListColumns, "columns", nil, "Columns to display (comma-separated)")
 	datasetItemsListCmd.Flags().

--- a/cmd/dataset_runs.go
+++ b/cmd/dataset_runs.go
@@ -193,7 +193,7 @@ func init() {
 	_ = datasetRunsListCmd.MarkFlagRequired("dataset-name")
 	datasetRunsListCmd.Flags().
 		IntVar(&datasetRunsListPage, "page", 1, "Page number (starts at 1)")
-	datasetRunsListCmd.Flags().IntVar(&datasetRunsListLimit, "limit", 0, "Items per page")
+	datasetRunsListCmd.Flags().IntVar(&datasetRunsListLimit, "limit", 0, "Items per page (max 100)")
 	datasetRunsListCmd.Flags().
 		StringSliceVar(&datasetRunsListColumns, "columns", nil, "Columns to display (comma-separated)")
 	datasetRunsListCmd.Flags().

--- a/cmd/datasets.go
+++ b/cmd/datasets.go
@@ -189,7 +189,7 @@ var datasetsCreateCmd = &cobra.Command{
 
 func init() {
 	datasetsListCmd.Flags().IntVar(&datasetsListPage, "page", 1, "Page number (starts at 1)")
-	datasetsListCmd.Flags().IntVar(&datasetsListLimit, "limit", 0, "Items per page")
+	datasetsListCmd.Flags().IntVar(&datasetsListLimit, "limit", 0, "Items per page (max 100)")
 	datasetsListCmd.Flags().
 		StringSliceVar(&datasetsListColumns, "columns", nil, "Columns to display (comma-separated)")
 	datasetsListCmd.Flags().

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -131,7 +131,7 @@ func init() {
 	metricsListCmd.Flags().
 		StringVar(&metricsListToTimestamp, "to-timestamp", "", "Filter metrics to this timestamp (ISO 8601)")
 	metricsListCmd.Flags().IntVar(&metricsListPage, "page", 1, "Page number (starts at 1)")
-	metricsListCmd.Flags().IntVar(&metricsListLimit, "limit", 0, "Items per page")
+	metricsListCmd.Flags().IntVar(&metricsListLimit, "limit", 0, "Items per page (max 365)")
 	metricsListCmd.Flags().
 		StringVar(&metricsListTraceName, "trace-name", "", "Filter by trace name")
 	metricsListCmd.Flags().StringVar(&metricsListUserID, "user-id", "", "Filter by user ID")

--- a/cmd/observations.go
+++ b/cmd/observations.go
@@ -249,7 +249,7 @@ func init() {
 	obsListCmd.Flags().
 		StringVar(&obsListToTimestamp, "to-timestamp", "", "Filter observations to this timestamp (ISO 8601)")
 	obsListCmd.Flags().StringVar(&obsListCursor, "cursor", "", "Cursor for pagination")
-	obsListCmd.Flags().IntVar(&obsListLimit, "limit", 0, "Items per page")
+	obsListCmd.Flags().IntVar(&obsListLimit, "limit", 0, "Items per page (max 100)")
 	obsListCmd.Flags().
 		StringVar(&obsListFields, "fields", "", "Field groups to include (comma-separated)")
 	obsListCmd.Flags().StringVar(&obsListType, "type", "", "Filter by observation type")

--- a/cmd/queue_items.go
+++ b/cmd/queue_items.go
@@ -310,7 +310,7 @@ func init() {
 		StringVar(&queueItemsListStatus, "status", "", "Filter by status (PENDING/COMPLETED)")
 	queueItemsListCmd.Flags().
 		IntVar(&queueItemsListPage, "page", 1, "Page number (starts at 1)")
-	queueItemsListCmd.Flags().IntVar(&queueItemsListLimit, "limit", 0, "Items per page")
+	queueItemsListCmd.Flags().IntVar(&queueItemsListLimit, "limit", 0, "Items per page (max 100)")
 	queueItemsListCmd.Flags().
 		StringSliceVar(&queueItemsListColumns, "columns", nil, "Columns to display (comma-separated)")
 	queueItemsListCmd.Flags().

--- a/cmd/queues.go
+++ b/cmd/queues.go
@@ -266,7 +266,7 @@ This command requires API key authentication.`,
 
 func init() {
 	queuesListCmd.Flags().IntVar(&queuesListPage, "page", 1, "Page number (starts at 1)")
-	queuesListCmd.Flags().IntVar(&queuesListLimit, "limit", 0, "Items per page")
+	queuesListCmd.Flags().IntVar(&queuesListLimit, "limit", 0, "Items per page (max 100)")
 	queuesListCmd.Flags().
 		StringSliceVar(&queuesListColumns, "columns", nil, "Columns to display (comma-separated)")
 	queuesListCmd.Flags().

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Interactive-AI-Labs/interactive-cli/internal/versioncheck"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 const (
@@ -47,24 +48,34 @@ Use the subcommands below to manage your organizations, projects, agents, servic
 				deploymentHostname = "https://" + deploymentHostname
 			}
 
-			if cmd.Name() != "update" {
-				go checkForUpdate()
+			if cmd.Name() != "update" && updateNoticeAllowed() {
+				notifyUpdate()
+				go versioncheck.RefreshCache(cfgDirName)
 			}
 		},
 	}
 )
 
-func checkForUpdate() {
-	latest, err := versioncheck.GetLatestVersion(cfgDirName)
-	if err != nil {
+// updateNoticeAllowed reports whether the upgrade nudge may be shown: never
+// in CI, in scripts (stderr not a terminal), or when the user opted out.
+func updateNoticeAllowed() bool {
+	if os.Getenv("CI") != "" || os.Getenv("INTERACTIVE_NO_UPDATE_NOTIFIER") != "" {
+		return false
+	}
+	return term.IsTerminal(int(os.Stderr.Fd()))
+}
+
+// notifyUpdate queues the upgrade nudge from the on-disk version cache, so a
+// new release is announced one run after RefreshCache first stores it.
+func notifyUpdate() {
+	latest, ok := versioncheck.PendingNotification(cfgDirName, version)
+	if !ok {
 		return
 	}
-	if versioncheck.IsNewer(version, latest) {
-		updateMessage <- fmt.Sprintf(
-			"\nA new version of iai is available: v%s → v%s\nRun \"iai update\" to upgrade.",
-			version, latest,
-		)
-	}
+	updateMessage <- fmt.Sprintf(
+		"\nA new version of iai is available: v%s → v%s\nRun \"iai update\" to upgrade.",
+		version, latest,
+	)
 }
 
 // chainRootPersistentPreRun calls the root command's PersistentPreRun manually.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,6 +48,8 @@ Use the subcommands below to manage your organizations, projects, agents, servic
 				deploymentHostname = "https://" + deploymentHostname
 			}
 
+			// RefreshCache is intentionally gated too: no point keeping the
+			// cache warm when the notice can't be shown anyway.
 			if cmd.Name() != "update" && updateNoticeAllowed() {
 				notifyUpdate()
 				go versioncheck.RefreshCache(cfgDirName)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version            = "0.34.1"
+	version            = "0.34.2"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second

--- a/cmd/run_items.go
+++ b/cmd/run_items.go
@@ -161,7 +161,7 @@ func init() {
 	runItemsListCmd.Flags().
 		StringVar(&runItemsListDatasetName, "dataset-name", "", "Filter by dataset name")
 	runItemsListCmd.Flags().IntVar(&runItemsListPage, "page", 1, "Page number (starts at 1)")
-	runItemsListCmd.Flags().IntVar(&runItemsListLimit, "limit", 0, "Items per page")
+	runItemsListCmd.Flags().IntVar(&runItemsListLimit, "limit", 0, "Items per page (max 100)")
 	runItemsListCmd.Flags().
 		StringSliceVar(&runItemsListColumns, "columns", nil, "Columns to display (comma-separated)")
 	runItemsListCmd.Flags().

--- a/cmd/score_configs.go
+++ b/cmd/score_configs.go
@@ -298,7 +298,7 @@ func init() {
 	scoreConfigsListCmd.Flags().
 		IntVar(&scoreConfigsListPage, "page", 1, "Page number (starts at 1)")
 	scoreConfigsListCmd.Flags().
-		IntVar(&scoreConfigsListLimit, "limit", 0, "Items per page")
+		IntVar(&scoreConfigsListLimit, "limit", 0, "Items per page (max 100)")
 	scoreConfigsListCmd.Flags().
 		StringSliceVar(&scoreConfigsListColumns, "columns", nil, "Columns to display (comma-separated)")
 	scoreConfigsListCmd.Flags().

--- a/cmd/scores.go
+++ b/cmd/scores.go
@@ -250,7 +250,7 @@ func init() {
 	scoresListCmd.Flags().
 		StringVar(&scoresToTimestamp, "to-timestamp", "", "Filter scores to this timestamp (ISO 8601)")
 	scoresListCmd.Flags().StringVar(&scoresCursor, "cursor", "", "Cursor for pagination")
-	scoresListCmd.Flags().IntVar(&scoresLimit, "limit", 0, "Items per page")
+	scoresListCmd.Flags().IntVar(&scoresLimit, "limit", 0, "Items per page (max 100)")
 	scoresListCmd.Flags().
 		StringVar(&scoresFields, "fields", "", "Field groups to include (comma-separated)")
 	scoresListCmd.Flags().StringVar(&scoresName, "name", "", "Filter by score name")

--- a/cmd/sessions.go
+++ b/cmd/sessions.go
@@ -160,7 +160,7 @@ func init() {
 	sessionsListCmd.Flags().
 		StringVar(&sessionsToTimestamp, "to-timestamp", "", "Filter sessions to this timestamp (ISO 8601)")
 	sessionsListCmd.Flags().IntVar(&sessionsPage, "page", 1, "Page number (starts at 1)")
-	sessionsListCmd.Flags().IntVar(&sessionsLimit, "limit", 0, "Items per page")
+	sessionsListCmd.Flags().IntVar(&sessionsLimit, "limit", 0, "Items per page (max 100)")
 	sessionsListCmd.Flags().
 		StringVar(&sessionsEnvironment, "environment", "", "Filter by environment")
 	sessionsListCmd.Flags().

--- a/cmd/traces.go
+++ b/cmd/traces.go
@@ -299,7 +299,7 @@ Examples:
 func init() {
 	// traces list flags
 	tracesListCmd.Flags().IntVar(&tracesPage, "page", 1, "Page number (starts at 1)")
-	tracesListCmd.Flags().IntVar(&tracesLimit, "limit", 0, "Items per page")
+	tracesListCmd.Flags().IntVar(&tracesLimit, "limit", 0, "Items per page (max 100)")
 	tracesListCmd.Flags().StringVar(&tracesUserID, "user-id", "", "Filter by user ID")
 	tracesListCmd.Flags().StringVar(&tracesName, "name", "", "Filter by trace name")
 	tracesListCmd.Flags().StringVar(&tracesSessionID, "session-id", "", "Filter by session ID")

--- a/docs/iai_comments_list.md
+++ b/docs/iai_comments_list.md
@@ -17,7 +17,7 @@ iai comments list [flags]
       --columns strings         Columns to display (comma-separated)
   -h, --help                    help for list
       --json                    Output raw API response as JSON
-      --limit int               Items per page
+      --limit int               Items per page (max 100)
       --object-id string        Filter by object ID
       --object-type string      Filter by object type (TRACE/OBSERVATION/SESSION/PROMPT)
   -o, --organization string     Organization name that owns the project

--- a/docs/iai_dataset-items_list.md
+++ b/docs/iai_dataset-items_list.md
@@ -17,7 +17,7 @@ iai dataset-items list [flags]
       --dataset-name string            Dataset name (required)
   -h, --help                           help for list
       --json                           Output raw API response as JSON
-      --limit int                      Items per page
+      --limit int                      Items per page (max 100)
   -o, --organization string            Organization name that owns the project
       --page int                       Page number (starts at 1) (default 1)
   -p, --project string                 Project name

--- a/docs/iai_dataset-runs_list.md
+++ b/docs/iai_dataset-runs_list.md
@@ -17,7 +17,7 @@ iai dataset-runs list [flags]
       --dataset-name string   Dataset name (required)
   -h, --help                  help for list
       --json                  Output raw API response as JSON
-      --limit int             Items per page
+      --limit int             Items per page (max 100)
   -o, --organization string   Organization name that owns the project
       --page int              Page number (starts at 1) (default 1)
   -p, --project string        Project name

--- a/docs/iai_datasets_list.md
+++ b/docs/iai_datasets_list.md
@@ -16,7 +16,7 @@ iai datasets list [flags]
       --columns strings       Columns to display (comma-separated)
   -h, --help                  help for list
       --json                  Output raw API response as JSON
-      --limit int             Items per page
+      --limit int             Items per page (max 100)
   -o, --organization string   Organization name that owns the project
       --page int              Page number (starts at 1) (default 1)
   -p, --project string        Project name

--- a/docs/iai_metrics_list.md
+++ b/docs/iai_metrics_list.md
@@ -30,7 +30,7 @@ iai metrics list [flags]
       --from-timestamp string   Filter metrics from this timestamp (ISO 8601, default: 7 days ago)
   -h, --help                    help for list
       --json                    Output raw API response as JSON
-      --limit int               Items per page
+      --limit int               Items per page (max 365)
   -o, --organization string     Organization name that owns the project
       --page int                Page number (starts at 1) (default 1)
   -p, --project string          Project name

--- a/docs/iai_observations_list.md
+++ b/docs/iai_observations_list.md
@@ -40,7 +40,7 @@ iai observations list [flags]
       --include-io                     Include input/output/metadata in response (only with --trace-id)
       --json                           Output raw API response as JSON
       --level string                   Filter by level
-      --limit int                      Items per page
+      --limit int                      Items per page (max 100)
       --model string                   Filter by model
       --name string                    Filter by observation name
   -o, --organization string            Organization name that owns the project

--- a/docs/iai_queue-items_list.md
+++ b/docs/iai_queue-items_list.md
@@ -16,7 +16,7 @@ iai queue-items list [flags]
       --columns strings       Columns to display (comma-separated)
   -h, --help                  help for list
       --json                  Output raw API response as JSON
-      --limit int             Items per page
+      --limit int             Items per page (max 100)
   -o, --organization string   Organization name that owns the project
       --page int              Page number (starts at 1) (default 1)
   -p, --project string        Project name

--- a/docs/iai_queues_list.md
+++ b/docs/iai_queues_list.md
@@ -16,7 +16,7 @@ iai queues list [flags]
       --columns strings       Columns to display (comma-separated)
   -h, --help                  help for list
       --json                  Output raw API response as JSON
-      --limit int             Items per page
+      --limit int             Items per page (max 100)
   -o, --organization string   Organization name that owns the project
       --page int              Page number (starts at 1) (default 1)
   -p, --project string        Project name

--- a/docs/iai_run-items_list.md
+++ b/docs/iai_run-items_list.md
@@ -17,7 +17,7 @@ iai run-items list [flags]
       --dataset-name string   Filter by dataset name
   -h, --help                  help for list
       --json                  Output raw API response as JSON
-      --limit int             Items per page
+      --limit int             Items per page (max 100)
   -o, --organization string   Organization name that owns the project
       --page int              Page number (starts at 1) (default 1)
   -p, --project string        Project name

--- a/docs/iai_score-configs_list.md
+++ b/docs/iai_score-configs_list.md
@@ -16,7 +16,7 @@ iai score-configs list [flags]
       --columns strings       Columns to display (comma-separated)
   -h, --help                  help for list
       --json                  Output raw API response as JSON
-      --limit int             Items per page
+      --limit int             Items per page (max 100)
   -o, --organization string   Organization name that owns the project
       --page int              Page number (starts at 1) (default 1)
   -p, --project string        Project name

--- a/docs/iai_scores_list.md
+++ b/docs/iai_scores_list.md
@@ -26,7 +26,7 @@ iai scores list [flags]
       --from-timestamp string   Filter scores from this timestamp (ISO 8601, default: 7 days ago)
   -h, --help                    help for list
       --json                    Output raw API response as JSON
-      --limit int               Items per page
+      --limit int               Items per page (max 100)
       --max-value float         Maximum score value
       --min-value float         Minimum score value
       --name string             Filter by score name

--- a/docs/iai_sessions_list.md
+++ b/docs/iai_sessions_list.md
@@ -22,7 +22,7 @@ iai sessions list [flags]
       --from-timestamp string   Filter sessions from this timestamp (ISO 8601, default: 7 days ago)
   -h, --help                    help for list
       --json                    Output raw API response as JSON
-      --limit int               Items per page
+      --limit int               Items per page (max 100)
   -o, --organization string     Organization name that owns the project
       --page int                Page number (starts at 1) (default 1)
   -p, --project string          Project name

--- a/docs/iai_traces_list.md
+++ b/docs/iai_traces_list.md
@@ -40,7 +40,7 @@ iai traces list [flags]
   -h, --help                      help for list
       --json                      Output raw API response as JSON
       --level string              Filter by aggregated level: DEBUG, DEFAULT, WARNING, ERROR
-      --limit int                 Items per page
+      --limit int                 Items per page (max 100)
       --max-cost float            Maximum total cost filter
       --max-latency float         Maximum latency filter (seconds)
       --max-tokens int            Maximum total tokens filter

--- a/internal/files/version_cache.go
+++ b/internal/files/version_cache.go
@@ -4,17 +4,17 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"time"
 )
 
-const (
-	versionCacheFile = "latest_version"
-	versionCacheTTL  = 24 * time.Hour
-)
+const versionCacheFile = "latest_version"
 
-type versionCache struct {
+// VersionCache is the persisted state of the background update check.
+// CheckedAt is when LatestVersion was last fetched from the module proxy;
+// NotifiedAt is when the user was last shown the upgrade nudge.
+type VersionCache struct {
 	LatestVersion string `json:"latest_version"`
 	CheckedAt     int64  `json:"checked_at"`
+	NotifiedAt    int64  `json:"notified_at,omitempty"`
 }
 
 func versionCachePath(cfgDirName string) string {
@@ -25,36 +25,29 @@ func versionCachePath(cfgDirName string) string {
 	return filepath.Join(home, cfgDirName, versionCacheFile)
 }
 
-func ReadVersionCache(cfgDirName string) (string, bool) {
+func ReadVersionCache(cfgDirName string) (VersionCache, bool) {
 	path := versionCachePath(cfgDirName)
 	if path == "" {
-		return "", false
+		return VersionCache{}, false
 	}
 
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return "", false
+		return VersionCache{}, false
 	}
-	var c versionCache
+	var c VersionCache
 	if err := json.Unmarshal(data, &c); err != nil {
-		return "", false
+		return VersionCache{}, false
 	}
-	if time.Since(time.Unix(c.CheckedAt, 0)) > versionCacheTTL {
-		return "", false
-	}
-	return c.LatestVersion, true
+	return c, true
 }
 
-func WriteVersionCache(cfgDirName, version string) {
+func WriteVersionCache(cfgDirName string, c VersionCache) {
 	path := versionCachePath(cfgDirName)
 	if path == "" {
 		return
 	}
 
-	c := versionCache{
-		LatestVersion: version,
-		CheckedAt:     time.Now().Unix(),
-	}
 	data, err := json.Marshal(c)
 	if err != nil {
 		return

--- a/internal/files/version_cache_test.go
+++ b/internal/files/version_cache_test.go
@@ -1,11 +1,9 @@
 package files
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 )
 
 func TestVersionCacheReadWrite(t *testing.T) {
@@ -14,29 +12,22 @@ func TestVersionCacheReadWrite(t *testing.T) {
 	t.Setenv("HOME", filepath.Dir(dir))
 
 	// No cache yet
-	v, ok := ReadVersionCache(cfgDirName)
-	if ok {
-		t.Fatalf("expected cache miss, got %q", v)
+	if c, ok := ReadVersionCache(cfgDirName); ok {
+		t.Fatalf("expected cache miss, got %+v", c)
 	}
 
 	// Write and read back
-	WriteVersionCache(cfgDirName, "0.29.0")
-	v, ok = ReadVersionCache(cfgDirName)
-	if !ok || v != "0.29.0" {
-		t.Fatalf("ReadVersionCache() = (%q, %v), want (\"0.29.0\", true)", v, ok)
+	in := VersionCache{LatestVersion: "0.29.0", CheckedAt: 1700000000, NotifiedAt: 1700000100}
+	WriteVersionCache(cfgDirName, in)
+	out, ok := ReadVersionCache(cfgDirName)
+	if !ok || out != in {
+		t.Fatalf("ReadVersionCache() = (%+v, %v), want (%+v, true)", out, ok, in)
 	}
 
-	// Expired cache
+	// Corrupt cache
 	path := filepath.Join(dir, versionCacheFile)
-	expired := versionCache{
-		LatestVersion: "0.29.0",
-		CheckedAt:     time.Now().Add(-25 * time.Hour).Unix(),
-	}
-	data, _ := json.Marshal(expired)
-	_ = os.WriteFile(path, data, 0o644)
-
-	_, ok = ReadVersionCache(cfgDirName)
-	if ok {
-		t.Fatal("expected cache miss on expired entry")
+	_ = os.WriteFile(path, []byte("{"), 0o644)
+	if _, ok := ReadVersionCache(cfgDirName); ok {
+		t.Fatal("expected cache miss on corrupt entry")
 	}
 }

--- a/internal/files/version_cache_test.go
+++ b/internal/files/version_cache_test.go
@@ -6,28 +6,40 @@ import (
 	"testing"
 )
 
-func TestVersionCacheReadWrite(t *testing.T) {
+// tempCfgDir points HOME at a temp dir and returns the cfg dir name and path.
+func tempCfgDir(t *testing.T) (string, string) {
+	t.Helper()
 	dir := t.TempDir()
-	cfgDirName := filepath.Base(dir)
 	t.Setenv("HOME", filepath.Dir(dir))
+	return filepath.Base(dir), dir
+}
 
-	// No cache yet
-	if c, ok := ReadVersionCache(cfgDirName); ok {
-		t.Fatalf("expected cache miss, got %+v", c)
-	}
+func TestVersionCache(t *testing.T) {
+	t.Run("misses when no cache exists", func(t *testing.T) {
+		cfgDirName, _ := tempCfgDir(t)
+		if c, ok := ReadVersionCache(cfgDirName); ok {
+			t.Fatalf("expected cache miss, got %+v", c)
+		}
+	})
 
-	// Write and read back
-	in := VersionCache{LatestVersion: "0.29.0", CheckedAt: 1700000000, NotifiedAt: 1700000100}
-	WriteVersionCache(cfgDirName, in)
-	out, ok := ReadVersionCache(cfgDirName)
-	if !ok || out != in {
-		t.Fatalf("ReadVersionCache() = (%+v, %v), want (%+v, true)", out, ok, in)
-	}
+	t.Run("round-trips a written entry", func(t *testing.T) {
+		cfgDirName, _ := tempCfgDir(t)
+		in := VersionCache{LatestVersion: "0.29.0", CheckedAt: 1700000000, NotifiedAt: 1700000100}
+		WriteVersionCache(cfgDirName, in)
+		out, ok := ReadVersionCache(cfgDirName)
+		if !ok || out != in {
+			t.Fatalf("ReadVersionCache() = (%+v, %v), want (%+v, true)", out, ok, in)
+		}
+	})
 
-	// Corrupt cache
-	path := filepath.Join(dir, versionCacheFile)
-	_ = os.WriteFile(path, []byte("{"), 0o644)
-	if _, ok := ReadVersionCache(cfgDirName); ok {
-		t.Fatal("expected cache miss on corrupt entry")
-	}
+	t.Run("misses on corrupt entry", func(t *testing.T) {
+		cfgDirName, dir := tempCfgDir(t)
+		path := filepath.Join(dir, versionCacheFile)
+		if err := os.WriteFile(path, []byte("{"), 0o644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+		if _, ok := ReadVersionCache(cfgDirName); ok {
+			t.Fatal("expected cache miss on corrupt entry")
+		}
+	})
 }

--- a/internal/versioncheck/notify_test.go
+++ b/internal/versioncheck/notify_test.go
@@ -1,0 +1,72 @@
+package versioncheck
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/files"
+)
+
+func TestPendingNotification(t *testing.T) {
+	dir := t.TempDir()
+	cfgDirName := filepath.Base(dir)
+	t.Setenv("HOME", filepath.Dir(dir))
+
+	// No cache → nothing to announce.
+	if _, ok := PendingNotification(cfgDirName, "0.34.0"); ok {
+		t.Fatal("expected no notification without a cache")
+	}
+
+	files.WriteVersionCache(cfgDirName, files.VersionCache{
+		LatestVersion: "0.35.0",
+		CheckedAt:     time.Now().Unix(),
+	})
+
+	// First sighting of a newer release notifies and stamps the cache.
+	latest, ok := PendingNotification(cfgDirName, "0.34.0")
+	if !ok || latest != "0.35.0" {
+		t.Fatalf("PendingNotification() = (%q, %v), want (\"0.35.0\", true)", latest, ok)
+	}
+	if c, _ := files.ReadVersionCache(cfgDirName); c.NotifiedAt == 0 {
+		t.Fatal("expected NotifiedAt to be stamped")
+	}
+
+	// Within the notify interval it stays quiet.
+	if _, ok := PendingNotification(cfgDirName, "0.34.0"); ok {
+		t.Fatal("expected notification to be throttled")
+	}
+
+	// Once the stamp ages out, it fires again.
+	c, _ := files.ReadVersionCache(cfgDirName)
+	c.NotifiedAt = time.Now().Add(-notifyInterval - time.Hour).Unix()
+	files.WriteVersionCache(cfgDirName, c)
+	if _, ok := PendingNotification(cfgDirName, "0.34.0"); !ok {
+		t.Fatal("expected notification after the interval elapsed")
+	}
+
+	// Up to date → quiet regardless of stamps.
+	if _, ok := PendingNotification(cfgDirName, "0.35.0"); ok {
+		t.Fatal("expected no notification when already up to date")
+	}
+}
+
+func TestRefreshCacheSkipsFreshCache(t *testing.T) {
+	dir := t.TempDir()
+	cfgDirName := filepath.Base(dir)
+	t.Setenv("HOME", filepath.Dir(dir))
+
+	in := files.VersionCache{
+		LatestVersion: "9.9.9",
+		CheckedAt:     time.Now().Unix(),
+		NotifiedAt:    1700000000,
+	}
+	files.WriteVersionCache(cfgDirName, in)
+
+	// A fresh cache must short-circuit before any network access.
+	RefreshCache(cfgDirName)
+
+	if out, _ := files.ReadVersionCache(cfgDirName); out != in {
+		t.Fatalf("RefreshCache rewrote a fresh cache: %+v", out)
+	}
+}

--- a/internal/versioncheck/notify_test.go
+++ b/internal/versioncheck/notify_test.go
@@ -8,65 +8,80 @@ import (
 	"github.com/Interactive-AI-Labs/interactive-cli/internal/files"
 )
 
-func TestPendingNotification(t *testing.T) {
+// seedCache points HOME at a temp dir and writes the given cache entry,
+// returning the cfg dir name to pass to the functions under test.
+func seedCache(t *testing.T, c *files.VersionCache) string {
+	t.Helper()
 	dir := t.TempDir()
-	cfgDirName := filepath.Base(dir)
 	t.Setenv("HOME", filepath.Dir(dir))
-
-	// No cache → nothing to announce.
-	if _, ok := PendingNotification(cfgDirName, "0.34.0"); ok {
-		t.Fatal("expected no notification without a cache")
+	cfgDirName := filepath.Base(dir)
+	if c != nil {
+		files.WriteVersionCache(cfgDirName, *c)
 	}
-
-	files.WriteVersionCache(cfgDirName, files.VersionCache{
-		LatestVersion: "0.35.0",
-		CheckedAt:     time.Now().Unix(),
-	})
-
-	// First sighting of a newer release notifies and stamps the cache.
-	latest, ok := PendingNotification(cfgDirName, "0.34.0")
-	if !ok || latest != "0.35.0" {
-		t.Fatalf("PendingNotification() = (%q, %v), want (\"0.35.0\", true)", latest, ok)
-	}
-	if c, _ := files.ReadVersionCache(cfgDirName); c.NotifiedAt == 0 {
-		t.Fatal("expected NotifiedAt to be stamped")
-	}
-
-	// Within the notify interval it stays quiet.
-	if _, ok := PendingNotification(cfgDirName, "0.34.0"); ok {
-		t.Fatal("expected notification to be throttled")
-	}
-
-	// Once the stamp ages out, it fires again.
-	c, _ := files.ReadVersionCache(cfgDirName)
-	c.NotifiedAt = time.Now().Add(-notifyInterval - time.Hour).Unix()
-	files.WriteVersionCache(cfgDirName, c)
-	if _, ok := PendingNotification(cfgDirName, "0.34.0"); !ok {
-		t.Fatal("expected notification after the interval elapsed")
-	}
-
-	// Up to date → quiet regardless of stamps.
-	if _, ok := PendingNotification(cfgDirName, "0.35.0"); ok {
-		t.Fatal("expected no notification when already up to date")
-	}
+	return cfgDirName
 }
 
-func TestRefreshCacheSkipsFreshCache(t *testing.T) {
-	dir := t.TempDir()
-	cfgDirName := filepath.Base(dir)
-	t.Setenv("HOME", filepath.Dir(dir))
+func TestPendingNotification(t *testing.T) {
+	t.Run("quiet without a cache", func(t *testing.T) {
+		cfgDirName := seedCache(t, nil)
+		if _, ok := PendingNotification(cfgDirName, "0.34.0"); ok {
+			t.Fatal("expected no notification without a cache")
+		}
+	})
 
-	in := files.VersionCache{
-		LatestVersion: "9.9.9",
-		CheckedAt:     time.Now().Unix(),
-		NotifiedAt:    1700000000,
-	}
-	files.WriteVersionCache(cfgDirName, in)
+	t.Run("notifies on newer version and stamps cache", func(t *testing.T) {
+		cfgDirName := seedCache(t, &files.VersionCache{LatestVersion: "0.35.0"})
+		latest, ok := PendingNotification(cfgDirName, "0.34.0")
+		if !ok || latest != "0.35.0" {
+			t.Fatalf("PendingNotification() = (%q, %v), want (\"0.35.0\", true)", latest, ok)
+		}
+		if c, _ := files.ReadVersionCache(cfgDirName); c.NotifiedAt == 0 {
+			t.Fatal("expected NotifiedAt to be stamped")
+		}
+	})
 
-	// A fresh cache must short-circuit before any network access.
-	RefreshCache(cfgDirName)
+	t.Run("throttled within the notify interval", func(t *testing.T) {
+		cfgDirName := seedCache(t, &files.VersionCache{
+			LatestVersion: "0.35.0",
+			NotifiedAt:    time.Now().Unix(),
+		})
+		if _, ok := PendingNotification(cfgDirName, "0.34.0"); ok {
+			t.Fatal("expected notification to be throttled")
+		}
+	})
 
-	if out, _ := files.ReadVersionCache(cfgDirName); out != in {
-		t.Fatalf("RefreshCache rewrote a fresh cache: %+v", out)
-	}
+	t.Run("fires again after the interval elapses", func(t *testing.T) {
+		cfgDirName := seedCache(t, &files.VersionCache{
+			LatestVersion: "0.35.0",
+			NotifiedAt:    time.Now().Add(-notifyInterval - time.Hour).Unix(),
+		})
+		if _, ok := PendingNotification(cfgDirName, "0.34.0"); !ok {
+			t.Fatal("expected notification after the interval elapsed")
+		}
+	})
+
+	t.Run("quiet when already up to date", func(t *testing.T) {
+		cfgDirName := seedCache(t, &files.VersionCache{LatestVersion: "0.35.0"})
+		if _, ok := PendingNotification(cfgDirName, "0.35.0"); ok {
+			t.Fatal("expected no notification when already up to date")
+		}
+	})
+}
+
+func TestRefreshCache(t *testing.T) {
+	t.Run("skips fetch when cache is fresh", func(t *testing.T) {
+		in := files.VersionCache{
+			LatestVersion: "9.9.9",
+			CheckedAt:     time.Now().Unix(),
+			NotifiedAt:    1700000000,
+		}
+		cfgDirName := seedCache(t, &in)
+
+		// A fresh cache must short-circuit before any network access.
+		RefreshCache(cfgDirName)
+
+		if out, _ := files.ReadVersionCache(cfgDirName); out != in {
+			t.Fatalf("RefreshCache rewrote a fresh cache: %+v", out)
+		}
+	})
 }

--- a/internal/versioncheck/version.go
+++ b/internal/versioncheck/version.go
@@ -67,6 +67,11 @@ func RefreshCache(cfgDirName string) {
 		return
 	}
 
+	// Re-read after the slow fetch so a NotifiedAt stamped by a concurrent
+	// process is not clobbered by this write.
+	if fresh, ok := files.ReadVersionCache(cfgDirName); ok {
+		c = fresh
+	}
 	c.LatestVersion = v
 	c.CheckedAt = time.Now().Unix()
 	files.WriteVersionCache(cfgDirName, c)

--- a/internal/versioncheck/version.go
+++ b/internal/versioncheck/version.go
@@ -15,6 +15,9 @@ import (
 const (
 	goProxyURL   = "https://proxy.golang.org/github.com/!interactive-!a!i-!labs/interactive-cli/@latest"
 	fetchTimeout = 10 * time.Second
+
+	checkInterval  = 24 * time.Hour // how often to query the module proxy
+	notifyInterval = 24 * time.Hour // how often to show the upgrade nudge
 )
 
 type proxyInfo struct {
@@ -50,21 +53,40 @@ func FetchLatestVersion(timeout time.Duration) (string, error) {
 	return strings.TrimPrefix(info.Version, "v"), nil
 }
 
-// GetLatestVersion returns the latest version, using a local cache to avoid
-// hitting the network on every invocation. cfgDirName is the dotfile directory
-// name (e.g. ".interactiveai").
-func GetLatestVersion(cfgDirName string) (string, error) {
-	if v, ok := files.ReadVersionCache(cfgDirName); ok {
-		return v, nil
+// RefreshCache fetches the latest version into the on-disk cache, skipping
+// the network while the cached value is younger than checkInterval. Errors
+// are dropped — an interrupted background fetch is retried on a later run.
+func RefreshCache(cfgDirName string) {
+	c, ok := files.ReadVersionCache(cfgDirName)
+	if ok && time.Since(time.Unix(c.CheckedAt, 0)) < checkInterval {
+		return
 	}
 
 	v, err := FetchLatestVersion(0)
 	if err != nil {
-		return "", err
+		return
 	}
 
-	files.WriteVersionCache(cfgDirName, v)
-	return v, nil
+	c.LatestVersion = v
+	c.CheckedAt = time.Now().Unix()
+	files.WriteVersionCache(cfgDirName, c)
+}
+
+// PendingNotification reports whether to tell the user a newer release
+// exists, based only on the on-disk cache (no network access). It returns
+// true at most once per notifyInterval, stamping the cache when it does.
+func PendingNotification(cfgDirName, current string) (string, bool) {
+	c, ok := files.ReadVersionCache(cfgDirName)
+	if !ok || !IsNewer(current, c.LatestVersion) {
+		return "", false
+	}
+	if time.Since(time.Unix(c.NotifiedAt, 0)) < notifyInterval {
+		return "", false
+	}
+
+	c.NotifiedAt = time.Now().Unix()
+	files.WriteVersionCache(cfgDirName, c)
+	return c.LatestVersion, true
 }
 
 // IsNewer returns true if latest is a higher semver than current.


### PR DESCRIPTION
## What

### Update notice: at most once per day, never in CI/scripts
The "new version available" message printed on **every** command run: the 24h cache only throttled the network fetch, while the notice itself fired unconditionally on any cache hit. This adopts the update-notifier pattern (npm, gh):

- The notice is driven synchronously from the on-disk cache (`PendingNotification`), so it never races the command. A background `RefreshCache` keeps the cache fresh (proxy hit at most once per 24h); a new release is announced one run after it is first fetched.
- A `notified_at` stamp in the cache throttles the message to once per 24h.
- Fully suppressed when `CI` is set, stderr is not a TTY (scripts/pipelines), or `INTERACTIVE_NO_UPDATE_NOTIFIER` is set.

### Document --limit maximums
The API rejects `--limit` above 100 on 12 list commands (traces, sessions, observations, scores, score-configs, comments, datasets, dataset-runs, dataset-items, run-items, queues, queue-items) and above 365 on `metrics list`, but the flag help just said "Items per page". Help text and generated docs now state the max. Prompt-type list commands accept arbitrary limits and are unchanged.

## Testing

- Unit tests for the new cache/notify logic (notify-once, 24h throttle, re-fire after interval, refresh skips fresh cache) using real temp-dir files.
- Verified end-to-end with the built binary under a pseudo-TTY and a seeded cache: run 1 notifies, run 2 silent, CI/non-TTY/opt-out runs silent.
- Limit caps verified live against the API for every affected command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)