### PR TITLE
docs(cli): add missing command examples

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.34.3"
+current_version = "0.34.4"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -73,10 +73,8 @@ The config schema depends on the agent version. Run
 
 Routines and policies referenced in the config must already exist in the project
 and should be validated against the matching schema version (see --schema-version
-on their create/update commands).
-
-Examples:
-  iai agents create chat-agent --id interactive-agent --version 0.0.1 --file agent-config.yaml
+on their create/update commands).`,
+	Example: `  iai agents create chat-agent --id interactive-agent --version 0.0.1 --file agent-config.yaml
   iai agents create chat-agent --id interactive-agent --version 0.0.1 --file agent-config.yaml --endpoint
   iai agents create chat-agent --id interactive-agent --version 0.0.1 --file agent-config.yaml --secret api-keys --env LOG_LEVEL=info`,
 	Args: cobra.ExactArgs(1),
@@ -153,10 +151,8 @@ and --schedule-downtime auto-clears any existing uptime. Pass --schedule-timezon
 alongside either to change the timezone.
 
 Use --clear-env, --clear-secret, --clear-schedule, or --clear-stack-id to
-remove those configurations entirely.
-
-Examples:
-  iai agents update chat-agent --version 0.0.3
+remove those configurations entirely.`,
+	Example: `  iai agents update chat-agent --version 0.0.3
   iai agents update chat-agent --file agent-config.yaml
   iai agents update chat-agent --endpoint=false
   iai agents update chat-agent --schedule-uptime "Mon-Fri 07:30-20:30" --schedule-timezone Europe/Berlin
@@ -218,10 +214,8 @@ var agentListCmd = &cobra.Command{
 	Use:     "list",
 	Aliases: []string{"ls"},
 	Short:   "List agents in a project",
-	Long: `List agents in a specific project.
-
-Examples:
-  iai agents list
+	Long:    `List agents in a specific project.`,
+	Example: `  iai agents list
   iai agents list -p my-project
   iai agents list --json`,
 	Args: cobra.NoArgs,
@@ -257,10 +251,8 @@ var agentDescribeCmd = &cobra.Command{
 	Short:   "Describe an agent in detail",
 	Long: `Show detailed information about a specific agent including its configuration.
 
-Use --version to view a specific past version instead of the current state.
-
-Examples:
-  iai agents describe my-agent
+Use --version to view a specific past version instead of the current state.`,
+	Example: `  iai agents describe my-agent
   iai agents describe my-agent --version 3
   iai agents describe my-agent --yaml`,
 	Args: cobra.ExactArgs(1),
@@ -315,13 +307,11 @@ Examples:
 }
 
 var agentDeleteCmd = &cobra.Command{
-	Use:   "delete <agent_name>",
-	Short: "Delete an agent from a project",
-	Long: `Delete an agent from a specific project.
-
-Examples:
-  iai agents delete my-agent`,
-	Args: cobra.ExactArgs(1),
+	Use:     "delete <agent_name>",
+	Short:   "Delete an agent from a project",
+	Long:    `Delete an agent from a specific project.`,
+	Example: `  iai agents delete my-agent`,
+	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 		agentName := strings.TrimSpace(args[0])
@@ -353,13 +343,11 @@ Examples:
 }
 
 var agentRestartCmd = &cobra.Command{
-	Use:   "restart <agent_name>",
-	Short: "Restart an agent in a project",
-	Long: `Restart an agent in a specific project.
-
-Examples:
-  iai agents restart my-agent`,
-	Args: cobra.ExactArgs(1),
+	Use:     "restart <agent_name>",
+	Short:   "Restart an agent in a project",
+	Long:    `Restart an agent in a specific project.`,
+	Example: `  iai agents restart my-agent`,
+	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 		agentName := strings.TrimSpace(args[0])
@@ -412,10 +400,8 @@ Structured (JSON) logs are automatically formatted: the level and message
 fields are extracted and displayed as "LEVEL message". Use --fields or
 --all-fields to include additional top-level fields after the message. Use
 --raw for exact server JSON, or --decode to decode embedded JSON strings into
-nested JSON values.
-
-Examples:
-  iai agents logs my-agent
+nested JSON values.`,
+	Example: `  iai agents logs my-agent
   iai agents logs my-agent --follow
   iai agents logs my-agent --since 30m
   iai agents logs my-agent --start-time 2026-01-01T00:00:00Z --end-time 2026-01-01T01:00:00Z`,
@@ -482,10 +468,8 @@ var agentCatalogCmd = &cobra.Command{
 	Long: `List agent types available in the catalog.
 
 Without arguments, lists all available agent IDs.
-With an agent ID argument, lists available versions for that agent.
-
-Examples:
-  iai agents catalog
+With an agent ID argument, lists available versions for that agent.`,
+	Example: `  iai agents catalog
   iai agents catalog interactive-agent`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -532,10 +516,8 @@ var agentSchemaCmd = &cobra.Command{
 Defaults to the latest schema version. Use --schema-version to fetch a specific
 version (run 'iai agents compatibility-matrix' to see available versions).
 
-Use --json or --yaml for structured schema output.
-
-Examples:
-  iai agents schema
+Use --json or --yaml for structured schema output.`,
+	Example: `  iai agents schema
   iai agents schema --schema-version 2.1.0
   iai agents schema --json`,
 	Args: cobra.NoArgs,
@@ -586,10 +568,8 @@ Prompt types (routines, policies, etc.) also support versioned schemas — use
 --schema-version on their create/update commands to validate against the
 matching version.
 
-By default, output is a formatted table. Use --json for machine-readable output.
-
-Examples:
-  iai agents compatibility-matrix
+By default, output is a formatted table. Use --json for machine-readable output.`,
+	Example: `  iai agents compatibility-matrix
   iai agents compatibility-matrix --json`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -617,11 +597,9 @@ var agentRevisionsCmd = &cobra.Command{
 	Aliases: []string{"revs"},
 	Short:   "List revisions of an agent",
 	Long: `Show past revisions of an agent, sorted newest-first.
-Up to 50 revisions are retained per agent.
-
-Examples:
-  iai agents revisions my-agent`,
-	Args: cobra.ExactArgs(1),
+Up to 50 revisions are retained per agent.`,
+	Example: `  iai agents revisions my-agent`,
+	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 		agentName := strings.TrimSpace(args[0])
@@ -646,13 +624,11 @@ Examples:
 }
 
 var agentDiffCmd = &cobra.Command{
-	Use:   "diff <agent_name> <revision_a> <revision_b>",
-	Short: "Compare two revisions of an agent",
-	Long: `Show the differences between two revisions of an agent.
-
-Examples:
-  iai agents diff my-agent 1 3`,
-	Args: cobra.ExactArgs(3),
+	Use:     "diff <agent_name> <revision_a> <revision_b>",
+	Short:   "Compare two revisions of an agent",
+	Long:    `Show the differences between two revisions of an agent.`,
+	Example: `  iai agents diff my-agent 1 3`,
+	Args:    cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 		agentName := strings.TrimSpace(args[0])
@@ -710,10 +686,8 @@ to an agent running in the cluster.
 
 The remote port defaults to the agent's configured port. Use --port to
 override. Use --local-port to choose the local listening port (defaults to
---port when set, or an available OS-assigned port otherwise).
-
-Examples:
-  iai agents port-forward my-agent
+--port when set, or an available OS-assigned port otherwise).`,
+	Example: `  iai agents port-forward my-agent
   iai agents port-forward my-agent --port 8080
   iai agents port-forward my-agent --port 8080 --local-port 9090`,
 	Args: cobra.ExactArgs(1),
@@ -741,10 +715,8 @@ var agentLogFieldsCmd = &cobra.Command{
 	Short: "List available fields in structured logs",
 	Long: `Scan recent logs and list the extra top-level fields present in structured (JSON) log entries.
 
-Use the reported field names with 'iai agents logs --fields' to include them in output.
-
-Examples:
-  iai agents log-fields my-agent
+Use the reported field names with 'iai agents logs --fields' to include them in output.`,
+	Example: `  iai agents log-fields my-agent
   iai agents log-fields my-agent --since 1h`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/comments.go
+++ b/cmd/comments.go
@@ -50,7 +50,11 @@ var commentsListCmd = &cobra.Command{
 	Aliases: []string{"ls"},
 	Short:   "List comments",
 	Long:    `List comments with optional filters.`,
-	Args:    cobra.NoArgs,
+	Example: `  iai comments list
+  iai comments list --object-type TRACE --object-id trace-abc123
+  iai comments list --author-user-id user-42 --limit 50 --page 2
+  iai comments list --json`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -114,7 +118,10 @@ var commentsGetCmd = &cobra.Command{
 	Aliases: []string{"describe", "desc"},
 	Short:   "Get a comment",
 	Long:    `Get full details of a comment.`,
-	Args:    cobra.ExactArgs(1),
+	Example: `  iai comments get comment-abc123
+  iai comments get comment-abc123 --json
+  iai comments get comment-abc123 --yaml`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -153,6 +160,9 @@ var commentsCreateCmd = &cobra.Command{
 	Long: `Create a new comment on a trace, observation, session, or prompt.
 
 This command requires API key authentication.`,
+	Example: `  iai comments create --object-type TRACE --object-id trace-abc123 --content "Investigated this run"
+  iai comments create --object-type OBSERVATION --object-id obs-456 --content "Looks correct" --author-user-id user-42
+  iai comments create --object-type PROMPT --object-id prompt-789 --content "Needs review" --json`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()

--- a/cmd/connectors.go
+++ b/cmd/connectors.go
@@ -62,10 +62,8 @@ var connectorListCmd = &cobra.Command{
 	Use:     "list",
 	Aliases: []string{"ls"},
 	Short:   "List connectors in a project",
-	Long: `Show each connector's type, status, tool count, and endpoint in a table.
-
-Examples:
-  iai connectors list
+	Long:    `Show each connector's type, status, tool count, and endpoint in a table.`,
+	Example: `  iai connectors list
   iai connectors list --json`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -97,10 +95,8 @@ var connectorGetCmd = &cobra.Command{
 	Aliases: []string{"describe", "desc"},
 	Short:   "Show a connector and its tools",
 	Long: `Print a connector's full configuration and status alongside the cached list of
-tools discovered from the MCP server.
-
-Examples:
-  iai connectors get 3f9c1a2e-...
+tools discovered from the MCP server.`,
+	Example: `  iai connectors get 3f9c1a2e-...
   iai connectors get 3f9c1a2e-... --json`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -136,10 +132,8 @@ var connectorCatalogCmd = &cobra.Command{
 	Short: "Browse the connector catalog",
 	Long: `List the curated catalog of MCP servers you can connect to with
 'iai connectors create --catalog-id', showing each entry's id, category, and
-supported auth methods.
-
-Examples:
-  iai connectors catalog
+supported auth methods.`,
+	Example: `  iai connectors catalog
   iai connectors catalog --json`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -175,10 +169,8 @@ nothing is stored.
 
 Pass --catalog-id to connect a catalog entry (the endpoint and transport come from
 the catalog; see 'iai connectors catalog'). Otherwise the connector is custom and
---endpoint-url is required.
-
-Examples:
-  iai connectors create github \
+--endpoint-url is required.`,
+	Example: `  iai connectors create github \
     --catalog-id github --auth-type bearer --credential "$GITHUB_TOKEN"
   iai connectors create my-server \
     --endpoint-url https://mcp.example.com/mcp --auth-type none
@@ -287,10 +279,8 @@ var connectorDeleteCmd = &cobra.Command{
 	Aliases: []string{"rm"},
 	Short:   "Delete a connector",
 	Long: `Remove a connector and its cached tools from the project. The remote MCP server
-is not affected. Use -f to skip the confirmation prompt.
-
-Examples:
-  iai connectors delete 3f9c1a2e-...
+is not affected. Use -f to skip the confirmation prompt.`,
+	Example: `  iai connectors delete 3f9c1a2e-...
   iai connectors delete 3f9c1a2e-... -f`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -336,10 +326,8 @@ var connectorVerifyCmd = &cobra.Command{
 	Use:   "verify <connector_id>",
 	Short: "Re-verify a connector and refresh its tools",
 	Long: `Re-dial the MCP server for a connector (initialize + list tools) and refresh the
-cached tool list. Reports the status and, on failure, the error class and message.
-
-Examples:
-  iai connectors verify 3f9c1a2e-...
+cached tool list. Reports the status and, on failure, the error class and message.`,
+	Example: `  iai connectors verify 3f9c1a2e-...
   iai connectors verify 3f9c1a2e-... --json`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -381,10 +369,8 @@ var connectorRunToolCmd = &cobra.Command{
 	Long: `Call one of a connector's enabled tools and print the result it returns.
 
 Pass arguments as a JSON object with --args or --args-file (mutually exclusive);
-omit both to send an empty object.
-
-Examples:
-  iai connectors run-tool 3f9c1a2e-... search --args '{"query":"langfuse"}'
+omit both to send an empty object.`,
+	Example: `  iai connectors run-tool 3f9c1a2e-... search --args '{"query":"langfuse"}'
   iai connectors run-tool 3f9c1a2e-... search --args-file ./args.json`,
 	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/databases.go
+++ b/cmd/databases.go
@@ -69,7 +69,10 @@ var dbListCmd = &cobra.Command{
 	Aliases: []string{"ls"},
 	Short:   "List databases in a project",
 	Long:    `List databases in a project.`,
-	Args:    cobra.NoArgs,
+	Example: `  iai databases list
+  iai databases list -p my-project
+  iai databases list --json`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -99,10 +102,8 @@ var dbDescribeCmd = &cobra.Command{
 	Aliases: []string{"desc"},
 	Short:   "Describe a database in detail",
 	Long: `Show detailed information about a database including configuration, runtime
-status, and connection credentials.
-
-Examples:
-  iai databases describe my-db
+status, and connection credentials.`,
+	Example: `  iai databases describe my-db
   iai databases describe my-db --json`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -144,10 +145,8 @@ The "vector" extension is installed by default. To add other extensions, use
 --extensions. Values above 1 for --instances enable high availability.
 
 Changing the PostgreSQL major version after creation causes cluster downtime
-during the upgrade.
-
-Examples:
-  iai databases create my-db --instances 2 --cpu 1 --memory 2G --storage-size 20G
+during the upgrade.`,
+	Example: `  iai databases create my-db --instances 2 --cpu 1 --memory 2G --storage-size 20G
   iai databases create my-db --instances 1 --cpu 0.5 --memory 1G --storage-size 20G --extensions vector --extensions pg_trgm
   iai databases create my-db --instances 2 --cpu 1 --memory 2G --storage-size 50G --backup-schedule "0 0 2 * * *" --backup-retention 30d`,
 	Args: cobra.ExactArgs(1),
@@ -207,10 +206,8 @@ Storage can only be increased. Use --clear-backup to disable backups entirely.
 Changing the PostgreSQL major version triggers an automatic upgrade with cluster
 downtime.
 
-Use --clear-stack-id to remove the database from its stack.
-
-Examples:
-  iai databases update my-db --instances 3
+Use --clear-stack-id to remove the database from its stack.`,
+	Example: `  iai databases update my-db --instances 3
   iai databases update my-db --cpu 2 --memory 4G
   iai databases update my-db --storage-size 50G
   iai databases update my-db --backup-schedule "0 0 3 * * *" --backup-retention 60d
@@ -272,7 +269,9 @@ var dbDeleteCmd = &cobra.Command{
 	Aliases: []string{"rm"},
 	Short:   "Delete a database from a project",
 	Long:    `Delete a database and all associated resources from a project.`,
-	Args:    cobra.ExactArgs(1),
+	Example: `  iai databases delete my-db
+  iai databases delete my-db -p my-project`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 		databaseName := strings.TrimSpace(args[0])
@@ -316,6 +315,10 @@ severity and message are extracted from it automatically. Use --fields record
 to see the nested PostgreSQL details; --all-fields includes extra top-level
 fields only. Use --raw for exact server JSON, or --decode to decode embedded
 JSON strings into nested JSON values.`,
+	Example: `  iai databases logs my-db
+  iai databases logs my-db --follow
+  iai databases logs my-db --since 30m
+  iai databases logs my-db --start-time 2026-01-01T00:00:00Z --end-time 2026-01-01T01:00:00Z`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
@@ -393,10 +396,8 @@ var dbLogFieldsCmd = &cobra.Command{
 
 PostgreSQL-specific details are often nested under the 'record' field, so seeing
 'record' in the results is expected. Use the reported field names with
-'iai databases logs --fields' to include them in output.
-
-Examples:
-  iai databases log-fields my-db
+'iai databases logs --fields' to include them in output.`,
+	Example: `  iai databases log-fields my-db
   iai databases log-fields my-db --since 1h`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -442,7 +443,9 @@ var dbBackupsCmd = &cobra.Command{
 	Use:   "backups <database_name>",
 	Short: "List backups for a database",
 	Long:  `List backups for a database, sorted by most recent first.`,
-	Args:  cobra.ExactArgs(1),
+	Example: `  iai databases backups my-db
+  iai databases backups my-db -p my-project`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 		databaseName := strings.TrimSpace(args[0])
@@ -471,6 +474,8 @@ var dbBackupCmd = &cobra.Command{
 	Short: "Trigger an on-demand backup",
 	Long: `Trigger an on-demand backup for a database. The database must have backups
 enabled.`,
+	Example: `  iai databases backup my-db
+  iai databases backup my-db -p my-project`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
@@ -505,10 +510,8 @@ var dbRestoreCmd = &cobra.Command{
 source database must have backups enabled.
 
 Optionally specify --target-time for point-in-time recovery (RFC3339 format).
-If omitted, the latest backup is restored.
-
-Examples:
-  iai databases restore my-restored-db --source-database my-db --instances 2 --cpu 1 --memory 2G --storage-size 20G
+If omitted, the latest backup is restored.`,
+	Example: `  iai databases restore my-restored-db --source-database my-db --instances 2 --cpu 1 --memory 2G --storage-size 20G
   iai databases restore my-restored-db --source-database my-db --target-time 2026-05-12T10:00:00Z --instances 2 --cpu 1 --memory 2G --storage-size 20G`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -576,10 +579,8 @@ The remote port defaults to 5432. Use --port to override. Use --local-port
 to choose the local listening port (defaults to the remote port).
 
 After connecting you can use psql, pgAdmin, or any PostgreSQL client against
-localhost:<local-port>.
-
-Examples:
-  iai databases port-forward my-db
+localhost:<local-port>.`,
+	Example: `  iai databases port-forward my-db
   iai databases port-forward my-db --local-port 15432`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/dataset_items.go
+++ b/cmd/dataset_items.go
@@ -57,7 +57,11 @@ var datasetItemsListCmd = &cobra.Command{
 	Aliases: []string{"ls"},
 	Short:   "List dataset items",
 	Long:    `List items in a dataset with optional filters.`,
-	Args:    cobra.NoArgs,
+	Example: `  iai dataset-items list --dataset-name my-dataset
+  iai dataset-items list --dataset-name my-dataset --source-trace-id trace-123 --limit 50
+  iai dataset-items list --dataset-name my-dataset --columns id,status,input
+  iai dataset-items list --dataset-name my-dataset --json`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -125,7 +129,10 @@ var datasetItemsGetCmd = &cobra.Command{
 	Aliases: []string{"describe", "desc"},
 	Short:   "Get a dataset item",
 	Long:    `Get detailed information about a specific dataset item.`,
-	Args:    cobra.ExactArgs(1),
+	Example: `  iai dataset-items get item-123
+  iai dataset-items get item-123 --json
+  iai dataset-items get item-123 --yaml`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -166,7 +173,11 @@ var datasetItemsCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a dataset item",
 	Long:  `Create or upsert an item in a dataset.`,
-	Args:  cobra.NoArgs,
+	Example: `  iai dataset-items create --dataset-name my-dataset --input '{"question":"2+2?"}'
+  iai dataset-items create --dataset-name my-dataset --input '{"question":"2+2?"}' --expected-output '{"answer":"4"}'
+  iai dataset-items create --dataset-name my-dataset --id item-123 --input '{"q":"hi"}' --metadata-json '{"source":"manual"}' --status ACTIVE
+  iai dataset-items create --dataset-name my-dataset --input '{"q":"hi"}' --source-trace-id trace-123 --json`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -220,7 +231,9 @@ var datasetItemsDeleteCmd = &cobra.Command{
 	Aliases: []string{"rm"},
 	Short:   "Delete a dataset item",
 	Long:    `Delete a dataset item by ID.`,
-	Args:    cobra.ExactArgs(1),
+	Example: `  iai dataset-items delete item-123
+  iai dataset-items delete item-123 --organization my-org --project my-project`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 

--- a/cmd/dataset_runs.go
+++ b/cmd/dataset_runs.go
@@ -44,7 +44,11 @@ var datasetRunsListCmd = &cobra.Command{
 	Aliases: []string{"ls"},
 	Short:   "List dataset runs",
 	Long:    `List runs for a given dataset.`,
-	Args:    cobra.NoArgs,
+	Example: `  iai dataset-runs list --dataset-name my-dataset
+  iai dataset-runs list --dataset-name my-dataset -o my-org -p my-project
+  iai dataset-runs list --dataset-name my-dataset --page 2 --limit 50 --columns name,status
+  iai dataset-runs list --dataset-name my-dataset --json`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -112,7 +116,11 @@ var datasetRunsGetCmd = &cobra.Command{
 	Aliases: []string{"describe", "desc"},
 	Short:   "Get a dataset run",
 	Long:    `Get detailed information about a specific dataset run.`,
-	Args:    cobra.ExactArgs(1),
+	Example: `  iai dataset-runs get my-run --dataset-name my-dataset
+  iai dataset-runs get my-run --dataset-name my-dataset -o my-org -p my-project
+  iai dataset-runs get my-run --dataset-name my-dataset --json
+  iai dataset-runs get my-run --dataset-name my-dataset --yaml`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -156,7 +164,9 @@ var datasetRunsDeleteCmd = &cobra.Command{
 	Aliases: []string{"rm"},
 	Short:   "Delete a dataset run",
 	Long:    `Delete a dataset run by name.`,
-	Args:    cobra.ExactArgs(1),
+	Example: `  iai dataset-runs delete my-run --dataset-name my-dataset
+  iai dataset-runs delete my-run --dataset-name my-dataset -o my-org -p my-project`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 

--- a/cmd/datasets.go
+++ b/cmd/datasets.go
@@ -45,7 +45,11 @@ var datasetsListCmd = &cobra.Command{
 	Aliases: []string{"ls"},
 	Short:   "List datasets",
 	Long:    `List evaluation datasets with pagination.`,
-	Args:    cobra.NoArgs,
+	Example: `  iai datasets list
+  iai datasets list -p my-project --limit 50 --page 2
+  iai datasets list --columns name,description
+  iai datasets list --json`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -106,7 +110,10 @@ var datasetsGetCmd = &cobra.Command{
 	Aliases: []string{"describe", "desc"},
 	Short:   "Get a dataset by name",
 	Long:    `Get detailed information about a specific dataset.`,
-	Args:    cobra.ExactArgs(1),
+	Example: `  iai datasets get my-dataset
+  iai datasets get my-dataset -o my-org -p my-project
+  iai datasets get my-dataset --yaml`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -143,7 +150,11 @@ var datasetsCreateCmd = &cobra.Command{
 	Use:   "create <name>",
 	Short: "Create a dataset",
 	Long:  `Create a new evaluation dataset.`,
-	Args:  cobra.ExactArgs(1),
+	Example: `  iai datasets create my-dataset
+  iai datasets create my-dataset --description "Golden eval set"
+  iai datasets create my-dataset --metadata-json '{"source":"prod"}' -p my-project
+  iai datasets create my-dataset --json`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 

--- a/cmd/gen_docs.go
+++ b/cmd/gen_docs.go
@@ -165,15 +165,21 @@ func injectSchemaDoc(outDir, filename, schemaDoc string) error {
 		return fmt.Errorf("schema section marker not found in %s", filename)
 	}
 
-	// Find "### Options" which follows the schema section
-	optionsMarker := "\n### Options"
-	optionsIdx := strings.Index(text, optionsMarker)
-	if optionsIdx == -1 {
-		return fmt.Errorf("options section marker not found in %s", filename)
+	// Find the end of the schema section. Prefer to stop before the Examples
+	// section (rendered from the command's Example field) so the CLI usage
+	// examples are preserved; fall back to Options when a command has none.
+	endMarker := "\n### Examples"
+	endIdx := strings.Index(text, endMarker)
+	if endIdx == -1 {
+		endMarker = "\n### Options"
+		endIdx = strings.Index(text, endMarker)
+	}
+	if endIdx == -1 {
+		return fmt.Errorf("schema section end marker not found in %s", filename)
 	}
 
 	// Replace the plain-text section with the markdown template
-	text = text[:schemaStart] + "\n\n" + schemaDoc + optionsMarker + text[optionsIdx+len(optionsMarker):]
+	text = text[:schemaStart] + "\n\n" + schemaDoc + endMarker + text[endIdx+len(endMarker):]
 
 	return os.WriteFile(docPath, []byte(text), 0o644)
 }

--- a/cmd/glossaries.go
+++ b/cmd/glossaries.go
@@ -42,10 +42,8 @@ Example (glossary.json):
 
 The server automatically assigns the "latest" label to new versions. To make a
 version retrievable via the default 'get' (which resolves "production"), assign
-the "production" label with --labels production.
-
-Examples:
-  iai glossaries create finance-terms --file glossary.json
+the "production" label with --labels production.`,
+		CreateExample: `  iai glossaries create finance-terms --file glossary.json
   iai glossaries create finance-terms --file glossary.json --schema-version 2.1.0
   iai glossaries create finance-terms --file glossary.json --labels production
   iai glossaries create finance-terms --file glossary.json --tags domain`,
@@ -53,20 +51,16 @@ Examples:
 
 Returns all glossary entries with their name, labels, tags, and last update time.
 Folders are shown with a trailing "/" (colored when stdout is a terminal) and
-can be browsed into with --folder.
-
-Examples:
-  iai glossaries list
+can be browsed into with --folder.`,
+		ListExample: `  iai glossaries list
   iai glossaries list --folder my-folder
   iai glossaries list --folder my-folder/sub-folder
   iai glossaries list --page 2 --limit 10`,
 		GetLong: `Show detailed information about a specific glossary definition, including its full content.
 
 By default returns the version labeled "production". Use --version to retrieve a
-specific version number, or --label to resolve a different label.
-
-Examples:
-  iai glossaries get finance-terms
+specific version number, or --label to resolve a different label.`,
+		GetExample: `  iai glossaries get finance-terms
   iai glossaries get finance-terms --version 3
   iai glossaries get finance-terms --label staging`,
 		UpdateLong: `Update a glossary definition by creating a new version with updated content.
@@ -97,20 +91,16 @@ Example (glossary.json):
     }
   }
 
-  Add as many entries under 'terms' as you need — each key must be unique.
-
-Examples:
-  iai glossaries update finance-terms --file glossary.json
+  Add as many entries under 'terms' as you need — each key must be unique.`,
+		UpdateExample: `  iai glossaries update finance-terms --file glossary.json
   iai glossaries update finance-terms --file glossary.json --schema-version 2.1.0
   iai glossaries update finance-terms --file glossary.json --labels production,staging`,
 		DeleteLong: `Delete a glossary definition and all its versions, or delete specific versions.
 
 Without flags, deletes the glossary entry and all its versions (requires
 confirmation). Use --version to delete a specific version, or --label to delete
-versions with a specific label. Use -f to skip the confirmation prompt.
-
-Examples:
-  iai glossaries delete finance-terms
+versions with a specific label. Use -f to skip the confirmation prompt.`,
+		DeleteExample: `  iai glossaries delete finance-terms
   iai glossaries delete finance-terms -f
   iai glossaries delete finance-terms --version 3
   iai glossaries delete finance-terms --label staging`,

--- a/cmd/images.go
+++ b/cmd/images.go
@@ -43,7 +43,11 @@ var imageListCmd = &cobra.Command{
 	Aliases: []string{"ls"},
 	Short:   "List images for a project",
 	Long:    `List container images in the deployment registry for a specific project.`,
-	Args:    cobra.NoArgs,
+	Example: `  iai images list
+  iai images list --organization my-org --project my-project
+  iai images list --json
+  iai images list --yaml`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -76,6 +80,9 @@ var imageBuildCmd = &cobra.Command{
 
 This is a thin wrapper around 'docker build' that requires an explicit tag,
 Dockerfile, and build context.`,
+	Example: `  iai images build my-service --tag 1.2.3
+  iai images build my-service --tag 1.2.3 --file docker/Dockerfile --context .
+  iai images build my-service --tag 1.2.3 --platform linux/amd64`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
@@ -128,7 +135,9 @@ var imagePushCmd = &cobra.Command{
 	Aliases: []string{"p"},
 	Short:   "Push an image for a project",
 	Long:    `Create a Docker image tarball and push it to the deployment images endpoint for a specific project.`,
-	Args:    cobra.ExactArgs(1),
+	Example: `  iai images push my-service --tag 1.2.3
+  iai images push my-service --tag 1.2.3 --organization my-org --project my-project`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 		in := cmd.InOrStdin()

--- a/cmd/macros.go
+++ b/cmd/macros.go
@@ -21,30 +21,24 @@ Example (disclaimer.md):
 
 The server automatically assigns the "latest" label to new versions. To make a
 version retrievable via the default 'get' (which resolves "production"), assign
-the "production" label with --labels production.
-
-Examples:
-  iai macros create disclaimer --file disclaimer.md
+the "production" label with --labels production.`,
+		CreateExample: `  iai macros create disclaimer --file disclaimer.md
   iai macros create disclaimer --file disclaimer.md --labels production
   iai macros create disclaimer --file disclaimer.md --tags legal`,
 		ListLong: `List macros in a specific project.
 
 Returns all macros with their name, labels, tags, and last update time.
 Folders are shown with a trailing "/" (colored when stdout is a terminal) and
-can be browsed into with --folder.
-
-Examples:
-  iai macros list
+can be browsed into with --folder.`,
+		ListExample: `  iai macros list
   iai macros list --folder my-folder
   iai macros list --folder my-folder/sub-folder
   iai macros list --page 2 --limit 10`,
 		GetLong: `Show detailed information about a specific macro, including its full content.
 
 By default returns the version labeled "production". Use --version to retrieve a
-specific version number, or --label to resolve a different label.
-
-Examples:
-  iai macros get disclaimer
+specific version number, or --label to resolve a different label.`,
+		GetExample: `  iai macros get disclaimer
   iai macros get disclaimer --version 3
   iai macros get disclaimer --label staging`,
 		UpdateLong: `Update a macro by creating a new version with updated content.
@@ -55,19 +49,15 @@ The previous versions are preserved and can still be accessed by version number.
 No schema validation is applied — any text content is accepted.
 
 Example (disclaimer.md):
-  **Disclaimer:** This is not financial advice. Consult a professional.
-
-Examples:
-  iai macros update disclaimer --file disclaimer.md
+  **Disclaimer:** This is not financial advice. Consult a professional.`,
+		UpdateExample: `  iai macros update disclaimer --file disclaimer.md
   iai macros update disclaimer --file disclaimer.md --labels production,staging`,
 		DeleteLong: `Delete a macro and all its versions, or delete specific versions.
 
 Without flags, deletes the macro and all its versions (requires confirmation).
 Use --version to delete a specific version, or --label to delete versions with a
-specific label. Use -f to skip the confirmation prompt.
-
-Examples:
-  iai macros delete disclaimer
+specific label. Use -f to skip the confirmation prompt.`,
+		DeleteExample: `  iai macros delete disclaimer
   iai macros delete disclaimer -f
   iai macros delete disclaimer --version 3
   iai macros delete disclaimer --label staging`,

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -45,10 +45,8 @@ var metricsListCmd = &cobra.Command{
 
 Uses the platform API with dual authentication (API key or session).
 If --from-timestamp is not provided, defaults to 7 days ago.
-Use --daily to get metrics aggregated by day (default).
-
-Examples:
-  iai metrics list --daily
+Use --daily to get metrics aggregated by day (default).`,
+	Example: `  iai metrics list --daily
   iai metrics list --daily --from-timestamp 2025-01-01T00:00:00Z
   iai metrics list --daily --trace-name my-trace --show-models
   iai metrics list --daily --json | jq '.data'`,

--- a/cmd/observations.go
+++ b/cmd/observations.go
@@ -56,10 +56,8 @@ var obsListCmd = &cobra.Command{
 When --trace-id is provided, lists observations within that trace.
 Without --trace-id, searches observations across all traces with optional filters.
 
-Uses the platform API with dual authentication (API key or session).
-
-Examples:
-  # List observations for a specific trace
+Uses the platform API with dual authentication (API key or session).`,
+	Example: `  # List observations for a specific trace
   iai observations list --trace-id abc123
   iai observations list --trace-id abc123 --include-io
   iai observations list --trace-id abc123 --columns id,type,name,model,latency_ms
@@ -188,10 +186,8 @@ var obsGetCmd = &cobra.Command{
 	Short: "Get a specific observation",
 	Long: `Get detailed information about a specific observation.
 
-Uses the platform API with dual authentication (API key or session).
-
-Examples:
-  iai observations get obs-abc123
+Uses the platform API with dual authentication (API key or session).`,
+	Example: `  iai observations get obs-abc123
   iai observations get obs-abc123 --json | jq '.data.observation'`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/organizations.go
+++ b/cmd/organizations.go
@@ -27,6 +27,9 @@ var organizationsListCmd = &cobra.Command{
 	Aliases: []string{"ls"},
 	Short:   "List organizations",
 	Long:    `List all organizations you are a member of.`,
+	Example: `  iai organizations list
+  iai organizations list --json
+  iai organizations list --yaml`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -73,6 +76,7 @@ var organizationsSelectCmd = &cobra.Command{
 	Aliases: []string{"set"},
 	Short:   "Select an organization for subsequent commands",
 	Long:    `Select an organization by name and store it in the local CLI configuration so other commands can use it without specifying the organization each time.`,
+	Example: `  iai organizations select my-organization`,
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()

--- a/cmd/policies.go
+++ b/cmd/policies.go
@@ -32,10 +32,8 @@ Example (policy.yaml):
 
 The server automatically assigns the "latest" label to new versions. To make a
 version retrievable via the default 'get' (which resolves "production"), assign
-the "production" label with --labels production.
-
-Examples:
-  iai policies create safety-rules --file policy.yaml
+the "production" label with --labels production.`,
+		CreateExample: `  iai policies create safety-rules --file policy.yaml
   iai policies create safety-rules --file policy.yaml --schema-version 2.1.0
   iai policies create safety-rules --file policy.yaml --labels production
   iai policies create safety-rules --file policy.yaml --tags compliance`,
@@ -43,20 +41,16 @@ Examples:
 
 Returns all policies with their name, labels, tags, and last update time.
 Folders are shown with a trailing "/" (colored when stdout is a terminal) and
-can be browsed into with --folder.
-
-Examples:
-  iai policies list
+can be browsed into with --folder.`,
+		ListExample: `  iai policies list
   iai policies list --folder my-folder
   iai policies list --folder my-folder/sub-folder
   iai policies list --page 2 --limit 10`,
 		GetLong: `Show detailed information about a specific policy, including its full content.
 
 By default returns the version labeled "production". Use --version to retrieve a
-specific version number, or --label to resolve a different label.
-
-Examples:
-  iai policies get safety-rules
+specific version number, or --label to resolve a different label.`,
+		GetExample: `  iai policies get safety-rules
   iai policies get safety-rules --version 3
   iai policies get safety-rules --label staging`,
 		UpdateLong: `Update a policy by creating a new version with updated content.
@@ -77,20 +71,16 @@ Example (policy.yaml):
   name: Escalation Policy
   condition: User requests human agent
   action: Transfer to human
-  criticality: HIGH
-
-Examples:
-  iai policies update safety-rules --file policy.yaml
+  criticality: HIGH`,
+		UpdateExample: `  iai policies update safety-rules --file policy.yaml
   iai policies update safety-rules --file policy.yaml --schema-version 2.1.0
   iai policies update safety-rules --file policy.yaml --labels production,staging`,
 		DeleteLong: `Delete a policy and all its versions, or delete specific versions.
 
 Without flags, deletes the policy and all its versions (requires confirmation).
 Use --version to delete a specific version, or --label to delete versions with a
-specific label. Use -f to skip the confirmation prompt.
-
-Examples:
-  iai policies delete safety-rules
+specific label. Use -f to skip the confirmation prompt.`,
+		DeleteExample: `  iai policies delete safety-rules
   iai policies delete safety-rules -f
   iai policies delete safety-rules --version 3
   iai policies delete safety-rules --label staging`,

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -29,7 +29,10 @@ var projectsListCmd = &cobra.Command{
 	Aliases: []string{"ls"},
 	Short:   "List projects in an organization",
 	Long:    `List all projects within a specific organization. The organization name will be resolved to its Id before making API calls.`,
-	Args:    cobra.NoArgs,
+	Example: `  iai projects list
+  iai projects list --organization my-org
+  iai projects list --json`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -87,7 +90,9 @@ var projectsSelectCmd = &cobra.Command{
 	Aliases: []string{"set"},
 	Short:   "Select a project for subsequent commands",
 	Long:    `Select a project by name and store it in the local CLI configuration so other commands can use it without specifying the project each time.`,
-	Args:    cobra.ExactArgs(1),
+	Example: `  iai projects select my-project
+  iai projects select my-project --organization my-org`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 		projectName := args[0]

--- a/cmd/prompt_types.go
+++ b/cmd/prompt_types.go
@@ -34,6 +34,11 @@ type PromptTypeConfig struct {
 	GetLong               string // long description for the describe subcommand
 	UpdateLong            string // long description for the update subcommand
 	DeleteLong            string // long description for the delete subcommand
+	CreateExample         string // usage examples for the create subcommand
+	ListExample           string // usage examples for the list subcommand
+	GetExample            string // usage examples for the describe subcommand
+	UpdateExample         string // usage examples for the update subcommand
+	DeleteExample         string // usage examples for the delete subcommand
 }
 
 func registerPromptType(ptCfg PromptTypeConfig) {
@@ -85,6 +90,9 @@ Use --schema-version to request a specific schema version (defaults to latest st
 Use --json or --yaml to output the schema response in a structured format.
 
 This is a public endpoint and does not require authentication.`, ptCfg.Plural),
+		Example: fmt.Sprintf(`  iai %s schema
+  iai %s schema --schema-version 0.0.1
+  iai %s schema --json`, ptCfg.Plural, ptCfg.Plural, ptCfg.Plural),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out := cmd.OutOrStdout()
@@ -127,10 +135,11 @@ func makeCreateCmd(ptCfg PromptTypeConfig) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "create <name>",
-		Short: fmt.Sprintf("Create a %s", ptCfg.TypeName),
-		Long:  ptCfg.CreateLong,
-		Args:  cobra.ExactArgs(1),
+		Use:     "create <name>",
+		Short:   fmt.Sprintf("Create a %s", ptCfg.TypeName),
+		Long:    ptCfg.CreateLong,
+		Example: ptCfg.CreateExample,
+		Args:    cobra.ExactArgs(1),
 	}
 
 	var configBuilder ConfigFlagBuilder
@@ -209,6 +218,7 @@ func makeListCmd(ptCfg PromptTypeConfig) *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   fmt.Sprintf("List %s in a project", ptCfg.Plural),
 		Long:    ptCfg.ListLong,
+		Example: ptCfg.ListExample,
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out := cmd.OutOrStdout()
@@ -280,6 +290,7 @@ func makeGetCmd(ptCfg PromptTypeConfig) *cobra.Command {
 		Aliases: []string{"describe", "desc"},
 		Short:   fmt.Sprintf("Describe a %s in detail", ptCfg.TypeName),
 		Long:    ptCfg.GetLong,
+		Example: ptCfg.GetExample,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out := cmd.OutOrStdout()
@@ -336,10 +347,11 @@ func makeUpdateCmd(ptCfg PromptTypeConfig) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "update <name>",
-		Short: fmt.Sprintf("Update a %s (creates a new version)", ptCfg.TypeName),
-		Long:  ptCfg.UpdateLong,
-		Args:  cobra.ExactArgs(1),
+		Use:     "update <name>",
+		Short:   fmt.Sprintf("Update a %s (creates a new version)", ptCfg.TypeName),
+		Long:    ptCfg.UpdateLong,
+		Example: ptCfg.UpdateExample,
+		Args:    cobra.ExactArgs(1),
 	}
 
 	var configBuilder ConfigFlagBuilder
@@ -419,6 +431,7 @@ func makeDeleteCmd(ptCfg PromptTypeConfig) *cobra.Command {
 		Aliases: []string{"rm"},
 		Short:   fmt.Sprintf("Delete a %s", ptCfg.TypeName),
 		Long:    ptCfg.DeleteLong,
+		Example: ptCfg.DeleteExample,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out := cmd.OutOrStdout()
@@ -497,11 +510,9 @@ func makeVersionsCmd(ptCfg PromptTypeConfig) *cobra.Command {
 		Use:     "versions <name>",
 		Aliases: []string{"vers"},
 		Short:   fmt.Sprintf("List versions of a %s", ptCfg.TypeName),
-		Long: fmt.Sprintf(`List all versions of a %s, sorted newest-first.
-
-Examples:
-  iai %s versions my-%s`, ptCfg.TypeName, ptCfg.Plural, ptCfg.TypeName),
-		Args: cobra.ExactArgs(1),
+		Long:    fmt.Sprintf(`List all versions of a %s, sorted newest-first.`, ptCfg.TypeName),
+		Example: fmt.Sprintf(`  iai %s versions my-%s`, ptCfg.Plural, ptCfg.TypeName),
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out := cmd.OutOrStdout()
 			name := strings.TrimSpace(args[0])
@@ -535,13 +546,11 @@ func makeDiffCmd(ptCfg PromptTypeConfig) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "diff <name> <version_a> <version_b>",
-		Short: fmt.Sprintf("Compare two versions of a %s", ptCfg.TypeName),
-		Long: fmt.Sprintf(`Show the differences between two versions of a %s.
-
-Examples:
-  iai %s diff my-%s 1 3`, ptCfg.TypeName, ptCfg.Plural, ptCfg.TypeName),
-		Args: cobra.ExactArgs(3),
+		Use:     "diff <name> <version_a> <version_b>",
+		Short:   fmt.Sprintf("Compare two versions of a %s", ptCfg.TypeName),
+		Long:    fmt.Sprintf(`Show the differences between two versions of a %s.`, ptCfg.TypeName),
+		Example: fmt.Sprintf(`  iai %s diff my-%s 1 3`, ptCfg.Plural, ptCfg.TypeName),
+		Args:    cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out := cmd.OutOrStdout()
 			name := strings.TrimSpace(args[0])

--- a/cmd/prompts.go
+++ b/cmd/prompts.go
@@ -64,10 +64,8 @@ The --type flag selects the prompt type: "text" (default) or "chat".
 
 The server automatically assigns the "latest" label to new versions. To make a
 version retrievable via the default 'get' (which resolves "production"), assign
-the "production" label with --labels production.
-
-Examples:
-  iai prompts create greeting --content "Hello, how can I help you?"
+the "production" label with --labels production.`,
+		Example: `  iai prompts create greeting --content "Hello, how can I help you?"
   iai prompts create greeting --file greeting.txt
   iai prompts create greeting --file greeting.txt --type chat
   iai prompts create greeting --content "Hi!" --labels production
@@ -154,10 +152,8 @@ func makeGenericListCmd() *cobra.Command {
 
 Returns all general-purpose prompts with their name, labels, tags, and last
 update time. Typed prompts (routines, policies, etc.) are excluded.
-Folders are shown with a trailing "/" and can be browsed into with --folder.
-
-Examples:
-  iai prompts list
+Folders are shown with a trailing "/" and can be browsed into with --folder.`,
+		Example: `  iai prompts list
   iai prompts list --folder my-folder
   iai prompts list --folder my-folder/sub-folder
   iai prompts list --page 2 --limit 10`,
@@ -237,10 +233,8 @@ func makeGenericGetCmd() *cobra.Command {
 		Long: `Show detailed information about a specific prompt, including its full content.
 
 By default returns the version labeled "production". Use --version to retrieve a
-specific version number, or --label to resolve a different label.
-
-Examples:
-  iai prompts get greeting
+specific version number, or --label to resolve a different label.`,
+		Example: `  iai prompts get greeting
   iai prompts get greeting --version 3
   iai prompts get greeting --label staging`,
 		Args: cobra.ExactArgs(1),
@@ -311,10 +305,8 @@ This creates a new version of the prompt using the content from the provided
 file or inline string. Previous versions are preserved and can still be accessed
 by version number.
 
-Exactly one of --file or --content must be specified.
-
-Examples:
-  iai prompts update greeting --content "Hello! How may I assist you today?"
+Exactly one of --file or --content must be specified.`,
+		Example: `  iai prompts update greeting --content "Hello! How may I assist you today?"
   iai prompts update greeting --file greeting.txt
   iai prompts update greeting --file greeting.txt --labels production,staging`,
 		Args: cobra.ExactArgs(1),
@@ -392,10 +384,8 @@ func makeGenericDeleteCmd() *cobra.Command {
 
 Without flags, deletes the prompt and all its versions (requires confirmation).
 Use --version to delete a specific version, or --label to delete versions with a
-specific label. Use -f to skip the confirmation prompt.
-
-Examples:
-  iai prompts delete greeting
+specific label. Use -f to skip the confirmation prompt.`,
+		Example: `  iai prompts delete greeting
   iai prompts delete greeting -f
   iai prompts delete greeting --version 3
   iai prompts delete greeting --label staging`,
@@ -511,11 +501,9 @@ func makeGenericVersionsCmd() *cobra.Command {
 		Use:     "versions <name>",
 		Aliases: []string{"vers"},
 		Short:   "List versions of a prompt",
-		Long: `List all versions of a prompt, sorted newest-first.
-
-Examples:
-  iai prompts versions greeting`,
-		Args: cobra.ExactArgs(1),
+		Long:    `List all versions of a prompt, sorted newest-first.`,
+		Example: `  iai prompts versions greeting`,
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out := cmd.OutOrStdout()
 			name := strings.TrimSpace(args[0])
@@ -561,13 +549,11 @@ func makeGenericDiffCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "diff <name> <version_a> <version_b>",
-		Short: "Compare two versions of a prompt",
-		Long: `Show the differences between two versions of a prompt.
-
-Examples:
-  iai prompts diff greeting 1 3`,
-		Args: cobra.ExactArgs(3),
+		Use:     "diff <name> <version_a> <version_b>",
+		Short:   "Compare two versions of a prompt",
+		Long:    `Show the differences between two versions of a prompt.`,
+		Example: `  iai prompts diff greeting 1 3`,
+		Args:    cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out := cmd.OutOrStdout()
 			name := strings.TrimSpace(args[0])

--- a/cmd/queue_items.go
+++ b/cmd/queue_items.go
@@ -61,7 +61,11 @@ var queueItemsListCmd = &cobra.Command{
 	Aliases: []string{"ls"},
 	Short:   "List queue items",
 	Long:    `List items in an annotation queue.`,
-	Args:    cobra.NoArgs,
+	Example: `  iai queue-items list --queue-id queue-123
+  iai queue-items list --queue-id queue-123 --status PENDING
+  iai queue-items list --queue-id queue-123 --page 2 --limit 50
+  iai queue-items list --queue-id queue-123 --json`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -130,7 +134,10 @@ var queueItemsGetCmd = &cobra.Command{
 	Aliases: []string{"describe", "desc"},
 	Short:   "Get a queue item",
 	Long:    `Get detailed information about a queue item.`,
-	Args:    cobra.ExactArgs(1),
+	Example: `  iai queue-items get item-456 --queue-id queue-123
+  iai queue-items get item-456 --queue-id queue-123 --json
+  iai queue-items get item-456 --queue-id queue-123 --yaml`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -175,6 +182,9 @@ var queueItemsCreateCmd = &cobra.Command{
 	Long: `Add an item to an annotation queue.
 
 This command requires API key authentication.`,
+	Example: `  iai queue-items create --queue-id queue-123 --object-id trace-789 --object-type TRACE
+  iai queue-items create --queue-id queue-123 --object-id obs-789 --object-type OBSERVATION --status PENDING
+  iai queue-items create --queue-id queue-123 --object-id trace-789 --object-type TRACE --json`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
@@ -225,6 +235,9 @@ var queueItemsUpdateCmd = &cobra.Command{
 	Long: `Update the status of a queue item.
 
 This command requires API key authentication.`,
+	Example: `  iai queue-items update item-456 --queue-id queue-123 --status COMPLETED
+  iai queue-items update item-456 --queue-id queue-123 --status PENDING --json
+  iai queue-items update item-456 --queue-id queue-123 --status COMPLETED --yaml`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
@@ -271,7 +284,9 @@ var queueItemsDeleteCmd = &cobra.Command{
 	Aliases: []string{"rm"},
 	Short:   "Delete a queue item",
 	Long:    `Delete an item from an annotation queue.`,
-	Args:    cobra.ExactArgs(1),
+	Example: `  iai queue-items delete item-456 --queue-id queue-123
+  iai queue-items delete item-456 --queue-id queue-123 -p my-project`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 

--- a/cmd/queues.go
+++ b/cmd/queues.go
@@ -53,7 +53,11 @@ var queuesListCmd = &cobra.Command{
 	Aliases: []string{"ls"},
 	Short:   "List annotation queues",
 	Long:    `List annotation queues with pagination.`,
-	Args:    cobra.NoArgs,
+	Example: `  iai queues list
+  iai queues list --page 2 --limit 50
+  iai queues list --columns id,name,description
+  iai queues list -o my-org -p my-project --json`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -110,7 +114,10 @@ var queuesGetCmd = &cobra.Command{
 	Aliases: []string{"describe", "desc"},
 	Short:   "Get an annotation queue",
 	Long:    `Get detailed information about an annotation queue.`,
-	Args:    cobra.ExactArgs(1),
+	Example: `  iai queues get queue-123
+  iai queues get queue-123 --json
+  iai queues get queue-123 -o my-org -p my-project --yaml`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -149,6 +156,10 @@ var queuesCreateCmd = &cobra.Command{
 	Long: `Create a new annotation queue.
 
 This command requires API key authentication.`,
+	Example: `  iai queues create my-queue
+  iai queues create my-queue --description "Review of chat outputs"
+  iai queues create my-queue --score-config-ids sc-1,sc-2
+  iai queues create my-queue --description "QA queue" --score-config-ids sc-1 --json`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
@@ -196,6 +207,8 @@ var queuesAssignCmd = &cobra.Command{
 	Long: `Assign a user to an annotation queue.
 
 This command requires API key authentication.`,
+	Example: `  iai queues assign queue-123 --user-id user-456
+  iai queues assign queue-123 --user-id user-456 -o my-org -p my-project`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
@@ -233,6 +246,8 @@ var queuesUnassignCmd = &cobra.Command{
 	Long: `Remove a user from an annotation queue.
 
 This command requires API key authentication.`,
+	Example: `  iai queues unassign queue-123 --user-id user-456
+  iai queues unassign queue-123 --user-id user-456 -o my-org -p my-project`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()

--- a/cmd/replicas.go
+++ b/cmd/replicas.go
@@ -36,7 +36,10 @@ var replicasListCmd = &cobra.Command{
 	Aliases: []string{"ls"},
 	Short:   "List replicas for a service",
 	Long:    `List pods backing a service in a specific project.`,
-	Args:    cobra.ExactArgs(1),
+	Example: `  iai replicas list my-service
+  iai replicas list my-service -p my-project -o my-org
+  iai replicas list my-service --json`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -81,7 +84,10 @@ var replicasDescribeCmd = &cobra.Command{
 	Aliases: []string{"desc"},
 	Short:   "Describe a replica in detail",
 	Long:    `Show detailed information about a specific replica including status, resources, healthcheck configuration, and events.`,
-	Args:    cobra.ExactArgs(1),
+	Example: `  iai replicas describe my-service-abc123
+  iai replicas describe my-service-abc123 -p my-project -o my-org
+  iai replicas describe my-service-abc123 --yaml`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -144,6 +150,10 @@ fields are extracted and displayed as "LEVEL message". Use --fields or
 --all-fields to include additional top-level fields after the message. Use
 --raw for exact server JSON, or --decode to decode embedded JSON strings into
 nested JSON values.`,
+	Example: `  iai replicas logs my-service-abc123
+  iai replicas logs my-service-abc123 --follow
+  iai replicas logs my-service-abc123 --since 30m --fields logger,pid
+  iai replicas logs my-service-abc123 --start-time 2026-01-01T00:00:00Z --end-time 2026-01-01T01:00:00Z`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
@@ -247,10 +257,8 @@ var replicaLogFieldsCmd = &cobra.Command{
 	Short: "List available fields in structured logs",
 	Long: `Scan recent logs and list the extra top-level fields present in structured (JSON) log entries.
 
-Use the reported field names with 'iai replicas logs --fields' to include them in output.
-
-Examples:
-  iai replicas log-fields my-service-abc123
+Use the reported field names with 'iai replicas logs --fields' to include them in output.`,
+	Example: `  iai replicas log-fields my-service-abc123
   iai replicas log-fields my-service-abc123 --since 1h`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version            = "0.34.3"
+	version            = "0.34.4"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second

--- a/cmd/routines.go
+++ b/cmd/routines.go
@@ -37,10 +37,8 @@ Example (routine.yaml):
 
 The server automatically assigns the "latest" label to new versions. To make a
 version retrievable via the default 'get' (which resolves "production"), assign
-the "production" label with --labels production.
-
-Examples:
-  iai routines create onboarding-flow --file routine.yaml
+the "production" label with --labels production.`,
+		CreateExample: `  iai routines create onboarding-flow --file routine.yaml
   iai routines create onboarding-flow --file routine.yaml --schema-version 2.1.0
   iai routines create onboarding-flow --file routine.yaml --labels production
   iai routines create onboarding-flow --file routine.yaml --tags v2,experimental`,
@@ -48,20 +46,16 @@ Examples:
 
 Returns all routines with their name, labels, tags, and last update time.
 Folders are shown with a trailing "/" (colored when stdout is a terminal) and
-can be browsed into with --folder.
-
-Examples:
-  iai routines list
+can be browsed into with --folder.`,
+		ListExample: `  iai routines list
   iai routines list --folder my-folder
   iai routines list --folder my-folder/sub-folder
   iai routines list --page 2 --limit 10`,
 		GetLong: `Show detailed information about a specific routine, including its full content.
 
 By default returns the version labeled "production". Use --version to retrieve a
-specific version number, or --label to resolve a different label.
-
-Examples:
-  iai routines get onboarding-flow
+specific version number, or --label to resolve a different label.`,
+		GetExample: `  iai routines get onboarding-flow
   iai routines get onboarding-flow --version 3
   iai routines get onboarding-flow --label staging`,
 		UpdateLong: `Update a routine by creating a new version with updated content.
@@ -87,20 +81,16 @@ Example (routine.yaml):
     - id: lookup
       source: greet
       tools: crm:get_user
-      tool_instruction: Fetch user data
-
-Examples:
-  iai routines update onboarding-flow --file routine.yaml
+      tool_instruction: Fetch user data`,
+		UpdateExample: `  iai routines update onboarding-flow --file routine.yaml
   iai routines update onboarding-flow --file routine.yaml --schema-version 2.1.0
   iai routines update onboarding-flow --file routine.yaml --labels production,staging`,
 		DeleteLong: `Delete a routine and all its versions, or delete specific versions.
 
 Without flags, deletes the routine and all its versions (requires confirmation).
 Use --version to delete a specific version, or --label to delete versions with a
-specific label. Use -f to skip the confirmation prompt.
-
-Examples:
-  iai routines delete onboarding-flow
+specific label. Use -f to skip the confirmation prompt.`,
+		DeleteExample: `  iai routines delete onboarding-flow
   iai routines delete onboarding-flow -f
   iai routines delete onboarding-flow --version 3
   iai routines delete onboarding-flow --label staging`,

--- a/cmd/run_items.go
+++ b/cmd/run_items.go
@@ -44,7 +44,11 @@ var runItemsListCmd = &cobra.Command{
 	Aliases: []string{"ls"},
 	Short:   "List run items",
 	Long:    `List dataset run items. Requires at least one of --run-name or --dataset-name.`,
-	Args:    cobra.NoArgs,
+	Example: `  iai run-items list --run-name nightly-eval
+  iai run-items list --dataset-name qa-set --page 2 --limit 50
+  iai run-items list --run-name nightly-eval --columns id,trace_id,created_at
+  iai run-items list --run-name nightly-eval --json`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -108,6 +112,10 @@ var runItemsCreateCmd = &cobra.Command{
 	Long: `Create a new dataset run item linking a trace/observation to a dataset item.
 
 This command requires API key authentication.`,
+	Example: `  iai run-items create --run-name nightly-eval --dataset-item-id item-123
+  iai run-items create --run-name nightly-eval --dataset-item-id item-123 --trace-id trace-abc --observation-id obs-xyz
+  iai run-items create --run-name nightly-eval --dataset-item-id item-123 --run-description "Nightly regression run" --metadata-json '{"model":"v2"}'
+  iai run-items create --run-name nightly-eval --dataset-item-id item-123 --json`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()

--- a/cmd/score_configs.go
+++ b/cmd/score_configs.go
@@ -60,7 +60,11 @@ var scoreConfigsListCmd = &cobra.Command{
 	Aliases: []string{"ls"},
 	Short:   "List score configs",
 	Long:    `List scoring configurations with pagination.`,
-	Args:    cobra.NoArgs,
+	Example: `  iai score-configs list
+  iai score-configs list -o my-org -p my-project
+  iai score-configs list --page 2 --limit 50
+  iai score-configs list --json`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -125,7 +129,10 @@ var scoreConfigsGetCmd = &cobra.Command{
 	Aliases: []string{"describe", "desc"},
 	Short:   "Get a score config",
 	Long:    `Get detailed information about a score configuration.`,
-	Args:    cobra.ExactArgs(1),
+	Example: `  iai score-configs get sc_123
+  iai score-configs get sc_123 -o my-org -p my-project
+  iai score-configs get sc_123 --yaml`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -168,6 +175,10 @@ var scoreConfigsCreateCmd = &cobra.Command{
 	Long: `Create a new scoring configuration.
 
 This command requires API key authentication.`,
+	Example: `  iai score-configs create --name accuracy --data-type NUMERIC --min-value 0 --max-value 1
+  iai score-configs create --name sentiment --data-type CATEGORICAL --categories '["positive","neutral","negative"]'
+  iai score-configs create --name passed --data-type BOOLEAN --description "Did the response pass review"
+  iai score-configs create --name accuracy --data-type NUMERIC --min-value 0 --max-value 1 --json`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
@@ -227,6 +238,10 @@ var scoreConfigsUpdateCmd = &cobra.Command{
 	Long: `Update an existing scoring configuration.
 
 This command requires API key authentication.`,
+	Example: `  iai score-configs update sc_123 --description "Updated scoring rubric"
+  iai score-configs update sc_123 --min-value 0 --max-value 10
+  iai score-configs update sc_123 --categories '["pass","fail"]'
+  iai score-configs update sc_123 --is-archived --yaml`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()

--- a/cmd/scores.go
+++ b/cmd/scores.go
@@ -75,6 +75,10 @@ var scoresListCmd = &cobra.Command{
 
 Uses the platform API with dual authentication (API key or session).
 If --from-timestamp is not provided, defaults to 7 days ago.`,
+	Example: `  iai scores list
+  iai scores list --name accuracy --data-type NUMERIC
+  iai scores list --from-timestamp 2026-01-01T00:00:00Z --to-timestamp 2026-02-01T00:00:00Z --limit 50
+  iai scores list --trace-id trace-abc123 --json`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
@@ -162,6 +166,9 @@ var scoresCreateCmd = &cobra.Command{
 	Long: `Create a score on exactly one target resource.
 
 This command currently requires API key authentication.`,
+	Example: `  iai scores create --name accuracy --value 0.95 --trace-id trace-abc123
+  iai scores create --name relevance --value 1 --data-type NUMERIC --observation-id obs-xyz789 --comment "looks good"
+  iai scores create --name sentiment --value positive --data-type CATEGORICAL --session-id sess-456 --json`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
@@ -215,6 +222,8 @@ var scoresDeleteCmd = &cobra.Command{
 	Long: `Delete a score by ID.
 
 This command currently requires API key authentication.`,
+	Example: `  iai scores delete score-abc123
+  iai scores delete score-abc123 -o my-org -p my-project`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()

--- a/cmd/secrets.go
+++ b/cmd/secrets.go
@@ -39,7 +39,10 @@ var secretsListCmd = &cobra.Command{
 	Aliases: []string{"ls"},
 	Short:   "List secrets in a project",
 	Long:    `List secrets in a specific project.`,
-	Args:    cobra.NoArgs,
+	Example: `  iai secrets list
+  iai secrets list -p my-project -o my-org
+  iai secrets list --json`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -78,6 +81,10 @@ Secret data can be provided via:
   --from-env-file FILE     (KEY=VALUE pairs, one per line)
 
 When both are provided, --data values take precedence.`,
+	Example: `  iai secrets create my-secret -d API_KEY=abc123
+  iai secrets create my-secret -d API_KEY=abc123 -d DB_PASS=secret
+  iai secrets create my-secret --from-env-file .env
+  iai secrets create my-secret --from-env-file .env -d API_KEY=override -p my-project`,
 	Args: cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
@@ -149,10 +156,8 @@ Secret data can be provided via:
   --data KEY=VALUE         (can be repeated)
   --from-env-file FILE     (KEY=VALUE pairs, one per line)
 
-When both are provided, --data values take precedence.
-
-Examples:
-  # Update a single key (other keys preserved)
+When both are provided, --data values take precedence.`,
+	Example: `  # Update a single key (other keys preserved)
   iai secrets update my-secret -d API_KEY=new-value
 
   # Update multiple keys (other keys preserved)
@@ -286,7 +291,9 @@ var secretsDeleteCmd = &cobra.Command{
 	Aliases: []string{"rm"},
 	Short:   "Delete a secret in a project",
 	Long:    `Delete a secret in a specific project using the deployment service.`,
-	Args:    cobra.ExactArgs(1),
+	Example: `  iai secrets delete my-secret
+  iai secrets delete my-secret -p my-project -o my-org`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -329,7 +336,10 @@ var secretsGetCmd = &cobra.Command{
 	Use:   "get <secret_name>",
 	Short: "Get a secret in a project",
 	Long:  `Get a secret in a specific project using the deployment service.`,
-	Args:  cobra.ExactArgs(1),
+	Example: `  iai secrets get my-secret
+  iai secrets get my-secret -p my-project
+  iai secrets get my-secret --json`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -72,8 +72,11 @@ var servicesCmd = &cobra.Command{
 var servCCmd = &cobra.Command{
 	Use:   "create <service_name>",
 	Short: "Create a service in a project",
-	Long: `Create a service in a specific project using the deployment service.
-`,
+	Long:  `Create a service in a specific project using the deployment service.`,
+	Example: `  iai services create my-svc --image-type external --image-repository docker.io --image-name nginx --image-tag latest --port 80 --memory 512M --cpu 0.5
+  iai services create my-svc --image-name my-app --image-tag v1 --port 8080 --memory 1G --cpu 1 --replicas 3 --endpoint
+  iai services create my-svc --image-name my-app --image-tag v1 --memory 512M --cpu 0.5 --env LOG_LEVEL=debug --secret DB_PASSWORD --healthcheck-path /health
+  iai services create my-svc --image-name my-app --image-tag v1 --memory 512M --cpu 0.5 --schedule-uptime "Mon-Fri 08:00-18:00" --schedule-timezone Europe/Berlin`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
@@ -156,10 +159,8 @@ and --schedule-downtime auto-clears any existing uptime. Pass --schedule-timezon
 alongside either to change the timezone.
 
 Use --clear-env, --clear-secret, --clear-healthcheck, --clear-schedule, or
---clear-stack-id to remove those configurations entirely.
-
-Examples:
-  iai services update my-svc --image-tag v2
+--clear-stack-id to remove those configurations entirely.`,
+	Example: `  iai services update my-svc --image-tag v2
   iai services update my-svc --memory 1G --cpu 0.5
   iai services update my-svc --replicas 3
   iai services update my-svc --autoscaling-max-replicas 8
@@ -254,7 +255,10 @@ var servListCmd = &cobra.Command{
 	Aliases: []string{"ls"},
 	Short:   "List services in a project",
 	Long:    `List services in a specific project using the deployment service.`,
-	Args:    cobra.NoArgs,
+	Example: `  iai services list
+  iai services list --project my-project
+  iai services list --json`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -291,10 +295,8 @@ var servDescribeCmd = &cobra.Command{
 	Short:   "Describe a service in detail",
 	Long: `Show detailed information about a specific service including its configuration.
 
-Use --version to view a specific past version instead of the current state.
-
-Examples:
-  iai services describe my-service
+Use --version to view a specific past version instead of the current state.`,
+	Example: `  iai services describe my-service
   iai services describe my-service --version 3
   iai services describe my-service --json`,
 	Args: cobra.ExactArgs(1),
@@ -356,7 +358,9 @@ var servDCmd = &cobra.Command{
 	Use:   "delete <service_name>",
 	Short: "Delete a service from a project",
 	Long:  `Delete a service from a specific project using the deployment service.`,
-	Args:  cobra.ExactArgs(1),
+	Example: `  iai services delete my-svc
+  iai services delete my-svc --project my-project`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 		serviceName := strings.TrimSpace(args[0])
@@ -395,7 +399,9 @@ var servRestartCmd = &cobra.Command{
 	Use:   "restart <service_name>",
 	Short: "Restart a service in a project",
 	Long:  `Restart a service in a specific project using the deployment service.`,
-	Args:  cobra.ExactArgs(1),
+	Example: `  iai services restart my-svc
+  iai services restart my-svc --project my-project`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 
@@ -454,6 +460,10 @@ fields are extracted and displayed as "LEVEL message". Use --fields or
 --all-fields to include additional top-level fields after the message. Use
 --raw for exact server JSON, or --decode to decode embedded JSON strings into
 nested JSON values.`,
+	Example: `  iai services logs my-svc
+  iai services logs my-svc --follow
+  iai services logs my-svc --since 3h
+  iai services logs my-svc --fields logger,pid`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
@@ -528,10 +538,8 @@ var servLogFieldsCmd = &cobra.Command{
 	Short: "List available fields in structured logs",
 	Long: `Scan recent logs and list the extra top-level fields present in structured (JSON) log entries.
 
-Use the reported field names with 'iai services logs --fields' to include them in output.
-
-Examples:
-  iai services log-fields my-service
+Use the reported field names with 'iai services logs --fields' to include them in output.`,
+	Example: `  iai services log-fields my-service
   iai services log-fields my-service --since 1h`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -585,11 +593,9 @@ var servRevisionsCmd = &cobra.Command{
 	Aliases: []string{"revs"},
 	Short:   "List revisions of a service",
 	Long: `Show past revisions of a service, sorted newest-first.
-Up to 50 revisions are retained per service.
-
-Examples:
-  iai services revisions my-service`,
-	Args: cobra.ExactArgs(1),
+Up to 50 revisions are retained per service.`,
+	Example: `  iai services revisions my-service`,
+	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 		serviceName := strings.TrimSpace(args[0])
@@ -618,13 +624,11 @@ Examples:
 }
 
 var servDiffCmd = &cobra.Command{
-	Use:   "diff <service_name> <revision_a> <revision_b>",
-	Short: "Compare two revisions of a service",
-	Long: `Show the differences between two revisions of a service.
-
-Examples:
-  iai services diff my-service 1 3`,
-	Args: cobra.ExactArgs(3),
+	Use:     "diff <service_name> <revision_a> <revision_b>",
+	Short:   "Compare two revisions of a service",
+	Long:    `Show the differences between two revisions of a service.`,
+	Example: `  iai services diff my-service 1 3`,
+	Args:    cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 		serviceName := strings.TrimSpace(args[0])
@@ -686,10 +690,8 @@ to a service running in the cluster.
 
 The remote port defaults to the service's configured port. Use --port to
 override. Use --local-port to choose the local listening port (defaults to
---port when set, or an available OS-assigned port otherwise).
-
-Examples:
-  iai services port-forward my-svc
+--port when set, or an available OS-assigned port otherwise).`,
+	Example: `  iai services port-forward my-svc
   iai services port-forward my-svc --port 8080
   iai services port-forward my-svc --port 8080 --local-port 9090`,
 	Args: cobra.ExactArgs(1),
@@ -721,6 +723,8 @@ The sync command will:
 - Delete services that exist in the project but not in the config (for the specified stack)
 
 The project is selected with --project or via 'iai projects select', and the config file with --cfg-file.`,
+	Example: `  iai services sync --cfg-file stack.yaml
+  iai services sync --cfg-file stack.yaml --project my-project`,
 	Args:       cobra.NoArgs,
 	Deprecated: "use 'iai stack sync' instead",
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/sessions.go
+++ b/cmd/sessions.go
@@ -45,6 +45,10 @@ var sessionsListCmd = &cobra.Command{
 
 Uses the platform API with dual authentication (API key or session).
 If --from-timestamp is not provided, defaults to 7 days ago.`,
+	Example: `  iai sessions list
+  iai sessions list --from-timestamp 2026-06-01T00:00:00Z --to-timestamp 2026-06-08T00:00:00Z
+  iai sessions list --environment production --limit 50 --page 2
+  iai sessions list --columns id,created_at,total_cost --json`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
@@ -116,6 +120,9 @@ var sessionsGetCmd = &cobra.Command{
 	Long: `Get detailed information about a specific session.
 
 Uses the platform API with dual authentication (API key or session).`,
+	Example: `  iai sessions get <session-id>
+  iai sessions get <session-id> --fields core,traces
+  iai sessions get <session-id> --json`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()

--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -38,10 +38,8 @@ Example (skill.md):
 
 The server automatically assigns the "latest" label to new versions. To make
 a version retrievable via the default 'get' (which resolves "production"),
-assign the "production" label with --labels production.
-
-Examples:
-  iai skills create summarize-trace --file ./skill.md \
+assign the "production" label with --labels production.`,
+		CreateExample: `  iai skills create summarize-trace --file ./skill.md \
     --description "Summarize a Langfuse trace" \
     --intents "summarize trace" --intents "explain trace"
   iai skills create summarize-trace --file ./skill.md --labels production`,
@@ -49,19 +47,15 @@ Examples:
 
 Returns all Copilot skills with their name, labels, tags, and last update time.
 Folders are shown with a trailing "/" (colored when stdout is a terminal) and
-can be browsed into with --folder.
-
-Examples:
-  iai skills list
+can be browsed into with --folder.`,
+		ListExample: `  iai skills list
   iai skills list --folder my-folder
   iai skills list --page 2 --limit 10`,
 		GetLong: `Show a Copilot skill in detail, including its config and full content.
 
 By default returns the version labeled "production". Use --version to retrieve a
-specific version number, or --label to resolve a different label.
-
-Examples:
-  iai skills get summarize-trace
+specific version number, or --label to resolve a different label.`,
+		GetExample: `  iai skills get summarize-trace
   iai skills get summarize-trace --version 3
   iai skills get summarize-trace --label staging`,
 		UpdateLong: `Update a Copilot skill by creating a new version with updated content.
@@ -73,10 +67,8 @@ omitted the new version's config.skill block will be empty, even if the
 prior version had values for them. Pass them again on every update if you
 want the new version to keep them.
 
-Pass --intents once per intent (the flag is repeatable).
-
-Examples:
-  iai skills update summarize-trace --file ./skill.md \
+Pass --intents once per intent (the flag is repeatable).`,
+		UpdateExample: `  iai skills update summarize-trace --file ./skill.md \
     --description "Summarize a Langfuse trace" \
     --intents "summarize trace" --intents "explain trace"
   iai skills update summarize-trace --file ./skill.md --labels production,staging`,
@@ -84,10 +76,8 @@ Examples:
 
 Without flags, deletes the skill and all its versions (requires confirmation).
 Use --version to delete a specific version, or --label to delete versions
-with a specific label. Use -f to skip the confirmation prompt.
-
-Examples:
-  iai skills delete summarize-trace
+with a specific label. Use -f to skip the confirmation prompt.`,
+		DeleteExample: `  iai skills delete summarize-trace
   iai skills delete summarize-trace -f
   iai skills delete summarize-trace --version 3
   iai skills delete summarize-trace --label staging`,

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -36,6 +36,9 @@ Agents are created, updated, or deleted to match the config file.
 Databases are created, updated, or deleted (--allow-delete=databases) to match the config file.
 
 The organization and project are read from the config file, flags, or resolved via 'iai organizations select' / 'iai projects select'.`,
+	Example: `  iai stacks sync --file stack.yaml
+  iai stacks sync --file stack.yaml --project my-project --organization my-org
+  iai stacks sync --file stack.yaml --allow-delete databases`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()

--- a/cmd/traces.go
+++ b/cmd/traces.go
@@ -69,10 +69,8 @@ var tracesListCmd = &cobra.Command{
 	Long: `List traces with optional filters.
 
 Uses the platform API with dual authentication (API key or session).
-If --from-timestamp is not provided, defaults to 7 days ago.
-
-Examples:
-  iai traces list
+If --from-timestamp is not provided, defaults to 7 days ago.`,
+	Example: `  iai traces list
   iai traces list --limit 20 --page 2
   iai traces list --name my-trace --user-id user123
   iai traces list --from-timestamp 2025-01-01T00:00:00Z
@@ -183,10 +181,8 @@ var tracesGetCmd = &cobra.Command{
 	Short: "Get a specific trace",
 	Long: `Get detailed information about a specific trace.
 
-Uses the platform API with dual authentication (API key or session).
-
-Examples:
-  iai traces get abc123
+Uses the platform API with dual authentication (API key or session).`,
+	Example: `  iai traces get abc123
   iai traces get abc123 --fields core,io,metrics
   iai traces get abc123 --json | jq '.data.trace'`,
 	Args: cobra.ExactArgs(1),
@@ -224,10 +220,8 @@ var tracesDeleteCmd = &cobra.Command{
 	Short:   "Delete one or more traces",
 	Long: `Delete a single trace or bulk delete multiple traces.
 
-This command currently requires API key authentication.
-
-Examples:
-  iai traces delete trace-123
+This command currently requires API key authentication.`,
+	Example: `  iai traces delete trace-123
   iai traces delete --ids trace-1,trace-2
   iai traces delete --ids trace-1 --ids trace-2 -f`,
 	Args: cobra.MaximumNArgs(1),

--- a/cmd/variables.go
+++ b/cmd/variables.go
@@ -40,10 +40,8 @@ Example (variables.json):
 
 The server automatically assigns the "latest" label to new versions. To make a
 version retrievable via the default 'get' (which resolves "production"), assign
-the "production" label with --labels production.
-
-Examples:
-  iai variables create session-vars --file variables.json
+the "production" label with --labels production.`,
+		CreateExample: `  iai variables create session-vars --file variables.json
   iai variables create session-vars --file variables.json --schema-version 2.1.0
   iai variables create session-vars --file variables.json --labels production
   iai variables create session-vars --file variables.json --tags core`,
@@ -51,20 +49,16 @@ Examples:
 
 Returns all variables with their name, labels, tags, and last update time.
 Folders are shown with a trailing "/" (colored when stdout is a terminal) and
-can be browsed into with --folder.
-
-Examples:
-  iai variables list
+can be browsed into with --folder.`,
+		ListExample: `  iai variables list
   iai variables list --folder my-folder
   iai variables list --folder my-folder/sub-folder
   iai variables list --page 2 --limit 10`,
 		GetLong: `Show detailed information about a specific variable definition, including its full content.
 
 By default returns the version labeled "production". Use --version to retrieve a
-specific version number, or --label to resolve a different label.
-
-Examples:
-  iai variables get session-vars
+specific version number, or --label to resolve a different label.`,
+		GetExample: `  iai variables get session-vars
   iai variables get session-vars --version 3
   iai variables get session-vars --label staging`,
 		UpdateLong: `Update a variable definition by creating a new version with updated content.
@@ -93,20 +87,16 @@ Example (variables.json):
     }
   }
 
-  Add as many entries under 'variables' as you need — each key must be unique.
-
-Examples:
-  iai variables update session-vars --file variables.json
+  Add as many entries under 'variables' as you need — each key must be unique.`,
+		UpdateExample: `  iai variables update session-vars --file variables.json
   iai variables update session-vars --file variables.json --schema-version 2.1.0
   iai variables update session-vars --file variables.json --labels production,staging`,
 		DeleteLong: `Delete a variable definition and all its versions, or delete specific versions.
 
 Without flags, deletes the variable and all its versions (requires confirmation).
 Use --version to delete a specific version, or --label to delete versions with a
-specific label. Use -f to skip the confirmation prompt.
-
-Examples:
-  iai variables delete session-vars
+specific label. Use -f to skip the confirmation prompt.`,
+		DeleteExample: `  iai variables delete session-vars
   iai variables delete session-vars -f
   iai variables delete session-vars --version 3
   iai variables delete session-vars --label staging`,

--- a/docs/iai_agents_catalog.md
+++ b/docs/iai_agents_catalog.md
@@ -9,12 +9,15 @@ List agent types available in the catalog.
 Without arguments, lists all available agent IDs.
 With an agent ID argument, lists available versions for that agent.
 
-Examples:
-  iai agents catalog
-  iai agents catalog interactive-agent
-
 ```
 iai agents catalog [agent_id] [flags]
+```
+
+### Examples
+
+```
+  iai agents catalog
+  iai agents catalog interactive-agent
 ```
 
 ### Options

--- a/docs/iai_agents_compatibility-matrix.md
+++ b/docs/iai_agents_compatibility-matrix.md
@@ -16,12 +16,15 @@ matching version.
 
 By default, output is a formatted table. Use --json for machine-readable output.
 
-Examples:
-  iai agents compatibility-matrix
-  iai agents compatibility-matrix --json
-
 ```
 iai agents compatibility-matrix [flags]
+```
+
+### Examples
+
+```
+  iai agents compatibility-matrix
+  iai agents compatibility-matrix --json
 ```
 
 ### Options

--- a/docs/iai_agents_create.md
+++ b/docs/iai_agents_create.md
@@ -18,13 +18,16 @@ Routines and policies referenced in the config must already exist in the project
 and should be validated against the matching schema version (see --schema-version
 on their create/update commands).
 
-Examples:
+```
+iai agents create <agent_name> [flags]
+```
+
+### Examples
+
+```
   iai agents create chat-agent --id interactive-agent --version 0.0.1 --file agent-config.yaml
   iai agents create chat-agent --id interactive-agent --version 0.0.1 --file agent-config.yaml --endpoint
   iai agents create chat-agent --id interactive-agent --version 0.0.1 --file agent-config.yaml --secret api-keys --env LOG_LEVEL=info
-
-```
-iai agents create <agent_name> [flags]
 ```
 
 ### Options

--- a/docs/iai_agents_delete.md
+++ b/docs/iai_agents_delete.md
@@ -6,11 +6,14 @@ Delete an agent from a project
 
 Delete an agent from a specific project.
 
-Examples:
-  iai agents delete my-agent
-
 ```
 iai agents delete <agent_name> [flags]
+```
+
+### Examples
+
+```
+  iai agents delete my-agent
 ```
 
 ### Options

--- a/docs/iai_agents_describe.md
+++ b/docs/iai_agents_describe.md
@@ -8,13 +8,16 @@ Show detailed information about a specific agent including its configuration.
 
 Use --version to view a specific past version instead of the current state.
 
-Examples:
+```
+iai agents describe <agent_name> [flags]
+```
+
+### Examples
+
+```
   iai agents describe my-agent
   iai agents describe my-agent --version 3
   iai agents describe my-agent --yaml
-
-```
-iai agents describe <agent_name> [flags]
 ```
 
 ### Options

--- a/docs/iai_agents_diff.md
+++ b/docs/iai_agents_diff.md
@@ -6,11 +6,14 @@ Compare two revisions of an agent
 
 Show the differences between two revisions of an agent.
 
-Examples:
-  iai agents diff my-agent 1 3
-
 ```
 iai agents diff <agent_name> <revision_a> <revision_b> [flags]
+```
+
+### Examples
+
+```
+  iai agents diff my-agent 1 3
 ```
 
 ### Options

--- a/docs/iai_agents_list.md
+++ b/docs/iai_agents_list.md
@@ -6,13 +6,16 @@ List agents in a project
 
 List agents in a specific project.
 
-Examples:
+```
+iai agents list [flags]
+```
+
+### Examples
+
+```
   iai agents list
   iai agents list -p my-project
   iai agents list --json
-
-```
-iai agents list [flags]
 ```
 
 ### Options

--- a/docs/iai_agents_log-fields.md
+++ b/docs/iai_agents_log-fields.md
@@ -8,12 +8,15 @@ Scan recent logs and list the extra top-level fields present in structured (JSON
 
 Use the reported field names with 'iai agents logs --fields' to include them in output.
 
-Examples:
-  iai agents log-fields my-agent
-  iai agents log-fields my-agent --since 1h
-
 ```
 iai agents log-fields <agent_name> [flags]
+```
+
+### Examples
+
+```
+  iai agents log-fields my-agent
+  iai agents log-fields my-agent --since 1h
 ```
 
 ### Options

--- a/docs/iai_agents_logs.md
+++ b/docs/iai_agents_logs.md
@@ -14,14 +14,17 @@ fields are extracted and displayed as "LEVEL message". Use --fields or
 --raw for exact server JSON, or --decode to decode embedded JSON strings into
 nested JSON values.
 
-Examples:
+```
+iai agents logs <agent_name> [flags]
+```
+
+### Examples
+
+```
   iai agents logs my-agent
   iai agents logs my-agent --follow
   iai agents logs my-agent --since 30m
   iai agents logs my-agent --start-time 2026-01-01T00:00:00Z --end-time 2026-01-01T01:00:00Z
-
-```
-iai agents logs <agent_name> [flags]
 ```
 
 ### Options

--- a/docs/iai_agents_port-forward.md
+++ b/docs/iai_agents_port-forward.md
@@ -11,13 +11,16 @@ The remote port defaults to the agent's configured port. Use --port to
 override. Use --local-port to choose the local listening port (defaults to
 --port when set, or an available OS-assigned port otherwise).
 
-Examples:
+```
+iai agents port-forward <agent_name> [flags]
+```
+
+### Examples
+
+```
   iai agents port-forward my-agent
   iai agents port-forward my-agent --port 8080
   iai agents port-forward my-agent --port 8080 --local-port 9090
-
-```
-iai agents port-forward <agent_name> [flags]
 ```
 
 ### Options

--- a/docs/iai_agents_restart.md
+++ b/docs/iai_agents_restart.md
@@ -6,11 +6,14 @@ Restart an agent in a project
 
 Restart an agent in a specific project.
 
-Examples:
-  iai agents restart my-agent
-
 ```
 iai agents restart <agent_name> [flags]
+```
+
+### Examples
+
+```
+  iai agents restart my-agent
 ```
 
 ### Options

--- a/docs/iai_agents_revisions.md
+++ b/docs/iai_agents_revisions.md
@@ -7,11 +7,14 @@ List revisions of an agent
 Show past revisions of an agent, sorted newest-first.
 Up to 50 revisions are retained per agent.
 
-Examples:
-  iai agents revisions my-agent
-
 ```
 iai agents revisions <agent_name> [flags]
+```
+
+### Examples
+
+```
+  iai agents revisions my-agent
 ```
 
 ### Options

--- a/docs/iai_agents_schema.md
+++ b/docs/iai_agents_schema.md
@@ -11,13 +11,16 @@ version (run 'iai agents compatibility-matrix' to see available versions).
 
 Use --json or --yaml for structured schema output.
 
-Examples:
+```
+iai agents schema [flags]
+```
+
+### Examples
+
+```
   iai agents schema
   iai agents schema --schema-version 2.1.0
   iai agents schema --json
-
-```
-iai agents schema [flags]
 ```
 
 ### Options

--- a/docs/iai_agents_update.md
+++ b/docs/iai_agents_update.md
@@ -29,7 +29,13 @@ alongside either to change the timezone.
 Use --clear-env, --clear-secret, --clear-schedule, or --clear-stack-id to
 remove those configurations entirely.
 
-Examples:
+```
+iai agents update <agent_name> [flags]
+```
+
+### Examples
+
+```
   iai agents update chat-agent --version 0.0.3
   iai agents update chat-agent --file agent-config.yaml
   iai agents update chat-agent --endpoint=false
@@ -37,9 +43,6 @@ Examples:
   iai agents update chat-agent --clear-schedule
   iai agents update chat-agent --stack-id my-stack
   iai agents update chat-agent --clear-stack-id
-
-```
-iai agents update <agent_name> [flags]
 ```
 
 ### Options

--- a/docs/iai_comments_create.md
+++ b/docs/iai_comments_create.md
@@ -12,6 +12,14 @@ This command requires API key authentication.
 iai comments create [flags]
 ```
 
+### Examples
+
+```
+  iai comments create --object-type TRACE --object-id trace-abc123 --content "Investigated this run"
+  iai comments create --object-type OBSERVATION --object-id obs-456 --content "Looks correct" --author-user-id user-42
+  iai comments create --object-type PROMPT --object-id prompt-789 --content "Needs review" --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_comments_get.md
+++ b/docs/iai_comments_get.md
@@ -10,6 +10,14 @@ Get full details of a comment.
 iai comments get <id> [flags]
 ```
 
+### Examples
+
+```
+  iai comments get comment-abc123
+  iai comments get comment-abc123 --json
+  iai comments get comment-abc123 --yaml
+```
+
 ### Options
 
 ```

--- a/docs/iai_comments_list.md
+++ b/docs/iai_comments_list.md
@@ -10,6 +10,15 @@ List comments with optional filters.
 iai comments list [flags]
 ```
 
+### Examples
+
+```
+  iai comments list
+  iai comments list --object-type TRACE --object-id trace-abc123
+  iai comments list --author-user-id user-42 --limit 50 --page 2
+  iai comments list --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_connectors_catalog.md
+++ b/docs/iai_connectors_catalog.md
@@ -8,12 +8,15 @@ List the curated catalog of MCP servers you can connect to with
 'iai connectors create --catalog-id', showing each entry's id, category, and
 supported auth methods.
 
-Examples:
-  iai connectors catalog
-  iai connectors catalog --json
-
 ```
 iai connectors catalog [flags]
+```
+
+### Examples
+
+```
+  iai connectors catalog
+  iai connectors catalog --json
 ```
 
 ### Options

--- a/docs/iai_connectors_create.md
+++ b/docs/iai_connectors_create.md
@@ -12,7 +12,13 @@ Pass --catalog-id to connect a catalog entry (the endpoint and transport come fr
 the catalog; see 'iai connectors catalog'). Otherwise the connector is custom and
 --endpoint-url is required.
 
-Examples:
+```
+iai connectors create <connector_name> [flags]
+```
+
+### Examples
+
+```
   iai connectors create github \
     --catalog-id github --auth-type bearer --credential "$GITHUB_TOKEN"
   iai connectors create my-server \
@@ -23,9 +29,6 @@ Examples:
   iai connectors create internal \
     --endpoint-url https://mcp.internal/sse --transport sse \
     --auth-type api_key --credential "$KEY" --header "X-Team=platform"
-
-```
-iai connectors create <connector_name> [flags]
 ```
 
 ### Options

--- a/docs/iai_connectors_delete.md
+++ b/docs/iai_connectors_delete.md
@@ -7,12 +7,15 @@ Delete a connector
 Remove a connector and its cached tools from the project. The remote MCP server
 is not affected. Use -f to skip the confirmation prompt.
 
-Examples:
-  iai connectors delete 3f9c1a2e-...
-  iai connectors delete 3f9c1a2e-... -f
-
 ```
 iai connectors delete <connector_id> [flags]
+```
+
+### Examples
+
+```
+  iai connectors delete 3f9c1a2e-...
+  iai connectors delete 3f9c1a2e-... -f
 ```
 
 ### Options

--- a/docs/iai_connectors_get.md
+++ b/docs/iai_connectors_get.md
@@ -7,12 +7,15 @@ Show a connector and its tools
 Print a connector's full configuration and status alongside the cached list of
 tools discovered from the MCP server.
 
-Examples:
-  iai connectors get 3f9c1a2e-...
-  iai connectors get 3f9c1a2e-... --json
-
 ```
 iai connectors get <connector_id> [flags]
+```
+
+### Examples
+
+```
+  iai connectors get 3f9c1a2e-...
+  iai connectors get 3f9c1a2e-... --json
 ```
 
 ### Options

--- a/docs/iai_connectors_list.md
+++ b/docs/iai_connectors_list.md
@@ -6,12 +6,15 @@ List connectors in a project
 
 Show each connector's type, status, tool count, and endpoint in a table.
 
-Examples:
-  iai connectors list
-  iai connectors list --json
-
 ```
 iai connectors list [flags]
+```
+
+### Examples
+
+```
+  iai connectors list
+  iai connectors list --json
 ```
 
 ### Options

--- a/docs/iai_connectors_run-tool.md
+++ b/docs/iai_connectors_run-tool.md
@@ -9,12 +9,15 @@ Call one of a connector's enabled tools and print the result it returns.
 Pass arguments as a JSON object with --args or --args-file (mutually exclusive);
 omit both to send an empty object.
 
-Examples:
-  iai connectors run-tool 3f9c1a2e-... search --args '{"query":"langfuse"}'
-  iai connectors run-tool 3f9c1a2e-... search --args-file ./args.json
-
 ```
 iai connectors run-tool <connector_id> <tool_name> [flags]
+```
+
+### Examples
+
+```
+  iai connectors run-tool 3f9c1a2e-... search --args '{"query":"langfuse"}'
+  iai connectors run-tool 3f9c1a2e-... search --args-file ./args.json
 ```
 
 ### Options

--- a/docs/iai_connectors_verify.md
+++ b/docs/iai_connectors_verify.md
@@ -7,12 +7,15 @@ Re-verify a connector and refresh its tools
 Re-dial the MCP server for a connector (initialize + list tools) and refresh the
 cached tool list. Reports the status and, on failure, the error class and message.
 
-Examples:
-  iai connectors verify 3f9c1a2e-...
-  iai connectors verify 3f9c1a2e-... --json
-
 ```
 iai connectors verify <connector_id> [flags]
+```
+
+### Examples
+
+```
+  iai connectors verify 3f9c1a2e-...
+  iai connectors verify 3f9c1a2e-... --json
 ```
 
 ### Options

--- a/docs/iai_databases_backup.md
+++ b/docs/iai_databases_backup.md
@@ -11,6 +11,13 @@ enabled.
 iai databases backup <database_name> [flags]
 ```
 
+### Examples
+
+```
+  iai databases backup my-db
+  iai databases backup my-db -p my-project
+```
+
 ### Options
 
 ```

--- a/docs/iai_databases_backups.md
+++ b/docs/iai_databases_backups.md
@@ -10,6 +10,13 @@ List backups for a database, sorted by most recent first.
 iai databases backups <database_name> [flags]
 ```
 
+### Examples
+
+```
+  iai databases backups my-db
+  iai databases backups my-db -p my-project
+```
+
 ### Options
 
 ```

--- a/docs/iai_databases_create.md
+++ b/docs/iai_databases_create.md
@@ -12,13 +12,16 @@ The "vector" extension is installed by default. To add other extensions, use
 Changing the PostgreSQL major version after creation causes cluster downtime
 during the upgrade.
 
-Examples:
+```
+iai databases create <database_name> [flags]
+```
+
+### Examples
+
+```
   iai databases create my-db --instances 2 --cpu 1 --memory 2G --storage-size 20G
   iai databases create my-db --instances 1 --cpu 0.5 --memory 1G --storage-size 20G --extensions vector --extensions pg_trgm
   iai databases create my-db --instances 2 --cpu 1 --memory 2G --storage-size 50G --backup-schedule "0 0 2 * * *" --backup-retention 30d
-
-```
-iai databases create <database_name> [flags]
 ```
 
 ### Options

--- a/docs/iai_databases_delete.md
+++ b/docs/iai_databases_delete.md
@@ -10,6 +10,13 @@ Delete a database and all associated resources from a project.
 iai databases delete <database_name> [flags]
 ```
 
+### Examples
+
+```
+  iai databases delete my-db
+  iai databases delete my-db -p my-project
+```
+
 ### Options
 
 ```

--- a/docs/iai_databases_describe.md
+++ b/docs/iai_databases_describe.md
@@ -7,12 +7,15 @@ Describe a database in detail
 Show detailed information about a database including configuration, runtime
 status, and connection credentials.
 
-Examples:
-  iai databases describe my-db
-  iai databases describe my-db --json
-
 ```
 iai databases describe <database_name> [flags]
+```
+
+### Examples
+
+```
+  iai databases describe my-db
+  iai databases describe my-db --json
 ```
 
 ### Options

--- a/docs/iai_databases_list.md
+++ b/docs/iai_databases_list.md
@@ -10,6 +10,14 @@ List databases in a project.
 iai databases list [flags]
 ```
 
+### Examples
+
+```
+  iai databases list
+  iai databases list -p my-project
+  iai databases list --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_databases_log-fields.md
+++ b/docs/iai_databases_log-fields.md
@@ -10,12 +10,15 @@ PostgreSQL-specific details are often nested under the 'record' field, so seeing
 'record' in the results is expected. Use the reported field names with
 'iai databases logs --fields' to include them in output.
 
-Examples:
-  iai databases log-fields my-db
-  iai databases log-fields my-db --since 1h
-
 ```
 iai databases log-fields <database_name> [flags]
+```
+
+### Examples
+
+```
+  iai databases log-fields my-db
+  iai databases log-fields my-db --since 1h
 ```
 
 ### Options

--- a/docs/iai_databases_logs.md
+++ b/docs/iai_databases_logs.md
@@ -19,6 +19,15 @@ JSON strings into nested JSON values.
 iai databases logs <database_name> [flags]
 ```
 
+### Examples
+
+```
+  iai databases logs my-db
+  iai databases logs my-db --follow
+  iai databases logs my-db --since 30m
+  iai databases logs my-db --start-time 2026-01-01T00:00:00Z --end-time 2026-01-01T01:00:00Z
+```
+
 ### Options
 
 ```

--- a/docs/iai_databases_port-forward.md
+++ b/docs/iai_databases_port-forward.md
@@ -13,12 +13,15 @@ to choose the local listening port (defaults to the remote port).
 After connecting you can use psql, pgAdmin, or any PostgreSQL client against
 localhost:<local-port>.
 
-Examples:
-  iai databases port-forward my-db
-  iai databases port-forward my-db --local-port 15432
-
 ```
 iai databases port-forward <database_name> [flags]
+```
+
+### Examples
+
+```
+  iai databases port-forward my-db
+  iai databases port-forward my-db --local-port 15432
 ```
 
 ### Options

--- a/docs/iai_databases_restore.md
+++ b/docs/iai_databases_restore.md
@@ -10,12 +10,15 @@ source database must have backups enabled.
 Optionally specify --target-time for point-in-time recovery (RFC3339 format).
 If omitted, the latest backup is restored.
 
-Examples:
-  iai databases restore my-restored-db --source-database my-db --instances 2 --cpu 1 --memory 2G --storage-size 20G
-  iai databases restore my-restored-db --source-database my-db --target-time 2026-05-12T10:00:00Z --instances 2 --cpu 1 --memory 2G --storage-size 20G
-
 ```
 iai databases restore <database_name> [flags]
+```
+
+### Examples
+
+```
+  iai databases restore my-restored-db --source-database my-db --instances 2 --cpu 1 --memory 2G --storage-size 20G
+  iai databases restore my-restored-db --source-database my-db --target-time 2026-05-12T10:00:00Z --instances 2 --cpu 1 --memory 2G --storage-size 20G
 ```
 
 ### Options

--- a/docs/iai_databases_update.md
+++ b/docs/iai_databases_update.md
@@ -13,7 +13,13 @@ downtime.
 
 Use --clear-stack-id to remove the database from its stack.
 
-Examples:
+```
+iai databases update <database_name> [flags]
+```
+
+### Examples
+
+```
   iai databases update my-db --instances 3
   iai databases update my-db --cpu 2 --memory 4G
   iai databases update my-db --storage-size 50G
@@ -21,9 +27,6 @@ Examples:
   iai databases update my-db --clear-backup
   iai databases update my-db --stack-id my-stack
   iai databases update my-db --clear-stack-id
-
-```
-iai databases update <database_name> [flags]
 ```
 
 ### Options

--- a/docs/iai_dataset-items_create.md
+++ b/docs/iai_dataset-items_create.md
@@ -10,6 +10,15 @@ Create or upsert an item in a dataset.
 iai dataset-items create [flags]
 ```
 
+### Examples
+
+```
+  iai dataset-items create --dataset-name my-dataset --input '{"question":"2+2?"}'
+  iai dataset-items create --dataset-name my-dataset --input '{"question":"2+2?"}' --expected-output '{"answer":"4"}'
+  iai dataset-items create --dataset-name my-dataset --id item-123 --input '{"q":"hi"}' --metadata-json '{"source":"manual"}' --status ACTIVE
+  iai dataset-items create --dataset-name my-dataset --input '{"q":"hi"}' --source-trace-id trace-123 --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_dataset-items_delete.md
+++ b/docs/iai_dataset-items_delete.md
@@ -10,6 +10,13 @@ Delete a dataset item by ID.
 iai dataset-items delete <id> [flags]
 ```
 
+### Examples
+
+```
+  iai dataset-items delete item-123
+  iai dataset-items delete item-123 --organization my-org --project my-project
+```
+
 ### Options
 
 ```

--- a/docs/iai_dataset-items_get.md
+++ b/docs/iai_dataset-items_get.md
@@ -10,6 +10,14 @@ Get detailed information about a specific dataset item.
 iai dataset-items get <id> [flags]
 ```
 
+### Examples
+
+```
+  iai dataset-items get item-123
+  iai dataset-items get item-123 --json
+  iai dataset-items get item-123 --yaml
+```
+
 ### Options
 
 ```

--- a/docs/iai_dataset-items_list.md
+++ b/docs/iai_dataset-items_list.md
@@ -10,6 +10,15 @@ List items in a dataset with optional filters.
 iai dataset-items list [flags]
 ```
 
+### Examples
+
+```
+  iai dataset-items list --dataset-name my-dataset
+  iai dataset-items list --dataset-name my-dataset --source-trace-id trace-123 --limit 50
+  iai dataset-items list --dataset-name my-dataset --columns id,status,input
+  iai dataset-items list --dataset-name my-dataset --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_dataset-runs_delete.md
+++ b/docs/iai_dataset-runs_delete.md
@@ -10,6 +10,13 @@ Delete a dataset run by name.
 iai dataset-runs delete <run-name> [flags]
 ```
 
+### Examples
+
+```
+  iai dataset-runs delete my-run --dataset-name my-dataset
+  iai dataset-runs delete my-run --dataset-name my-dataset -o my-org -p my-project
+```
+
 ### Options
 
 ```

--- a/docs/iai_dataset-runs_get.md
+++ b/docs/iai_dataset-runs_get.md
@@ -10,6 +10,15 @@ Get detailed information about a specific dataset run.
 iai dataset-runs get <run-name> [flags]
 ```
 
+### Examples
+
+```
+  iai dataset-runs get my-run --dataset-name my-dataset
+  iai dataset-runs get my-run --dataset-name my-dataset -o my-org -p my-project
+  iai dataset-runs get my-run --dataset-name my-dataset --json
+  iai dataset-runs get my-run --dataset-name my-dataset --yaml
+```
+
 ### Options
 
 ```

--- a/docs/iai_dataset-runs_list.md
+++ b/docs/iai_dataset-runs_list.md
@@ -10,6 +10,15 @@ List runs for a given dataset.
 iai dataset-runs list [flags]
 ```
 
+### Examples
+
+```
+  iai dataset-runs list --dataset-name my-dataset
+  iai dataset-runs list --dataset-name my-dataset -o my-org -p my-project
+  iai dataset-runs list --dataset-name my-dataset --page 2 --limit 50 --columns name,status
+  iai dataset-runs list --dataset-name my-dataset --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_datasets_create.md
+++ b/docs/iai_datasets_create.md
@@ -10,6 +10,15 @@ Create a new evaluation dataset.
 iai datasets create <name> [flags]
 ```
 
+### Examples
+
+```
+  iai datasets create my-dataset
+  iai datasets create my-dataset --description "Golden eval set"
+  iai datasets create my-dataset --metadata-json '{"source":"prod"}' -p my-project
+  iai datasets create my-dataset --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_datasets_get.md
+++ b/docs/iai_datasets_get.md
@@ -10,6 +10,14 @@ Get detailed information about a specific dataset.
 iai datasets get <name> [flags]
 ```
 
+### Examples
+
+```
+  iai datasets get my-dataset
+  iai datasets get my-dataset -o my-org -p my-project
+  iai datasets get my-dataset --yaml
+```
+
 ### Options
 
 ```

--- a/docs/iai_datasets_list.md
+++ b/docs/iai_datasets_list.md
@@ -10,6 +10,15 @@ List evaluation datasets with pagination.
 iai datasets list [flags]
 ```
 
+### Examples
+
+```
+  iai datasets list
+  iai datasets list -p my-project --limit 50 --page 2
+  iai datasets list --columns name,description
+  iai datasets list --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_glossaries_create.md
+++ b/docs/iai_glossaries_create.md
@@ -32,6 +32,15 @@ Run `iai glossaries schema` to see the current field definitions.
 Each key under `terms` must be unique. Add as many terms as you need — the
 glossary accepts any number of entries.
 
+### Examples
+
+```
+  iai glossaries create finance-terms --file glossary.json
+  iai glossaries create finance-terms --file glossary.json --schema-version 2.1.0
+  iai glossaries create finance-terms --file glossary.json --labels production
+  iai glossaries create finance-terms --file glossary.json --tags domain
+```
+
 ### Options
 
 ```

--- a/docs/iai_glossaries_delete.md
+++ b/docs/iai_glossaries_delete.md
@@ -10,14 +10,17 @@ Without flags, deletes the glossary entry and all its versions (requires
 confirmation). Use --version to delete a specific version, or --label to delete
 versions with a specific label. Use -f to skip the confirmation prompt.
 
-Examples:
+```
+iai glossaries delete <name> [flags]
+```
+
+### Examples
+
+```
   iai glossaries delete finance-terms
   iai glossaries delete finance-terms -f
   iai glossaries delete finance-terms --version 3
   iai glossaries delete finance-terms --label staging
-
-```
-iai glossaries delete <name> [flags]
 ```
 
 ### Options

--- a/docs/iai_glossaries_diff.md
+++ b/docs/iai_glossaries_diff.md
@@ -6,11 +6,14 @@ Compare two versions of a glossary
 
 Show the differences between two versions of a glossary.
 
-Examples:
-  iai glossaries diff my-glossary 1 3
-
 ```
 iai glossaries diff <name> <version_a> <version_b> [flags]
+```
+
+### Examples
+
+```
+  iai glossaries diff my-glossary 1 3
 ```
 
 ### Options

--- a/docs/iai_glossaries_get.md
+++ b/docs/iai_glossaries_get.md
@@ -9,13 +9,16 @@ Show detailed information about a specific glossary definition, including its fu
 By default returns the version labeled "production". Use --version to retrieve a
 specific version number, or --label to resolve a different label.
 
-Examples:
+```
+iai glossaries get <name> [flags]
+```
+
+### Examples
+
+```
   iai glossaries get finance-terms
   iai glossaries get finance-terms --version 3
   iai glossaries get finance-terms --label staging
-
-```
-iai glossaries get <name> [flags]
 ```
 
 ### Options

--- a/docs/iai_glossaries_list.md
+++ b/docs/iai_glossaries_list.md
@@ -10,14 +10,17 @@ Returns all glossary entries with their name, labels, tags, and last update time
 Folders are shown with a trailing "/" (colored when stdout is a terminal) and
 can be browsed into with --folder.
 
-Examples:
+```
+iai glossaries list [flags]
+```
+
+### Examples
+
+```
   iai glossaries list
   iai glossaries list --folder my-folder
   iai glossaries list --folder my-folder/sub-folder
   iai glossaries list --page 2 --limit 10
-
-```
-iai glossaries list [flags]
 ```
 
 ### Options

--- a/docs/iai_glossaries_schema.md
+++ b/docs/iai_glossaries_schema.md
@@ -15,6 +15,14 @@ This is a public endpoint and does not require authentication.
 iai glossaries schema [flags]
 ```
 
+### Examples
+
+```
+  iai glossaries schema
+  iai glossaries schema --schema-version 0.0.1
+  iai glossaries schema --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_glossaries_update.md
+++ b/docs/iai_glossaries_update.md
@@ -34,6 +34,14 @@ Run `iai glossaries schema` to see the current field definitions.
 Each key under `terms` must be unique. Add as many terms as you need — the
 glossary accepts any number of entries.
 
+### Examples
+
+```
+  iai glossaries update finance-terms --file glossary.json
+  iai glossaries update finance-terms --file glossary.json --schema-version 2.1.0
+  iai glossaries update finance-terms --file glossary.json --labels production,staging
+```
+
 ### Options
 
 ```

--- a/docs/iai_glossaries_versions.md
+++ b/docs/iai_glossaries_versions.md
@@ -6,11 +6,14 @@ List versions of a glossary
 
 List all versions of a glossary, sorted newest-first.
 
-Examples:
-  iai glossaries versions my-glossary
-
 ```
 iai glossaries versions <name> [flags]
+```
+
+### Examples
+
+```
+  iai glossaries versions my-glossary
 ```
 
 ### Options

--- a/docs/iai_images_build.md
+++ b/docs/iai_images_build.md
@@ -13,6 +13,14 @@ Dockerfile, and build context.
 iai images build [image_name] [flags]
 ```
 
+### Examples
+
+```
+  iai images build my-service --tag 1.2.3
+  iai images build my-service --tag 1.2.3 --file docker/Dockerfile --context .
+  iai images build my-service --tag 1.2.3 --platform linux/amd64
+```
+
 ### Options
 
 ```

--- a/docs/iai_images_list.md
+++ b/docs/iai_images_list.md
@@ -10,6 +10,15 @@ List container images in the deployment registry for a specific project.
 iai images list [flags]
 ```
 
+### Examples
+
+```
+  iai images list
+  iai images list --organization my-org --project my-project
+  iai images list --json
+  iai images list --yaml
+```
+
 ### Options
 
 ```

--- a/docs/iai_images_push.md
+++ b/docs/iai_images_push.md
@@ -10,6 +10,13 @@ Create a Docker image tarball and push it to the deployment images endpoint for 
 iai images push [image_name] [flags]
 ```
 
+### Examples
+
+```
+  iai images push my-service --tag 1.2.3
+  iai images push my-service --tag 1.2.3 --organization my-org --project my-project
+```
+
 ### Options
 
 ```

--- a/docs/iai_macros_create.md
+++ b/docs/iai_macros_create.md
@@ -16,6 +16,14 @@ No schema validation is applied — any text content is accepted.
 **Disclaimer:** This is not financial advice. Consult a professional.
 ```
 
+### Examples
+
+```
+  iai macros create disclaimer --file disclaimer.md
+  iai macros create disclaimer --file disclaimer.md --labels production
+  iai macros create disclaimer --file disclaimer.md --tags legal
+```
+
 ### Options
 
 ```

--- a/docs/iai_macros_delete.md
+++ b/docs/iai_macros_delete.md
@@ -10,14 +10,17 @@ Without flags, deletes the macro and all its versions (requires confirmation).
 Use --version to delete a specific version, or --label to delete versions with a
 specific label. Use -f to skip the confirmation prompt.
 
-Examples:
+```
+iai macros delete <name> [flags]
+```
+
+### Examples
+
+```
   iai macros delete disclaimer
   iai macros delete disclaimer -f
   iai macros delete disclaimer --version 3
   iai macros delete disclaimer --label staging
-
-```
-iai macros delete <name> [flags]
 ```
 
 ### Options

--- a/docs/iai_macros_diff.md
+++ b/docs/iai_macros_diff.md
@@ -6,11 +6,14 @@ Compare two versions of a macro
 
 Show the differences between two versions of a macro.
 
-Examples:
-  iai macros diff my-macro 1 3
-
 ```
 iai macros diff <name> <version_a> <version_b> [flags]
+```
+
+### Examples
+
+```
+  iai macros diff my-macro 1 3
 ```
 
 ### Options

--- a/docs/iai_macros_get.md
+++ b/docs/iai_macros_get.md
@@ -9,13 +9,16 @@ Show detailed information about a specific macro, including its full content.
 By default returns the version labeled "production". Use --version to retrieve a
 specific version number, or --label to resolve a different label.
 
-Examples:
+```
+iai macros get <name> [flags]
+```
+
+### Examples
+
+```
   iai macros get disclaimer
   iai macros get disclaimer --version 3
   iai macros get disclaimer --label staging
-
-```
-iai macros get <name> [flags]
 ```
 
 ### Options

--- a/docs/iai_macros_list.md
+++ b/docs/iai_macros_list.md
@@ -10,14 +10,17 @@ Returns all macros with their name, labels, tags, and last update time.
 Folders are shown with a trailing "/" (colored when stdout is a terminal) and
 can be browsed into with --folder.
 
-Examples:
+```
+iai macros list [flags]
+```
+
+### Examples
+
+```
   iai macros list
   iai macros list --folder my-folder
   iai macros list --folder my-folder/sub-folder
   iai macros list --page 2 --limit 10
-
-```
-iai macros list [flags]
 ```
 
 ### Options

--- a/docs/iai_macros_update.md
+++ b/docs/iai_macros_update.md
@@ -18,6 +18,13 @@ No schema validation is applied — any text content is accepted.
 **Disclaimer:** This is not financial advice. Consult a professional.
 ```
 
+### Examples
+
+```
+  iai macros update disclaimer --file disclaimer.md
+  iai macros update disclaimer --file disclaimer.md --labels production,staging
+```
+
 ### Options
 
 ```

--- a/docs/iai_macros_versions.md
+++ b/docs/iai_macros_versions.md
@@ -6,11 +6,14 @@ List versions of a macro
 
 List all versions of a macro, sorted newest-first.
 
-Examples:
-  iai macros versions my-macro
-
 ```
 iai macros versions <name> [flags]
+```
+
+### Examples
+
+```
+  iai macros versions my-macro
 ```
 
 ### Options

--- a/docs/iai_metrics_list.md
+++ b/docs/iai_metrics_list.md
@@ -10,14 +10,17 @@ Uses the platform API with dual authentication (API key or session).
 If --from-timestamp is not provided, defaults to 7 days ago.
 Use --daily to get metrics aggregated by day (default).
 
-Examples:
+```
+iai metrics list [flags]
+```
+
+### Examples
+
+```
   iai metrics list --daily
   iai metrics list --daily --from-timestamp 2025-01-01T00:00:00Z
   iai metrics list --daily --trace-name my-trace --show-models
   iai metrics list --daily --json | jq '.data'
-
-```
-iai metrics list [flags]
 ```
 
 ### Options

--- a/docs/iai_observations_get.md
+++ b/docs/iai_observations_get.md
@@ -8,12 +8,15 @@ Get detailed information about a specific observation.
 
 Uses the platform API with dual authentication (API key or session).
 
-Examples:
-  iai observations get obs-abc123
-  iai observations get obs-abc123 --json | jq '.data.observation'
-
 ```
 iai observations get <observation-id> [flags]
+```
+
+### Examples
+
+```
+  iai observations get obs-abc123
+  iai observations get obs-abc123 --json | jq '.data.observation'
 ```
 
 ### Options

--- a/docs/iai_observations_list.md
+++ b/docs/iai_observations_list.md
@@ -11,7 +11,13 @@ Without --trace-id, searches observations across all traces with optional filter
 
 Uses the platform API with dual authentication (API key or session).
 
-Examples:
+```
+iai observations list [flags]
+```
+
+### Examples
+
+```
   # List observations for a specific trace
   iai observations list --trace-id abc123
   iai observations list --trace-id abc123 --include-io
@@ -21,9 +27,6 @@ Examples:
   iai observations list --type GENERATION --model gpt-4
   iai observations list --from-timestamp 2025-01-01T00:00:00Z --name my-span
   iai observations list --json | jq '.data'
-
-```
-iai observations list [flags]
 ```
 
 ### Options

--- a/docs/iai_organizations_list.md
+++ b/docs/iai_organizations_list.md
@@ -10,6 +10,14 @@ List all organizations you are a member of.
 iai organizations list [flags]
 ```
 
+### Examples
+
+```
+  iai organizations list
+  iai organizations list --json
+  iai organizations list --yaml
+```
+
 ### Options
 
 ```

--- a/docs/iai_organizations_select.md
+++ b/docs/iai_organizations_select.md
@@ -10,6 +10,12 @@ Select an organization by name and store it in the local CLI configuration so ot
 iai organizations select [organization_name] [flags]
 ```
 
+### Examples
+
+```
+  iai organizations select my-organization
+```
+
 ### Options
 
 ```

--- a/docs/iai_policies_create.md
+++ b/docs/iai_policies_create.md
@@ -22,6 +22,15 @@ action: Transfer to human
 criticality: HIGH
 ```
 
+### Examples
+
+```
+  iai policies create safety-rules --file policy.yaml
+  iai policies create safety-rules --file policy.yaml --schema-version 2.1.0
+  iai policies create safety-rules --file policy.yaml --labels production
+  iai policies create safety-rules --file policy.yaml --tags compliance
+```
+
 ### Options
 
 ```

--- a/docs/iai_policies_delete.md
+++ b/docs/iai_policies_delete.md
@@ -10,14 +10,17 @@ Without flags, deletes the policy and all its versions (requires confirmation).
 Use --version to delete a specific version, or --label to delete versions with a
 specific label. Use -f to skip the confirmation prompt.
 
-Examples:
+```
+iai policies delete <name> [flags]
+```
+
+### Examples
+
+```
   iai policies delete safety-rules
   iai policies delete safety-rules -f
   iai policies delete safety-rules --version 3
   iai policies delete safety-rules --label staging
-
-```
-iai policies delete <name> [flags]
 ```
 
 ### Options

--- a/docs/iai_policies_diff.md
+++ b/docs/iai_policies_diff.md
@@ -6,11 +6,14 @@ Compare two versions of a policy
 
 Show the differences between two versions of a policy.
 
-Examples:
-  iai policies diff my-policy 1 3
-
 ```
 iai policies diff <name> <version_a> <version_b> [flags]
+```
+
+### Examples
+
+```
+  iai policies diff my-policy 1 3
 ```
 
 ### Options

--- a/docs/iai_policies_get.md
+++ b/docs/iai_policies_get.md
@@ -9,13 +9,16 @@ Show detailed information about a specific policy, including its full content.
 By default returns the version labeled "production". Use --version to retrieve a
 specific version number, or --label to resolve a different label.
 
-Examples:
+```
+iai policies get <name> [flags]
+```
+
+### Examples
+
+```
   iai policies get safety-rules
   iai policies get safety-rules --version 3
   iai policies get safety-rules --label staging
-
-```
-iai policies get <name> [flags]
 ```
 
 ### Options

--- a/docs/iai_policies_list.md
+++ b/docs/iai_policies_list.md
@@ -10,14 +10,17 @@ Returns all policies with their name, labels, tags, and last update time.
 Folders are shown with a trailing "/" (colored when stdout is a terminal) and
 can be browsed into with --folder.
 
-Examples:
+```
+iai policies list [flags]
+```
+
+### Examples
+
+```
   iai policies list
   iai policies list --folder my-folder
   iai policies list --folder my-folder/sub-folder
   iai policies list --page 2 --limit 10
-
-```
-iai policies list [flags]
 ```
 
 ### Options

--- a/docs/iai_policies_schema.md
+++ b/docs/iai_policies_schema.md
@@ -15,6 +15,14 @@ This is a public endpoint and does not require authentication.
 iai policies schema [flags]
 ```
 
+### Examples
+
+```
+  iai policies schema
+  iai policies schema --schema-version 0.0.1
+  iai policies schema --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_policies_update.md
+++ b/docs/iai_policies_update.md
@@ -24,6 +24,14 @@ action: Transfer to human
 criticality: HIGH
 ```
 
+### Examples
+
+```
+  iai policies update safety-rules --file policy.yaml
+  iai policies update safety-rules --file policy.yaml --schema-version 2.1.0
+  iai policies update safety-rules --file policy.yaml --labels production,staging
+```
+
 ### Options
 
 ```

--- a/docs/iai_policies_versions.md
+++ b/docs/iai_policies_versions.md
@@ -6,11 +6,14 @@ List versions of a policy
 
 List all versions of a policy, sorted newest-first.
 
-Examples:
-  iai policies versions my-policy
-
 ```
 iai policies versions <name> [flags]
+```
+
+### Examples
+
+```
+  iai policies versions my-policy
 ```
 
 ### Options

--- a/docs/iai_projects_list.md
+++ b/docs/iai_projects_list.md
@@ -10,6 +10,14 @@ List all projects within a specific organization. The organization name will be 
 iai projects list [flags]
 ```
 
+### Examples
+
+```
+  iai projects list
+  iai projects list --organization my-org
+  iai projects list --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_projects_select.md
+++ b/docs/iai_projects_select.md
@@ -10,6 +10,13 @@ Select a project by name and store it in the local CLI configuration so other co
 iai projects select [project_name] [flags]
 ```
 
+### Examples
+
+```
+  iai projects select my-project
+  iai projects select my-project --organization my-org
+```
+
 ### Options
 
 ```

--- a/docs/iai_prompts_create.md
+++ b/docs/iai_prompts_create.md
@@ -15,15 +15,18 @@ The server automatically assigns the "latest" label to new versions. To make a
 version retrievable via the default 'get' (which resolves "production"), assign
 the "production" label with --labels production.
 
-Examples:
+```
+iai prompts create <name> [flags]
+```
+
+### Examples
+
+```
   iai prompts create greeting --content "Hello, how can I help you?"
   iai prompts create greeting --file greeting.txt
   iai prompts create greeting --file greeting.txt --type chat
   iai prompts create greeting --content "Hi!" --labels production
   iai prompts create greeting --file greeting.txt --tags support
-
-```
-iai prompts create <name> [flags]
 ```
 
 ### Options

--- a/docs/iai_prompts_delete.md
+++ b/docs/iai_prompts_delete.md
@@ -10,14 +10,17 @@ Without flags, deletes the prompt and all its versions (requires confirmation).
 Use --version to delete a specific version, or --label to delete versions with a
 specific label. Use -f to skip the confirmation prompt.
 
-Examples:
+```
+iai prompts delete <name> [flags]
+```
+
+### Examples
+
+```
   iai prompts delete greeting
   iai prompts delete greeting -f
   iai prompts delete greeting --version 3
   iai prompts delete greeting --label staging
-
-```
-iai prompts delete <name> [flags]
 ```
 
 ### Options

--- a/docs/iai_prompts_diff.md
+++ b/docs/iai_prompts_diff.md
@@ -6,11 +6,14 @@ Compare two versions of a prompt
 
 Show the differences between two versions of a prompt.
 
-Examples:
-  iai prompts diff greeting 1 3
-
 ```
 iai prompts diff <name> <version_a> <version_b> [flags]
+```
+
+### Examples
+
+```
+  iai prompts diff greeting 1 3
 ```
 
 ### Options

--- a/docs/iai_prompts_get.md
+++ b/docs/iai_prompts_get.md
@@ -9,13 +9,16 @@ Show detailed information about a specific prompt, including its full content.
 By default returns the version labeled "production". Use --version to retrieve a
 specific version number, or --label to resolve a different label.
 
-Examples:
+```
+iai prompts get <name> [flags]
+```
+
+### Examples
+
+```
   iai prompts get greeting
   iai prompts get greeting --version 3
   iai prompts get greeting --label staging
-
-```
-iai prompts get <name> [flags]
 ```
 
 ### Options

--- a/docs/iai_prompts_list.md
+++ b/docs/iai_prompts_list.md
@@ -10,14 +10,17 @@ Returns all general-purpose prompts with their name, labels, tags, and last
 update time. Typed prompts (routines, policies, etc.) are excluded.
 Folders are shown with a trailing "/" and can be browsed into with --folder.
 
-Examples:
+```
+iai prompts list [flags]
+```
+
+### Examples
+
+```
   iai prompts list
   iai prompts list --folder my-folder
   iai prompts list --folder my-folder/sub-folder
   iai prompts list --page 2 --limit 10
-
-```
-iai prompts list [flags]
 ```
 
 ### Options

--- a/docs/iai_prompts_update.md
+++ b/docs/iai_prompts_update.md
@@ -12,13 +12,16 @@ by version number.
 
 Exactly one of --file or --content must be specified.
 
-Examples:
+```
+iai prompts update <name> [flags]
+```
+
+### Examples
+
+```
   iai prompts update greeting --content "Hello! How may I assist you today?"
   iai prompts update greeting --file greeting.txt
   iai prompts update greeting --file greeting.txt --labels production,staging
-
-```
-iai prompts update <name> [flags]
 ```
 
 ### Options

--- a/docs/iai_prompts_versions.md
+++ b/docs/iai_prompts_versions.md
@@ -6,11 +6,14 @@ List versions of a prompt
 
 List all versions of a prompt, sorted newest-first.
 
-Examples:
-  iai prompts versions greeting
-
 ```
 iai prompts versions <name> [flags]
+```
+
+### Examples
+
+```
+  iai prompts versions greeting
 ```
 
 ### Options

--- a/docs/iai_queue-items_create.md
+++ b/docs/iai_queue-items_create.md
@@ -12,6 +12,14 @@ This command requires API key authentication.
 iai queue-items create [flags]
 ```
 
+### Examples
+
+```
+  iai queue-items create --queue-id queue-123 --object-id trace-789 --object-type TRACE
+  iai queue-items create --queue-id queue-123 --object-id obs-789 --object-type OBSERVATION --status PENDING
+  iai queue-items create --queue-id queue-123 --object-id trace-789 --object-type TRACE --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_queue-items_delete.md
+++ b/docs/iai_queue-items_delete.md
@@ -10,6 +10,13 @@ Delete an item from an annotation queue.
 iai queue-items delete <item-id> [flags]
 ```
 
+### Examples
+
+```
+  iai queue-items delete item-456 --queue-id queue-123
+  iai queue-items delete item-456 --queue-id queue-123 -p my-project
+```
+
 ### Options
 
 ```

--- a/docs/iai_queue-items_get.md
+++ b/docs/iai_queue-items_get.md
@@ -10,6 +10,14 @@ Get detailed information about a queue item.
 iai queue-items get <item-id> [flags]
 ```
 
+### Examples
+
+```
+  iai queue-items get item-456 --queue-id queue-123
+  iai queue-items get item-456 --queue-id queue-123 --json
+  iai queue-items get item-456 --queue-id queue-123 --yaml
+```
+
 ### Options
 
 ```

--- a/docs/iai_queue-items_list.md
+++ b/docs/iai_queue-items_list.md
@@ -10,6 +10,15 @@ List items in an annotation queue.
 iai queue-items list [flags]
 ```
 
+### Examples
+
+```
+  iai queue-items list --queue-id queue-123
+  iai queue-items list --queue-id queue-123 --status PENDING
+  iai queue-items list --queue-id queue-123 --page 2 --limit 50
+  iai queue-items list --queue-id queue-123 --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_queue-items_update.md
+++ b/docs/iai_queue-items_update.md
@@ -12,6 +12,14 @@ This command requires API key authentication.
 iai queue-items update <item-id> [flags]
 ```
 
+### Examples
+
+```
+  iai queue-items update item-456 --queue-id queue-123 --status COMPLETED
+  iai queue-items update item-456 --queue-id queue-123 --status PENDING --json
+  iai queue-items update item-456 --queue-id queue-123 --status COMPLETED --yaml
+```
+
 ### Options
 
 ```

--- a/docs/iai_queues_assign.md
+++ b/docs/iai_queues_assign.md
@@ -12,6 +12,13 @@ This command requires API key authentication.
 iai queues assign <queue-id> [flags]
 ```
 
+### Examples
+
+```
+  iai queues assign queue-123 --user-id user-456
+  iai queues assign queue-123 --user-id user-456 -o my-org -p my-project
+```
+
 ### Options
 
 ```

--- a/docs/iai_queues_create.md
+++ b/docs/iai_queues_create.md
@@ -12,6 +12,15 @@ This command requires API key authentication.
 iai queues create <name> [flags]
 ```
 
+### Examples
+
+```
+  iai queues create my-queue
+  iai queues create my-queue --description "Review of chat outputs"
+  iai queues create my-queue --score-config-ids sc-1,sc-2
+  iai queues create my-queue --description "QA queue" --score-config-ids sc-1 --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_queues_get.md
+++ b/docs/iai_queues_get.md
@@ -10,6 +10,14 @@ Get detailed information about an annotation queue.
 iai queues get <id> [flags]
 ```
 
+### Examples
+
+```
+  iai queues get queue-123
+  iai queues get queue-123 --json
+  iai queues get queue-123 -o my-org -p my-project --yaml
+```
+
 ### Options
 
 ```

--- a/docs/iai_queues_list.md
+++ b/docs/iai_queues_list.md
@@ -10,6 +10,15 @@ List annotation queues with pagination.
 iai queues list [flags]
 ```
 
+### Examples
+
+```
+  iai queues list
+  iai queues list --page 2 --limit 50
+  iai queues list --columns id,name,description
+  iai queues list -o my-org -p my-project --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_queues_unassign.md
+++ b/docs/iai_queues_unassign.md
@@ -12,6 +12,13 @@ This command requires API key authentication.
 iai queues unassign <queue-id> [flags]
 ```
 
+### Examples
+
+```
+  iai queues unassign queue-123 --user-id user-456
+  iai queues unassign queue-123 --user-id user-456 -o my-org -p my-project
+```
+
 ### Options
 
 ```

--- a/docs/iai_replicas_describe.md
+++ b/docs/iai_replicas_describe.md
@@ -10,6 +10,14 @@ Show detailed information about a specific replica including status, resources, 
 iai replicas describe <replica_name> [flags]
 ```
 
+### Examples
+
+```
+  iai replicas describe my-service-abc123
+  iai replicas describe my-service-abc123 -p my-project -o my-org
+  iai replicas describe my-service-abc123 --yaml
+```
+
 ### Options
 
 ```

--- a/docs/iai_replicas_list.md
+++ b/docs/iai_replicas_list.md
@@ -10,6 +10,14 @@ List pods backing a service in a specific project.
 iai replicas list [service_name] [flags]
 ```
 
+### Examples
+
+```
+  iai replicas list my-service
+  iai replicas list my-service -p my-project -o my-org
+  iai replicas list my-service --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_replicas_log-fields.md
+++ b/docs/iai_replicas_log-fields.md
@@ -8,12 +8,15 @@ Scan recent logs and list the extra top-level fields present in structured (JSON
 
 Use the reported field names with 'iai replicas logs --fields' to include them in output.
 
-Examples:
-  iai replicas log-fields my-service-abc123
-  iai replicas log-fields my-service-abc123 --since 1h
-
 ```
 iai replicas log-fields <replica_name> [flags]
+```
+
+### Examples
+
+```
+  iai replicas log-fields my-service-abc123
+  iai replicas log-fields my-service-abc123 --since 1h
 ```
 
 ### Options

--- a/docs/iai_replicas_logs.md
+++ b/docs/iai_replicas_logs.md
@@ -18,6 +18,15 @@ nested JSON values.
 iai replicas logs <replica_name> [flags]
 ```
 
+### Examples
+
+```
+  iai replicas logs my-service-abc123
+  iai replicas logs my-service-abc123 --follow
+  iai replicas logs my-service-abc123 --since 30m --fields logger,pid
+  iai replicas logs my-service-abc123 --start-time 2026-01-01T00:00:00Z --end-time 2026-01-01T01:00:00Z
+```
+
 ### Options
 
 ```

--- a/docs/iai_routines_create.md
+++ b/docs/iai_routines_create.md
@@ -27,6 +27,15 @@ steps:
     tool_instruction: Fetch user data
 ```
 
+### Examples
+
+```
+  iai routines create onboarding-flow --file routine.yaml
+  iai routines create onboarding-flow --file routine.yaml --schema-version 2.1.0
+  iai routines create onboarding-flow --file routine.yaml --labels production
+  iai routines create onboarding-flow --file routine.yaml --tags v2,experimental
+```
+
 ### Options
 
 ```

--- a/docs/iai_routines_delete.md
+++ b/docs/iai_routines_delete.md
@@ -10,14 +10,17 @@ Without flags, deletes the routine and all its versions (requires confirmation).
 Use --version to delete a specific version, or --label to delete versions with a
 specific label. Use -f to skip the confirmation prompt.
 
-Examples:
+```
+iai routines delete <name> [flags]
+```
+
+### Examples
+
+```
   iai routines delete onboarding-flow
   iai routines delete onboarding-flow -f
   iai routines delete onboarding-flow --version 3
   iai routines delete onboarding-flow --label staging
-
-```
-iai routines delete <name> [flags]
 ```
 
 ### Options

--- a/docs/iai_routines_diff.md
+++ b/docs/iai_routines_diff.md
@@ -6,11 +6,14 @@ Compare two versions of a routine
 
 Show the differences between two versions of a routine.
 
-Examples:
-  iai routines diff my-routine 1 3
-
 ```
 iai routines diff <name> <version_a> <version_b> [flags]
+```
+
+### Examples
+
+```
+  iai routines diff my-routine 1 3
 ```
 
 ### Options

--- a/docs/iai_routines_get.md
+++ b/docs/iai_routines_get.md
@@ -9,13 +9,16 @@ Show detailed information about a specific routine, including its full content.
 By default returns the version labeled "production". Use --version to retrieve a
 specific version number, or --label to resolve a different label.
 
-Examples:
+```
+iai routines get <name> [flags]
+```
+
+### Examples
+
+```
   iai routines get onboarding-flow
   iai routines get onboarding-flow --version 3
   iai routines get onboarding-flow --label staging
-
-```
-iai routines get <name> [flags]
 ```
 
 ### Options

--- a/docs/iai_routines_list.md
+++ b/docs/iai_routines_list.md
@@ -10,14 +10,17 @@ Returns all routines with their name, labels, tags, and last update time.
 Folders are shown with a trailing "/" (colored when stdout is a terminal) and
 can be browsed into with --folder.
 
-Examples:
+```
+iai routines list [flags]
+```
+
+### Examples
+
+```
   iai routines list
   iai routines list --folder my-folder
   iai routines list --folder my-folder/sub-folder
   iai routines list --page 2 --limit 10
-
-```
-iai routines list [flags]
 ```
 
 ### Options

--- a/docs/iai_routines_schema.md
+++ b/docs/iai_routines_schema.md
@@ -15,6 +15,14 @@ This is a public endpoint and does not require authentication.
 iai routines schema [flags]
 ```
 
+### Examples
+
+```
+  iai routines schema
+  iai routines schema --schema-version 0.0.1
+  iai routines schema --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_routines_update.md
+++ b/docs/iai_routines_update.md
@@ -29,6 +29,14 @@ steps:
     tool_instruction: Fetch user data
 ```
 
+### Examples
+
+```
+  iai routines update onboarding-flow --file routine.yaml
+  iai routines update onboarding-flow --file routine.yaml --schema-version 2.1.0
+  iai routines update onboarding-flow --file routine.yaml --labels production,staging
+```
+
 ### Options
 
 ```

--- a/docs/iai_routines_versions.md
+++ b/docs/iai_routines_versions.md
@@ -6,11 +6,14 @@ List versions of a routine
 
 List all versions of a routine, sorted newest-first.
 
-Examples:
-  iai routines versions my-routine
-
 ```
 iai routines versions <name> [flags]
+```
+
+### Examples
+
+```
+  iai routines versions my-routine
 ```
 
 ### Options

--- a/docs/iai_run-items_create.md
+++ b/docs/iai_run-items_create.md
@@ -12,6 +12,15 @@ This command requires API key authentication.
 iai run-items create [flags]
 ```
 
+### Examples
+
+```
+  iai run-items create --run-name nightly-eval --dataset-item-id item-123
+  iai run-items create --run-name nightly-eval --dataset-item-id item-123 --trace-id trace-abc --observation-id obs-xyz
+  iai run-items create --run-name nightly-eval --dataset-item-id item-123 --run-description "Nightly regression run" --metadata-json '{"model":"v2"}'
+  iai run-items create --run-name nightly-eval --dataset-item-id item-123 --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_run-items_list.md
+++ b/docs/iai_run-items_list.md
@@ -10,6 +10,15 @@ List dataset run items. Requires at least one of --run-name or --dataset-name.
 iai run-items list [flags]
 ```
 
+### Examples
+
+```
+  iai run-items list --run-name nightly-eval
+  iai run-items list --dataset-name qa-set --page 2 --limit 50
+  iai run-items list --run-name nightly-eval --columns id,trace_id,created_at
+  iai run-items list --run-name nightly-eval --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_score-configs_create.md
+++ b/docs/iai_score-configs_create.md
@@ -12,6 +12,15 @@ This command requires API key authentication.
 iai score-configs create [flags]
 ```
 
+### Examples
+
+```
+  iai score-configs create --name accuracy --data-type NUMERIC --min-value 0 --max-value 1
+  iai score-configs create --name sentiment --data-type CATEGORICAL --categories '["positive","neutral","negative"]'
+  iai score-configs create --name passed --data-type BOOLEAN --description "Did the response pass review"
+  iai score-configs create --name accuracy --data-type NUMERIC --min-value 0 --max-value 1 --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_score-configs_get.md
+++ b/docs/iai_score-configs_get.md
@@ -10,6 +10,14 @@ Get detailed information about a score configuration.
 iai score-configs get <id> [flags]
 ```
 
+### Examples
+
+```
+  iai score-configs get sc_123
+  iai score-configs get sc_123 -o my-org -p my-project
+  iai score-configs get sc_123 --yaml
+```
+
 ### Options
 
 ```

--- a/docs/iai_score-configs_list.md
+++ b/docs/iai_score-configs_list.md
@@ -10,6 +10,15 @@ List scoring configurations with pagination.
 iai score-configs list [flags]
 ```
 
+### Examples
+
+```
+  iai score-configs list
+  iai score-configs list -o my-org -p my-project
+  iai score-configs list --page 2 --limit 50
+  iai score-configs list --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_score-configs_update.md
+++ b/docs/iai_score-configs_update.md
@@ -12,6 +12,15 @@ This command requires API key authentication.
 iai score-configs update <id> [flags]
 ```
 
+### Examples
+
+```
+  iai score-configs update sc_123 --description "Updated scoring rubric"
+  iai score-configs update sc_123 --min-value 0 --max-value 10
+  iai score-configs update sc_123 --categories '["pass","fail"]'
+  iai score-configs update sc_123 --is-archived --yaml
+```
+
 ### Options
 
 ```

--- a/docs/iai_scores_create.md
+++ b/docs/iai_scores_create.md
@@ -12,6 +12,14 @@ This command currently requires API key authentication.
 iai scores create [flags]
 ```
 
+### Examples
+
+```
+  iai scores create --name accuracy --value 0.95 --trace-id trace-abc123
+  iai scores create --name relevance --value 1 --data-type NUMERIC --observation-id obs-xyz789 --comment "looks good"
+  iai scores create --name sentiment --value positive --data-type CATEGORICAL --session-id sess-456 --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_scores_delete.md
+++ b/docs/iai_scores_delete.md
@@ -12,6 +12,13 @@ This command currently requires API key authentication.
 iai scores delete <score-id> [flags]
 ```
 
+### Examples
+
+```
+  iai scores delete score-abc123
+  iai scores delete score-abc123 -o my-org -p my-project
+```
+
 ### Options
 
 ```

--- a/docs/iai_scores_list.md
+++ b/docs/iai_scores_list.md
@@ -13,6 +13,15 @@ If --from-timestamp is not provided, defaults to 7 days ago.
 iai scores list [flags]
 ```
 
+### Examples
+
+```
+  iai scores list
+  iai scores list --name accuracy --data-type NUMERIC
+  iai scores list --from-timestamp 2026-01-01T00:00:00Z --to-timestamp 2026-02-01T00:00:00Z --limit 50
+  iai scores list --trace-id trace-abc123 --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_secrets_create.md
+++ b/docs/iai_secrets_create.md
@@ -16,6 +16,15 @@ When both are provided, --data values take precedence.
 iai secrets create [secret_name] [flags]
 ```
 
+### Examples
+
+```
+  iai secrets create my-secret -d API_KEY=abc123
+  iai secrets create my-secret -d API_KEY=abc123 -d DB_PASS=secret
+  iai secrets create my-secret --from-env-file .env
+  iai secrets create my-secret --from-env-file .env -d API_KEY=override -p my-project
+```
+
 ### Options
 
 ```

--- a/docs/iai_secrets_delete.md
+++ b/docs/iai_secrets_delete.md
@@ -10,6 +10,13 @@ Delete a secret in a specific project using the deployment service.
 iai secrets delete <secret_name> [flags]
 ```
 
+### Examples
+
+```
+  iai secrets delete my-secret
+  iai secrets delete my-secret -p my-project -o my-org
+```
+
 ### Options
 
 ```

--- a/docs/iai_secrets_get.md
+++ b/docs/iai_secrets_get.md
@@ -10,6 +10,14 @@ Get a secret in a specific project using the deployment service.
 iai secrets get <secret_name> [flags]
 ```
 
+### Examples
+
+```
+  iai secrets get my-secret
+  iai secrets get my-secret -p my-project
+  iai secrets get my-secret --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_secrets_list.md
+++ b/docs/iai_secrets_list.md
@@ -10,6 +10,14 @@ List secrets in a specific project.
 iai secrets list [flags]
 ```
 
+### Examples
+
+```
+  iai secrets list
+  iai secrets list -p my-project -o my-org
+  iai secrets list --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_secrets_update.md
+++ b/docs/iai_secrets_update.md
@@ -21,7 +21,13 @@ Secret data can be provided via:
 
 When both are provided, --data values take precedence.
 
-Examples:
+```
+iai secrets update <secret_name> [flags]
+```
+
+### Examples
+
+```
   # Update a single key (other keys preserved)
   iai secrets update my-secret -d API_KEY=new-value
 
@@ -36,9 +42,6 @@ Examples:
 
   # Remove multiple keys
   iai secrets update my-secret --remove KEY1 --remove KEY2
-
-```
-iai secrets update <secret_name> [flags]
 ```
 
 ### Options

--- a/docs/iai_services_create.md
+++ b/docs/iai_services_create.md
@@ -6,9 +6,17 @@ Create a service in a project
 
 Create a service in a specific project using the deployment service.
 
-
 ```
 iai services create <service_name> [flags]
+```
+
+### Examples
+
+```
+  iai services create my-svc --image-type external --image-repository docker.io --image-name nginx --image-tag latest --port 80 --memory 512M --cpu 0.5
+  iai services create my-svc --image-name my-app --image-tag v1 --port 8080 --memory 1G --cpu 1 --replicas 3 --endpoint
+  iai services create my-svc --image-name my-app --image-tag v1 --memory 512M --cpu 0.5 --env LOG_LEVEL=debug --secret DB_PASSWORD --healthcheck-path /health
+  iai services create my-svc --image-name my-app --image-tag v1 --memory 512M --cpu 0.5 --schedule-uptime "Mon-Fri 08:00-18:00" --schedule-timezone Europe/Berlin
 ```
 
 ### Options

--- a/docs/iai_services_delete.md
+++ b/docs/iai_services_delete.md
@@ -10,6 +10,13 @@ Delete a service from a specific project using the deployment service.
 iai services delete <service_name> [flags]
 ```
 
+### Examples
+
+```
+  iai services delete my-svc
+  iai services delete my-svc --project my-project
+```
+
 ### Options
 
 ```

--- a/docs/iai_services_describe.md
+++ b/docs/iai_services_describe.md
@@ -8,13 +8,16 @@ Show detailed information about a specific service including its configuration.
 
 Use --version to view a specific past version instead of the current state.
 
-Examples:
+```
+iai services describe <service_name> [flags]
+```
+
+### Examples
+
+```
   iai services describe my-service
   iai services describe my-service --version 3
   iai services describe my-service --json
-
-```
-iai services describe <service_name> [flags]
 ```
 
 ### Options

--- a/docs/iai_services_diff.md
+++ b/docs/iai_services_diff.md
@@ -6,11 +6,14 @@ Compare two revisions of a service
 
 Show the differences between two revisions of a service.
 
-Examples:
-  iai services diff my-service 1 3
-
 ```
 iai services diff <service_name> <revision_a> <revision_b> [flags]
+```
+
+### Examples
+
+```
+  iai services diff my-service 1 3
 ```
 
 ### Options

--- a/docs/iai_services_list.md
+++ b/docs/iai_services_list.md
@@ -10,6 +10,14 @@ List services in a specific project using the deployment service.
 iai services list [flags]
 ```
 
+### Examples
+
+```
+  iai services list
+  iai services list --project my-project
+  iai services list --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_services_log-fields.md
+++ b/docs/iai_services_log-fields.md
@@ -8,12 +8,15 @@ Scan recent logs and list the extra top-level fields present in structured (JSON
 
 Use the reported field names with 'iai services logs --fields' to include them in output.
 
-Examples:
-  iai services log-fields my-service
-  iai services log-fields my-service --since 1h
-
 ```
 iai services log-fields <service_name> [flags]
+```
+
+### Examples
+
+```
+  iai services log-fields my-service
+  iai services log-fields my-service --since 1h
 ```
 
 ### Options

--- a/docs/iai_services_logs.md
+++ b/docs/iai_services_logs.md
@@ -18,6 +18,15 @@ nested JSON values.
 iai services logs <service_name> [flags]
 ```
 
+### Examples
+
+```
+  iai services logs my-svc
+  iai services logs my-svc --follow
+  iai services logs my-svc --since 3h
+  iai services logs my-svc --fields logger,pid
+```
+
 ### Options
 
 ```

--- a/docs/iai_services_port-forward.md
+++ b/docs/iai_services_port-forward.md
@@ -11,13 +11,16 @@ The remote port defaults to the service's configured port. Use --port to
 override. Use --local-port to choose the local listening port (defaults to
 --port when set, or an available OS-assigned port otherwise).
 
-Examples:
+```
+iai services port-forward <service_name> [flags]
+```
+
+### Examples
+
+```
   iai services port-forward my-svc
   iai services port-forward my-svc --port 8080
   iai services port-forward my-svc --port 8080 --local-port 9090
-
-```
-iai services port-forward <service_name> [flags]
 ```
 
 ### Options

--- a/docs/iai_services_restart.md
+++ b/docs/iai_services_restart.md
@@ -10,6 +10,13 @@ Restart a service in a specific project using the deployment service.
 iai services restart <service_name> [flags]
 ```
 
+### Examples
+
+```
+  iai services restart my-svc
+  iai services restart my-svc --project my-project
+```
+
 ### Options
 
 ```

--- a/docs/iai_services_revisions.md
+++ b/docs/iai_services_revisions.md
@@ -7,11 +7,14 @@ List revisions of a service
 Show past revisions of a service, sorted newest-first.
 Up to 50 revisions are retained per service.
 
-Examples:
-  iai services revisions my-service
-
 ```
 iai services revisions <service_name> [flags]
+```
+
+### Examples
+
+```
+  iai services revisions my-service
 ```
 
 ### Options

--- a/docs/iai_services_update.md
+++ b/docs/iai_services_update.md
@@ -22,7 +22,13 @@ alongside either to change the timezone.
 Use --clear-env, --clear-secret, --clear-healthcheck, --clear-schedule, or
 --clear-stack-id to remove those configurations entirely.
 
-Examples:
+```
+iai services update <service_name> [flags]
+```
+
+### Examples
+
+```
   iai services update my-svc --image-tag v2
   iai services update my-svc --memory 1G --cpu 0.5
   iai services update my-svc --replicas 3
@@ -31,9 +37,6 @@ Examples:
   iai services update my-svc --clear-healthcheck
   iai services update my-svc --stack-id my-stack
   iai services update my-svc --clear-stack-id
-
-```
-iai services update <service_name> [flags]
 ```
 
 ### Options

--- a/docs/iai_sessions_get.md
+++ b/docs/iai_sessions_get.md
@@ -12,6 +12,14 @@ Uses the platform API with dual authentication (API key or session).
 iai sessions get <session-id> [flags]
 ```
 
+### Examples
+
+```
+  iai sessions get <session-id>
+  iai sessions get <session-id> --fields core,traces
+  iai sessions get <session-id> --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_sessions_list.md
+++ b/docs/iai_sessions_list.md
@@ -13,6 +13,15 @@ If --from-timestamp is not provided, defaults to 7 days ago.
 iai sessions list [flags]
 ```
 
+### Examples
+
+```
+  iai sessions list
+  iai sessions list --from-timestamp 2026-06-01T00:00:00Z --to-timestamp 2026-06-08T00:00:00Z
+  iai sessions list --environment production --limit 50 --page 2
+  iai sessions list --columns id,created_at,total_cost --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_skills_create.md
+++ b/docs/iai_skills_create.md
@@ -23,14 +23,17 @@ The server automatically assigns the "latest" label to new versions. To make
 a version retrievable via the default 'get' (which resolves "production"),
 assign the "production" label with --labels production.
 
-Examples:
+```
+iai skills create <name> [flags]
+```
+
+### Examples
+
+```
   iai skills create summarize-trace --file ./skill.md \
     --description "Summarize a Langfuse trace" \
     --intents "summarize trace" --intents "explain trace"
   iai skills create summarize-trace --file ./skill.md --labels production
-
-```
-iai skills create <name> [flags]
 ```
 
 ### Options

--- a/docs/iai_skills_delete.md
+++ b/docs/iai_skills_delete.md
@@ -10,14 +10,17 @@ Without flags, deletes the skill and all its versions (requires confirmation).
 Use --version to delete a specific version, or --label to delete versions
 with a specific label. Use -f to skip the confirmation prompt.
 
-Examples:
+```
+iai skills delete <name> [flags]
+```
+
+### Examples
+
+```
   iai skills delete summarize-trace
   iai skills delete summarize-trace -f
   iai skills delete summarize-trace --version 3
   iai skills delete summarize-trace --label staging
-
-```
-iai skills delete <name> [flags]
 ```
 
 ### Options

--- a/docs/iai_skills_diff.md
+++ b/docs/iai_skills_diff.md
@@ -6,11 +6,14 @@ Compare two versions of a skill
 
 Show the differences between two versions of a skill.
 
-Examples:
-  iai skills diff my-skill 1 3
-
 ```
 iai skills diff <name> <version_a> <version_b> [flags]
+```
+
+### Examples
+
+```
+  iai skills diff my-skill 1 3
 ```
 
 ### Options

--- a/docs/iai_skills_get.md
+++ b/docs/iai_skills_get.md
@@ -9,13 +9,16 @@ Show a Copilot skill in detail, including its config and full content.
 By default returns the version labeled "production". Use --version to retrieve a
 specific version number, or --label to resolve a different label.
 
-Examples:
+```
+iai skills get <name> [flags]
+```
+
+### Examples
+
+```
   iai skills get summarize-trace
   iai skills get summarize-trace --version 3
   iai skills get summarize-trace --label staging
-
-```
-iai skills get <name> [flags]
 ```
 
 ### Options

--- a/docs/iai_skills_list.md
+++ b/docs/iai_skills_list.md
@@ -10,13 +10,16 @@ Returns all Copilot skills with their name, labels, tags, and last update time.
 Folders are shown with a trailing "/" (colored when stdout is a terminal) and
 can be browsed into with --folder.
 
-Examples:
+```
+iai skills list [flags]
+```
+
+### Examples
+
+```
   iai skills list
   iai skills list --folder my-folder
   iai skills list --page 2 --limit 10
-
-```
-iai skills list [flags]
 ```
 
 ### Options

--- a/docs/iai_skills_update.md
+++ b/docs/iai_skills_update.md
@@ -15,14 +15,17 @@ want the new version to keep them.
 
 Pass --intents once per intent (the flag is repeatable).
 
-Examples:
+```
+iai skills update <name> [flags]
+```
+
+### Examples
+
+```
   iai skills update summarize-trace --file ./skill.md \
     --description "Summarize a Langfuse trace" \
     --intents "summarize trace" --intents "explain trace"
   iai skills update summarize-trace --file ./skill.md --labels production,staging
-
-```
-iai skills update <name> [flags]
 ```
 
 ### Options

--- a/docs/iai_skills_versions.md
+++ b/docs/iai_skills_versions.md
@@ -6,11 +6,14 @@ List versions of a skill
 
 List all versions of a skill, sorted newest-first.
 
-Examples:
-  iai skills versions my-skill
-
 ```
 iai skills versions <name> [flags]
+```
+
+### Examples
+
+```
+  iai skills versions my-skill
 ```
 
 ### Options

--- a/docs/iai_stacks_sync.md
+++ b/docs/iai_stacks_sync.md
@@ -16,6 +16,14 @@ The organization and project are read from the config file, flags, or resolved v
 iai stacks sync [flags]
 ```
 
+### Examples
+
+```
+  iai stacks sync --file stack.yaml
+  iai stacks sync --file stack.yaml --project my-project --organization my-org
+  iai stacks sync --file stack.yaml --allow-delete databases
+```
+
 ### Example config file
 
 ```yaml

--- a/docs/iai_traces_delete.md
+++ b/docs/iai_traces_delete.md
@@ -8,13 +8,16 @@ Delete a single trace or bulk delete multiple traces.
 
 This command currently requires API key authentication.
 
-Examples:
+```
+iai traces delete [trace-id] [flags]
+```
+
+### Examples
+
+```
   iai traces delete trace-123
   iai traces delete --ids trace-1,trace-2
   iai traces delete --ids trace-1 --ids trace-2 -f
-
-```
-iai traces delete [trace-id] [flags]
 ```
 
 ### Options

--- a/docs/iai_traces_get.md
+++ b/docs/iai_traces_get.md
@@ -8,13 +8,16 @@ Get detailed information about a specific trace.
 
 Uses the platform API with dual authentication (API key or session).
 
-Examples:
+```
+iai traces get <trace-id> [flags]
+```
+
+### Examples
+
+```
   iai traces get abc123
   iai traces get abc123 --fields core,io,metrics
   iai traces get abc123 --json | jq '.data.trace'
-
-```
-iai traces get <trace-id> [flags]
 ```
 
 ### Options

--- a/docs/iai_traces_list.md
+++ b/docs/iai_traces_list.md
@@ -9,7 +9,13 @@ List traces with optional filters.
 Uses the platform API with dual authentication (API key or session).
 If --from-timestamp is not provided, defaults to 7 days ago.
 
-Examples:
+```
+iai traces list [flags]
+```
+
+### Examples
+
+```
   iai traces list
   iai traces list --limit 20 --page 2
   iai traces list --name my-trace --user-id user123
@@ -23,9 +29,6 @@ Examples:
   iai traces list --fields core,io,metrics
   iai traces list --json | jq '.data.traces[].name'
   iai traces list --columns id,name,latency,total_tokens,level
-
-```
-iai traces list [flags]
 ```
 
 ### Options

--- a/docs/iai_variables_create.md
+++ b/docs/iai_variables_create.md
@@ -30,6 +30,15 @@ Run `iai variables schema` to see the current field definitions.
 Each key under `variables` must be unique. Add as many entries as you need —
 the set accepts any number of variables.
 
+### Examples
+
+```
+  iai variables create session-vars --file variables.json
+  iai variables create session-vars --file variables.json --schema-version 2.1.0
+  iai variables create session-vars --file variables.json --labels production
+  iai variables create session-vars --file variables.json --tags core
+```
+
 ### Options
 
 ```

--- a/docs/iai_variables_delete.md
+++ b/docs/iai_variables_delete.md
@@ -10,14 +10,17 @@ Without flags, deletes the variable and all its versions (requires confirmation)
 Use --version to delete a specific version, or --label to delete versions with a
 specific label. Use -f to skip the confirmation prompt.
 
-Examples:
+```
+iai variables delete <name> [flags]
+```
+
+### Examples
+
+```
   iai variables delete session-vars
   iai variables delete session-vars -f
   iai variables delete session-vars --version 3
   iai variables delete session-vars --label staging
-
-```
-iai variables delete <name> [flags]
 ```
 
 ### Options

--- a/docs/iai_variables_diff.md
+++ b/docs/iai_variables_diff.md
@@ -6,11 +6,14 @@ Compare two versions of a variable
 
 Show the differences between two versions of a variable.
 
-Examples:
-  iai variables diff my-variable 1 3
-
 ```
 iai variables diff <name> <version_a> <version_b> [flags]
+```
+
+### Examples
+
+```
+  iai variables diff my-variable 1 3
 ```
 
 ### Options

--- a/docs/iai_variables_get.md
+++ b/docs/iai_variables_get.md
@@ -9,13 +9,16 @@ Show detailed information about a specific variable definition, including its fu
 By default returns the version labeled "production". Use --version to retrieve a
 specific version number, or --label to resolve a different label.
 
-Examples:
+```
+iai variables get <name> [flags]
+```
+
+### Examples
+
+```
   iai variables get session-vars
   iai variables get session-vars --version 3
   iai variables get session-vars --label staging
-
-```
-iai variables get <name> [flags]
 ```
 
 ### Options

--- a/docs/iai_variables_list.md
+++ b/docs/iai_variables_list.md
@@ -10,14 +10,17 @@ Returns all variables with their name, labels, tags, and last update time.
 Folders are shown with a trailing "/" (colored when stdout is a terminal) and
 can be browsed into with --folder.
 
-Examples:
+```
+iai variables list [flags]
+```
+
+### Examples
+
+```
   iai variables list
   iai variables list --folder my-folder
   iai variables list --folder my-folder/sub-folder
   iai variables list --page 2 --limit 10
-
-```
-iai variables list [flags]
 ```
 
 ### Options

--- a/docs/iai_variables_schema.md
+++ b/docs/iai_variables_schema.md
@@ -15,6 +15,14 @@ This is a public endpoint and does not require authentication.
 iai variables schema [flags]
 ```
 
+### Examples
+
+```
+  iai variables schema
+  iai variables schema --schema-version 0.0.1
+  iai variables schema --json
+```
+
 ### Options
 
 ```

--- a/docs/iai_variables_update.md
+++ b/docs/iai_variables_update.md
@@ -32,6 +32,14 @@ Run `iai variables schema` to see the current field definitions.
 Each key under `variables` must be unique. Add as many entries as you need —
 the set accepts any number of variables.
 
+### Examples
+
+```
+  iai variables update session-vars --file variables.json
+  iai variables update session-vars --file variables.json --schema-version 2.1.0
+  iai variables update session-vars --file variables.json --labels production,staging
+```
+
 ### Options
 
 ```

--- a/docs/iai_variables_versions.md
+++ b/docs/iai_variables_versions.md
@@ -6,11 +6,14 @@ List versions of a variable
 
 List all versions of a variable, sorted newest-first.
 
-Examples:
-  iai variables versions my-variable
-
 ```
 iai variables versions <name> [flags]
+```
+
+### Examples
+
+```
+  iai variables versions my-variable
 ```
 
 ### Options


### PR DESCRIPTION
Refs DEV-786.

## What
Scan all CLI commands and add usage examples to the leaf commands that were missing them (e.g. `service create`, the example called out in the issue).

While doing so, standardize on Cobra's native `Example:` field instead of embedding examples inside the `Long:` description. Cobra renders `Long` into the markdown "Synopsis" as a plain paragraph, which collapsed the indentation/newlines of the example block (it looked fine in `--help` but wrapped/ran together in the generated docs). The `Example:` field renders inside a fenced code block, so both `--help` and the markdown look correct.

## Changes
- Add examples to every leaf command that lacked them.
- Migrate **all** example blocks (new and pre-existing) from `Long:` into the native `Example:` field — including the templated prompt-type system (`routines`/`policies`/`variables`/`glossaries`/`macros`, via new `*Example` fields on `PromptTypeConfig`) and `skills`.
- Regenerate `docs/`.

## Verification
- `gofmt` clean, `go build ./...` passes, `go test ./...` passes.
- No `Examples:` blocks remain embedded in any `Long:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)