### PR TITLE
DEV-756: clarify columns output help

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.34.2"
+current_version = "0.34.3"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/comments.go
+++ b/cmd/comments.go
@@ -208,7 +208,7 @@ func init() {
 	commentsListCmd.Flags().IntVar(&commentsListPage, "page", 1, "Page number (starts at 1)")
 	commentsListCmd.Flags().IntVar(&commentsListLimit, "limit", 0, "Items per page (max 100)")
 	commentsListCmd.Flags().
-		StringSliceVar(&commentsListColumns, "columns", nil, "Columns to display (comma-separated)")
+		StringSliceVar(&commentsListColumns, "columns", nil, "Columns to display for table output only (comma-separated). Cannot be used with --json or --yaml")
 	commentsListCmd.Flags().
 		BoolVar(&commentsListJSON, "json", false, "Output raw API response as JSON")
 	commentsListCmd.Flags().

--- a/cmd/dataset_items.go
+++ b/cmd/dataset_items.go
@@ -265,7 +265,7 @@ func init() {
 	datasetItemsListCmd.Flags().
 		IntVar(&datasetItemsListLimit, "limit", 0, "Items per page (max 100)")
 	datasetItemsListCmd.Flags().
-		StringSliceVar(&datasetItemsListColumns, "columns", nil, "Columns to display (comma-separated)")
+		StringSliceVar(&datasetItemsListColumns, "columns", nil, "Columns to display for table output only (comma-separated). Cannot be used with --json or --yaml")
 	datasetItemsListCmd.Flags().
 		BoolVar(&datasetItemsListJSON, "json", false, "Output raw API response as JSON")
 	datasetItemsListCmd.Flags().

--- a/cmd/dataset_runs.go
+++ b/cmd/dataset_runs.go
@@ -195,7 +195,7 @@ func init() {
 		IntVar(&datasetRunsListPage, "page", 1, "Page number (starts at 1)")
 	datasetRunsListCmd.Flags().IntVar(&datasetRunsListLimit, "limit", 0, "Items per page (max 100)")
 	datasetRunsListCmd.Flags().
-		StringSliceVar(&datasetRunsListColumns, "columns", nil, "Columns to display (comma-separated)")
+		StringSliceVar(&datasetRunsListColumns, "columns", nil, "Columns to display for table output only (comma-separated). Cannot be used with --json or --yaml")
 	datasetRunsListCmd.Flags().
 		BoolVar(&datasetRunsListJSON, "json", false, "Output raw API response as JSON")
 	datasetRunsListCmd.Flags().

--- a/cmd/datasets.go
+++ b/cmd/datasets.go
@@ -191,7 +191,7 @@ func init() {
 	datasetsListCmd.Flags().IntVar(&datasetsListPage, "page", 1, "Page number (starts at 1)")
 	datasetsListCmd.Flags().IntVar(&datasetsListLimit, "limit", 0, "Items per page (max 100)")
 	datasetsListCmd.Flags().
-		StringSliceVar(&datasetsListColumns, "columns", nil, "Columns to display (comma-separated)")
+		StringSliceVar(&datasetsListColumns, "columns", nil, "Columns to display for table output only (comma-separated). Cannot be used with --json or --yaml")
 	datasetsListCmd.Flags().
 		BoolVar(&datasetsListJSON, "json", false, "Output raw API response as JSON")
 	datasetsListCmd.Flags().

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -140,7 +140,7 @@ func init() {
 	metricsListCmd.Flags().
 		StringVar(&metricsListEnvironment, "environment", "", "Filter by environment")
 	metricsListCmd.Flags().
-		StringSliceVar(&metricsListColumns, "columns", nil, "Columns to display (comma-separated, default: date,count_traces,count_observations,total_cost)\nAvailable: date,count_traces,count_observations,total_cost,total_tokens")
+		StringSliceVar(&metricsListColumns, "columns", nil, "Columns to display for table output only (comma-separated, default: date,count_traces,count_observations,total_cost). Cannot be used with --json or --yaml.\nAvailable: date,count_traces,count_observations,total_cost,total_tokens")
 	metricsListCmd.Flags().
 		BoolVar(&metricsListShowModels, "show-models", false, "Show per-model breakdown")
 	metricsListCmd.Flags().

--- a/cmd/observations.go
+++ b/cmd/observations.go
@@ -233,7 +233,7 @@ func init() {
 	obsListCmd.Flags().BoolVar(&obsListYAML, "yaml", false, "Output raw API response as YAML")
 	obsListCmd.MarkFlagsMutuallyExclusive("json", "yaml")
 	obsListCmd.Flags().
-		StringSliceVar(&obsColumns, "columns", nil, "Columns to display (comma-separated)\nWith --trace-id default: id,type,name,model,latency_ms,total_cost,total_tokens\nWithout --trace-id default: id,trace_id,type,name,model,latency_ms,total_cost,total_tokens")
+		StringSliceVar(&obsColumns, "columns", nil, "Columns to display for table output only (comma-separated). Cannot be used with --json or --yaml\nWith --trace-id default: id,type,name,model,latency_ms,total_cost,total_tokens\nWithout --trace-id default: id,trace_id,type,name,model,latency_ms,total_cost,total_tokens")
 	obsListCmd.Flags().
 		StringVarP(&obsListOrg, "organization", "o", "", "Organization name that owns the project")
 	obsListCmd.Flags().

--- a/cmd/queue_items.go
+++ b/cmd/queue_items.go
@@ -312,7 +312,7 @@ func init() {
 		IntVar(&queueItemsListPage, "page", 1, "Page number (starts at 1)")
 	queueItemsListCmd.Flags().IntVar(&queueItemsListLimit, "limit", 0, "Items per page (max 100)")
 	queueItemsListCmd.Flags().
-		StringSliceVar(&queueItemsListColumns, "columns", nil, "Columns to display (comma-separated)")
+		StringSliceVar(&queueItemsListColumns, "columns", nil, "Columns to display for table output only (comma-separated). Cannot be used with --json or --yaml")
 	queueItemsListCmd.Flags().
 		BoolVar(&queueItemsListJSON, "json", false, "Output raw API response as JSON")
 	queueItemsListCmd.Flags().

--- a/cmd/queues.go
+++ b/cmd/queues.go
@@ -268,7 +268,7 @@ func init() {
 	queuesListCmd.Flags().IntVar(&queuesListPage, "page", 1, "Page number (starts at 1)")
 	queuesListCmd.Flags().IntVar(&queuesListLimit, "limit", 0, "Items per page (max 100)")
 	queuesListCmd.Flags().
-		StringSliceVar(&queuesListColumns, "columns", nil, "Columns to display (comma-separated)")
+		StringSliceVar(&queuesListColumns, "columns", nil, "Columns to display for table output only (comma-separated). Cannot be used with --json or --yaml")
 	queuesListCmd.Flags().
 		BoolVar(&queuesListJSON, "json", false, "Output raw API response as JSON")
 	queuesListCmd.Flags().

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version            = "0.34.2"
+	version            = "0.34.3"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second

--- a/cmd/run_items.go
+++ b/cmd/run_items.go
@@ -163,7 +163,7 @@ func init() {
 	runItemsListCmd.Flags().IntVar(&runItemsListPage, "page", 1, "Page number (starts at 1)")
 	runItemsListCmd.Flags().IntVar(&runItemsListLimit, "limit", 0, "Items per page (max 100)")
 	runItemsListCmd.Flags().
-		StringSliceVar(&runItemsListColumns, "columns", nil, "Columns to display (comma-separated)")
+		StringSliceVar(&runItemsListColumns, "columns", nil, "Columns to display for table output only (comma-separated). Cannot be used with --json or --yaml")
 	runItemsListCmd.Flags().
 		BoolVar(&runItemsListJSON, "json", false, "Output raw API response as JSON")
 	runItemsListCmd.Flags().

--- a/cmd/score_configs.go
+++ b/cmd/score_configs.go
@@ -300,7 +300,7 @@ func init() {
 	scoreConfigsListCmd.Flags().
 		IntVar(&scoreConfigsListLimit, "limit", 0, "Items per page (max 100)")
 	scoreConfigsListCmd.Flags().
-		StringSliceVar(&scoreConfigsListColumns, "columns", nil, "Columns to display (comma-separated)")
+		StringSliceVar(&scoreConfigsListColumns, "columns", nil, "Columns to display for table output only (comma-separated). Cannot be used with --json or --yaml")
 	scoreConfigsListCmd.Flags().
 		BoolVar(&scoreConfigsListJSON, "json", false, "Output raw API response as JSON")
 	scoreConfigsListCmd.Flags().

--- a/cmd/scores.go
+++ b/cmd/scores.go
@@ -274,7 +274,7 @@ func init() {
 	scoresListCmd.Flags().StringVar(&scoresValue, "value", "", "Exact value filter")
 	scoresListCmd.Flags().StringVar(&scoresOperator, "operator", "", "Operator for --value")
 	scoresListCmd.Flags().
-		StringSliceVar(&scoresColumns, "columns", nil, "Columns to display (comma-separated, default: id,name,data_type,value,source,timestamp,trace_id)\nAvailable: id,name,data_type,value,source,timestamp,trace_id,observation_id,session_id,environment,config_id,user_id,comment")
+		StringSliceVar(&scoresColumns, "columns", nil, "Columns to display for table output only (comma-separated, default: id,name,data_type,value,source,timestamp,trace_id). Cannot be used with --json or --yaml.\nAvailable: id,name,data_type,value,source,timestamp,trace_id,observation_id,session_id,environment,config_id,user_id,comment")
 	scoresListCmd.Flags().
 		BoolVar(&scoresListJSON, "json", false, "Output raw API response as JSON")
 	scoresListCmd.Flags().

--- a/cmd/sessions.go
+++ b/cmd/sessions.go
@@ -164,7 +164,7 @@ func init() {
 	sessionsListCmd.Flags().
 		StringVar(&sessionsEnvironment, "environment", "", "Filter by environment")
 	sessionsListCmd.Flags().
-		StringSliceVar(&sessionsColumns, "columns", nil, "Columns to display (comma-separated, default: id,created_at,environment,trace_count,duration_seconds,total_cost,total_tokens)\nAvailable: id,created_at,updated_at,environment,user_id,trace_count,duration_seconds,total_cost,input_tokens,output_tokens,total_tokens")
+		StringSliceVar(&sessionsColumns, "columns", nil, "Columns to display for table output only (comma-separated, default: id,created_at,environment,trace_count,duration_seconds,total_cost,total_tokens). Cannot be used with --json or --yaml.\nAvailable: id,created_at,updated_at,environment,user_id,trace_count,duration_seconds,total_cost,input_tokens,output_tokens,total_tokens")
 	sessionsListCmd.Flags().
 		BoolVar(&sessionsListJSON, "json", false, "Output raw API response as JSON")
 	sessionsListCmd.Flags().

--- a/cmd/traces.go
+++ b/cmd/traces.go
@@ -342,7 +342,7 @@ func init() {
 	// StringSliceVar (not StringArrayVar) so users can pass --columns id,name,cost as a comma-separated list.
 	// --tags and --environment use StringArrayVar to avoid splitting values that may contain commas.
 	tracesListCmd.Flags().
-		StringSliceVar(&tracesColumns, "columns", nil, "Columns to display (comma-separated, default: id,name,timestamp,latency,cost,tags)\nAvailable: id,name,timestamp,user_id,session_id,release,version,environment,public,latency,cost,tags,observation_count,input_tokens,output_tokens,total_tokens,level")
+		StringSliceVar(&tracesColumns, "columns", nil, "Columns to display for table output only (comma-separated, default: id,name,timestamp,latency,cost,tags). Cannot be used with --json or --yaml.\nAvailable: id,name,timestamp,user_id,session_id,release,version,environment,public,latency,cost,tags,observation_count,input_tokens,output_tokens,total_tokens,level")
 
 	// Org/project flags
 	tracesListCmd.Flags().

--- a/docs/iai_comments_list.md
+++ b/docs/iai_comments_list.md
@@ -14,7 +14,7 @@ iai comments list [flags]
 
 ```
       --author-user-id string   Filter by author user ID
-      --columns strings         Columns to display (comma-separated)
+      --columns strings         Columns to display for table output only (comma-separated). Cannot be used with --json or --yaml
   -h, --help                    help for list
       --json                    Output raw API response as JSON
       --limit int               Items per page (max 100)

--- a/docs/iai_dataset-items_list.md
+++ b/docs/iai_dataset-items_list.md
@@ -13,7 +13,7 @@ iai dataset-items list [flags]
 ### Options
 
 ```
-      --columns strings                Columns to display (comma-separated)
+      --columns strings                Columns to display for table output only (comma-separated). Cannot be used with --json or --yaml
       --dataset-name string            Dataset name (required)
   -h, --help                           help for list
       --json                           Output raw API response as JSON

--- a/docs/iai_dataset-runs_list.md
+++ b/docs/iai_dataset-runs_list.md
@@ -13,7 +13,7 @@ iai dataset-runs list [flags]
 ### Options
 
 ```
-      --columns strings       Columns to display (comma-separated)
+      --columns strings       Columns to display for table output only (comma-separated). Cannot be used with --json or --yaml
       --dataset-name string   Dataset name (required)
   -h, --help                  help for list
       --json                  Output raw API response as JSON

--- a/docs/iai_datasets_list.md
+++ b/docs/iai_datasets_list.md
@@ -13,7 +13,7 @@ iai datasets list [flags]
 ### Options
 
 ```
-      --columns strings       Columns to display (comma-separated)
+      --columns strings       Columns to display for table output only (comma-separated). Cannot be used with --json or --yaml
   -h, --help                  help for list
       --json                  Output raw API response as JSON
       --limit int             Items per page (max 100)

--- a/docs/iai_metrics_list.md
+++ b/docs/iai_metrics_list.md
@@ -23,7 +23,7 @@ iai metrics list [flags]
 ### Options
 
 ```
-      --columns strings         Columns to display (comma-separated, default: date,count_traces,count_observations,total_cost)
+      --columns strings         Columns to display for table output only (comma-separated, default: date,count_traces,count_observations,total_cost). Cannot be used with --json or --yaml.
                                 Available: date,count_traces,count_observations,total_cost,total_tokens
       --daily                   Aggregate metrics by day (default true)
       --environment string      Filter by environment

--- a/docs/iai_observations_list.md
+++ b/docs/iai_observations_list.md
@@ -29,7 +29,7 @@ iai observations list [flags]
 ### Options
 
 ```
-      --columns strings                Columns to display (comma-separated)
+      --columns strings                Columns to display for table output only (comma-separated). Cannot be used with --json or --yaml
                                        With --trace-id default: id,type,name,model,latency_ms,total_cost,total_tokens
                                        Without --trace-id default: id,trace_id,type,name,model,latency_ms,total_cost,total_tokens
       --cursor string                  Cursor for pagination

--- a/docs/iai_queue-items_list.md
+++ b/docs/iai_queue-items_list.md
@@ -13,7 +13,7 @@ iai queue-items list [flags]
 ### Options
 
 ```
-      --columns strings       Columns to display (comma-separated)
+      --columns strings       Columns to display for table output only (comma-separated). Cannot be used with --json or --yaml
   -h, --help                  help for list
       --json                  Output raw API response as JSON
       --limit int             Items per page (max 100)

--- a/docs/iai_queues_list.md
+++ b/docs/iai_queues_list.md
@@ -13,7 +13,7 @@ iai queues list [flags]
 ### Options
 
 ```
-      --columns strings       Columns to display (comma-separated)
+      --columns strings       Columns to display for table output only (comma-separated). Cannot be used with --json or --yaml
   -h, --help                  help for list
       --json                  Output raw API response as JSON
       --limit int             Items per page (max 100)

--- a/docs/iai_run-items_list.md
+++ b/docs/iai_run-items_list.md
@@ -13,7 +13,7 @@ iai run-items list [flags]
 ### Options
 
 ```
-      --columns strings       Columns to display (comma-separated)
+      --columns strings       Columns to display for table output only (comma-separated). Cannot be used with --json or --yaml
       --dataset-name string   Filter by dataset name
   -h, --help                  help for list
       --json                  Output raw API response as JSON

--- a/docs/iai_score-configs_list.md
+++ b/docs/iai_score-configs_list.md
@@ -13,7 +13,7 @@ iai score-configs list [flags]
 ### Options
 
 ```
-      --columns strings       Columns to display (comma-separated)
+      --columns strings       Columns to display for table output only (comma-separated). Cannot be used with --json or --yaml
   -h, --help                  help for list
       --json                  Output raw API response as JSON
       --limit int             Items per page (max 100)

--- a/docs/iai_scores_list.md
+++ b/docs/iai_scores_list.md
@@ -16,7 +16,7 @@ iai scores list [flags]
 ### Options
 
 ```
-      --columns strings         Columns to display (comma-separated, default: id,name,data_type,value,source,timestamp,trace_id)
+      --columns strings         Columns to display for table output only (comma-separated, default: id,name,data_type,value,source,timestamp,trace_id). Cannot be used with --json or --yaml.
                                 Available: id,name,data_type,value,source,timestamp,trace_id,observation_id,session_id,environment,config_id,user_id,comment
       --config-id string        Filter by config ID
       --cursor string           Cursor for pagination

--- a/docs/iai_sessions_list.md
+++ b/docs/iai_sessions_list.md
@@ -16,7 +16,7 @@ iai sessions list [flags]
 ### Options
 
 ```
-      --columns strings         Columns to display (comma-separated, default: id,created_at,environment,trace_count,duration_seconds,total_cost,total_tokens)
+      --columns strings         Columns to display for table output only (comma-separated, default: id,created_at,environment,trace_count,duration_seconds,total_cost,total_tokens). Cannot be used with --json or --yaml.
                                 Available: id,created_at,updated_at,environment,user_id,trace_count,duration_seconds,total_cost,input_tokens,output_tokens,total_tokens
       --environment string      Filter by environment
       --from-timestamp string   Filter sessions from this timestamp (ISO 8601, default: 7 days ago)

--- a/docs/iai_traces_list.md
+++ b/docs/iai_traces_list.md
@@ -31,7 +31,7 @@ iai traces list [flags]
 ### Options
 
 ```
-      --columns strings           Columns to display (comma-separated, default: id,name,timestamp,latency,cost,tags)
+      --columns strings           Columns to display for table output only (comma-separated, default: id,name,timestamp,latency,cost,tags). Cannot be used with --json or --yaml.
                                   Available: id,name,timestamp,user_id,session_id,release,version,environment,public,latency,cost,tags,observation_count,input_tokens,output_tokens,total_tokens,level
       --environment stringArray   Filter by environment (repeatable)
       --fields string             Field groups to include: core, io, metrics (comma-separated) (default "core,metrics")


### PR DESCRIPTION
## Summary
- Clarify that --columns only applies to table output and cannot be combined with --json or --yaml
- Regenerate CLI docs for affected list commands

## Tests
- go test ./...