### PR TITLE
Fix log timestamps and shorten replica IDs

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.34.4"
+current_version = "0.34.5"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -379,14 +379,15 @@ var agentRestartCmd = &cobra.Command{
 }
 
 var (
-	agentLogsFollow    bool
-	agentLogsSince     string
-	agentLogsStartTime string
-	agentLogsEndTime   string
-	agentLogsRaw       bool
-	agentLogsDecode    bool
-	agentLogsFields    []string
-	agentLogsAllFields bool
+	agentLogsFollow     bool
+	agentLogsSince      string
+	agentLogsStartTime  string
+	agentLogsEndTime    string
+	agentLogsRaw        bool
+	agentLogsDecode     bool
+	agentLogsFields     []string
+	agentLogsAllFields  bool
+	agentLogsTimestamps bool
 )
 
 var agentLogsCmd = &cobra.Command{
@@ -404,6 +405,7 @@ nested JSON values.`,
 	Example: `  iai agents logs my-agent
   iai agents logs my-agent --follow
   iai agents logs my-agent --since 30m
+  iai agents logs my-agent --timestamps
   iai agents logs my-agent --start-time 2026-01-01T00:00:00Z --end-time 2026-01-01T01:00:00Z`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -449,10 +451,11 @@ nested JSON values.`,
 			Empty:     logsResp.Empty,
 		}
 		fmtOpts := output.LogFormatOptions{
-			Raw:       agentLogsRaw || agentLogsDecode,
-			Decode:    agentLogsDecode,
-			Fields:    agentLogsFields,
-			AllFields: agentLogsAllFields,
+			Raw:        agentLogsRaw || agentLogsDecode,
+			Decode:     agentLogsDecode,
+			Fields:     agentLogsFields,
+			AllFields:  agentLogsAllFields,
+			Timestamps: agentLogsTimestamps,
 		}
 		err = output.PrintLogStream(out, logsResp.Body, true, meta, fmtOpts)
 		if agentLogsFollow && ctx.Err() != nil {
@@ -881,6 +884,8 @@ func init() {
 		StringSliceVar(&agentLogsFields, "fields", nil, "Additional fields to show after the message for structured (JSON) logs (e.g. --fields logger,pid); ignored for plain-text logs; use --raw for exact server JSON")
 	agentLogsCmd.Flags().
 		BoolVar(&agentLogsAllFields, "all-fields", false, "Show all extra top-level fields from structured (JSON) logs after the message")
+	agentLogsCmd.Flags().
+		BoolVar(&agentLogsTimestamps, "timestamps", false, "Include platform log timestamps")
 	agentLogsCmd.MarkFlagsMutuallyExclusive("raw", "fields")
 	agentLogsCmd.MarkFlagsMutuallyExclusive("raw", "all-fields")
 	agentLogsCmd.MarkFlagsMutuallyExclusive("decode", "fields")

--- a/cmd/databases.go
+++ b/cmd/databases.go
@@ -39,14 +39,15 @@ var (
 	dbSourceDatabase string
 	dbTargetTime     string
 
-	dbLogsFollow    bool
-	dbLogsSince     string
-	dbLogsStartTime string
-	dbLogsEndTime   string
-	dbLogsRaw       bool
-	dbLogsDecode    bool
-	dbLogsFields    []string
-	dbLogsAllFields bool
+	dbLogsFollow     bool
+	dbLogsSince      string
+	dbLogsStartTime  string
+	dbLogsEndTime    string
+	dbLogsRaw        bool
+	dbLogsDecode     bool
+	dbLogsFields     []string
+	dbLogsAllFields  bool
+	dbLogsTimestamps bool
 )
 
 var databasesCmd = &cobra.Command{
@@ -318,6 +319,7 @@ JSON strings into nested JSON values.`,
 	Example: `  iai databases logs my-db
   iai databases logs my-db --follow
   iai databases logs my-db --since 30m
+  iai databases logs my-db --timestamps
   iai databases logs my-db --start-time 2026-01-01T00:00:00Z --end-time 2026-01-01T01:00:00Z`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -378,6 +380,7 @@ JSON strings into nested JSON values.`,
 			Fields:     dbLogsFields,
 			AllFields:  dbLogsAllFields,
 			CNPGFormat: true,
+			Timestamps: dbLogsTimestamps,
 		}
 		err = output.PrintLogStream(out, logsResp.Body, true, meta, fmtOpts)
 		if dbLogsFollow && ctx.Err() != nil {
@@ -695,6 +698,8 @@ func init() {
 		StringSliceVar(&dbLogsFields, "fields", nil, "Additional fields to show after the message for structured (JSON) logs (e.g. --fields record); ignored for plain-text logs; use --raw for exact server JSON")
 	dbLogsCmd.Flags().
 		BoolVar(&dbLogsAllFields, "all-fields", false, "Show all extra top-level fields from structured (JSON) logs after the message")
+	dbLogsCmd.Flags().
+		BoolVar(&dbLogsTimestamps, "timestamps", false, "Include platform log timestamps")
 	dbLogsCmd.MarkFlagsMutuallyExclusive("raw", "fields")
 	dbLogsCmd.MarkFlagsMutuallyExclusive("raw", "all-fields")
 	dbLogsCmd.MarkFlagsMutuallyExclusive("decode", "fields")

--- a/cmd/replicas.go
+++ b/cmd/replicas.go
@@ -128,14 +128,15 @@ var replicasDescribeCmd = &cobra.Command{
 }
 
 var (
-	replicaLogsFollow    bool
-	replicaLogsSince     string
-	replicaLogsStartTime string
-	replicaLogsEndTime   string
-	replicaLogsRaw       bool
-	replicaLogsDecode    bool
-	replicaLogsFields    []string
-	replicaLogsAllFields bool
+	replicaLogsFollow     bool
+	replicaLogsSince      string
+	replicaLogsStartTime  string
+	replicaLogsEndTime    string
+	replicaLogsRaw        bool
+	replicaLogsDecode     bool
+	replicaLogsFields     []string
+	replicaLogsAllFields  bool
+	replicaLogsTimestamps bool
 )
 
 var replicasLogsCmd = &cobra.Command{
@@ -153,6 +154,7 @@ nested JSON values.`,
 	Example: `  iai replicas logs my-service-abc123
   iai replicas logs my-service-abc123 --follow
   iai replicas logs my-service-abc123 --since 30m --fields logger,pid
+  iai replicas logs my-service-abc123 --timestamps
   iai replicas logs my-service-abc123 --start-time 2026-01-01T00:00:00Z --end-time 2026-01-01T01:00:00Z`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -237,10 +239,11 @@ nested JSON values.`,
 			Empty:     logsResp.Empty,
 		}
 		fmtOpts := output.LogFormatOptions{
-			Raw:       replicaLogsRaw || replicaLogsDecode,
-			Decode:    replicaLogsDecode,
-			Fields:    replicaLogsFields,
-			AllFields: replicaLogsAllFields,
+			Raw:        replicaLogsRaw || replicaLogsDecode,
+			Decode:     replicaLogsDecode,
+			Fields:     replicaLogsFields,
+			AllFields:  replicaLogsAllFields,
+			Timestamps: replicaLogsTimestamps,
 		}
 		err = output.PrintLogStream(out, logsResp.Body, false, meta, fmtOpts)
 		if replicaLogsFollow && ctx.Err() != nil {
@@ -352,6 +355,8 @@ func init() {
 		StringSliceVar(&replicaLogsFields, "fields", nil, "Additional fields to show after the message for structured (JSON) logs (e.g. --fields logger,pid); ignored for plain-text logs; use --raw for exact server JSON")
 	replicasLogsCmd.Flags().
 		BoolVar(&replicaLogsAllFields, "all-fields", false, "Show all extra top-level fields from structured (JSON) logs after the message")
+	replicasLogsCmd.Flags().
+		BoolVar(&replicaLogsTimestamps, "timestamps", false, "Include platform log timestamps")
 	replicasLogsCmd.MarkFlagsMutuallyExclusive("raw", "fields")
 	replicasLogsCmd.MarkFlagsMutuallyExclusive("raw", "all-fields")
 	replicasLogsCmd.MarkFlagsMutuallyExclusive("decode", "fields")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version            = "0.34.4"
+	version            = "0.34.5"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -438,14 +438,15 @@ var servRestartCmd = &cobra.Command{
 }
 
 var (
-	servLogsFollow    bool
-	servLogsSince     string
-	servLogsStartTime string
-	servLogsEndTime   string
-	servLogsRaw       bool
-	servLogsDecode    bool
-	servLogsFields    []string
-	servLogsAllFields bool
+	servLogsFollow     bool
+	servLogsSince      string
+	servLogsStartTime  string
+	servLogsEndTime    string
+	servLogsRaw        bool
+	servLogsDecode     bool
+	servLogsFields     []string
+	servLogsAllFields  bool
+	servLogsTimestamps bool
 )
 
 var servLogsCmd = &cobra.Command{
@@ -463,6 +464,7 @@ nested JSON values.`,
 	Example: `  iai services logs my-svc
   iai services logs my-svc --follow
   iai services logs my-svc --since 3h
+  iai services logs my-svc --timestamps
   iai services logs my-svc --fields logger,pid`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -518,10 +520,11 @@ nested JSON values.`,
 			Empty:     logsResp.Empty,
 		}
 		fmtOpts := output.LogFormatOptions{
-			Raw:       servLogsRaw || servLogsDecode,
-			Decode:    servLogsDecode,
-			Fields:    servLogsFields,
-			AllFields: servLogsAllFields,
+			Raw:        servLogsRaw || servLogsDecode,
+			Decode:     servLogsDecode,
+			Fields:     servLogsFields,
+			AllFields:  servLogsAllFields,
+			Timestamps: servLogsTimestamps,
 		}
 		err = output.PrintLogStream(out, logsResp.Body, true, meta, fmtOpts)
 		if servLogsFollow && ctx.Err() != nil {
@@ -991,6 +994,8 @@ func init() {
 		StringSliceVar(&servLogsFields, "fields", nil, "Additional fields to show after the message for structured (JSON) logs (e.g. --fields logger,pid); ignored for plain-text logs; use --raw for exact server JSON")
 	servLogsCmd.Flags().
 		BoolVar(&servLogsAllFields, "all-fields", false, "Show all extra top-level fields from structured (JSON) logs after the message")
+	servLogsCmd.Flags().
+		BoolVar(&servLogsTimestamps, "timestamps", false, "Include platform log timestamps")
 	servLogsCmd.MarkFlagsMutuallyExclusive("raw", "fields")
 	servLogsCmd.MarkFlagsMutuallyExclusive("raw", "all-fields")
 	servLogsCmd.MarkFlagsMutuallyExclusive("decode", "fields")

--- a/docs/iai_agents_logs.md
+++ b/docs/iai_agents_logs.md
@@ -24,6 +24,7 @@ iai agents logs <agent_name> [flags]
   iai agents logs my-agent
   iai agents logs my-agent --follow
   iai agents logs my-agent --since 30m
+  iai agents logs my-agent --timestamps
   iai agents logs my-agent --start-time 2026-01-01T00:00:00Z --end-time 2026-01-01T01:00:00Z
 ```
 
@@ -41,6 +42,7 @@ iai agents logs <agent_name> [flags]
       --raw                   Output exact server JSON lines without formatting
       --since string          Relative duration to look back (e.g. 30m, 1h, 3d, 1w); default 1h; max 72h; mutually exclusive with --start-time and --end-time
       --start-time string     Absolute RFC3339 start timestamp (e.g. 2026-02-24T10:00:00Z); mutually exclusive with --since; max 72h window
+      --timestamps            Include platform log timestamps
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_databases_logs.md
+++ b/docs/iai_databases_logs.md
@@ -25,6 +25,7 @@ iai databases logs <database_name> [flags]
   iai databases logs my-db
   iai databases logs my-db --follow
   iai databases logs my-db --since 30m
+  iai databases logs my-db --timestamps
   iai databases logs my-db --start-time 2026-01-01T00:00:00Z --end-time 2026-01-01T01:00:00Z
 ```
 
@@ -42,6 +43,7 @@ iai databases logs <database_name> [flags]
       --raw                   Output exact server JSON lines without formatting
       --since string          Relative duration to look back (e.g. 30m, 1h, 3d, 1w); default 1h; max 72h; mutually exclusive with --start-time and --end-time
       --start-time string     Absolute RFC3339 start timestamp (e.g. 2026-02-24T10:00:00Z); mutually exclusive with --since; max 72h window
+      --timestamps            Include platform log timestamps
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_replicas_logs.md
+++ b/docs/iai_replicas_logs.md
@@ -24,6 +24,7 @@ iai replicas logs <replica_name> [flags]
   iai replicas logs my-service-abc123
   iai replicas logs my-service-abc123 --follow
   iai replicas logs my-service-abc123 --since 30m --fields logger,pid
+  iai replicas logs my-service-abc123 --timestamps
   iai replicas logs my-service-abc123 --start-time 2026-01-01T00:00:00Z --end-time 2026-01-01T01:00:00Z
 ```
 
@@ -41,6 +42,7 @@ iai replicas logs <replica_name> [flags]
       --raw                   Output exact server JSON lines without formatting
       --since string          Relative duration to look back (e.g. 30m, 1h, 3d, 1w); default 1h; max 72h; mutually exclusive with --start-time and --end-time
       --start-time string     Absolute RFC3339 start timestamp (e.g. 2026-02-24T10:00:00Z); mutually exclusive with --since; max 72h window
+      --timestamps            Include platform log timestamps
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_services_logs.md
+++ b/docs/iai_services_logs.md
@@ -24,6 +24,7 @@ iai services logs <service_name> [flags]
   iai services logs my-svc
   iai services logs my-svc --follow
   iai services logs my-svc --since 3h
+  iai services logs my-svc --timestamps
   iai services logs my-svc --fields logger,pid
 ```
 
@@ -41,6 +42,7 @@ iai services logs <service_name> [flags]
       --raw                   Output exact server JSON lines without formatting
       --since string          Relative duration to look back (e.g. 30m, 1h, 3d, 1w); default 1h; max 72h; mutually exclusive with --start-time and --end-time
       --start-time string     Absolute RFC3339 start timestamp (e.g. 2026-02-24T10:00:00Z); mutually exclusive with --since; max 72h window
+      --timestamps            Include platform log timestamps
 ```
 
 ### Options inherited from parent commands

--- a/internal/output/logs.go
+++ b/internal/output/logs.go
@@ -5,16 +5,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"golang.org/x/term"
 )
 
 type logEntry struct {
-	Replica string `json:"replica,omitempty"`
-	Line    string `json:"line"`
+	Replica   string `json:"replica,omitempty"`
+	Timestamp string `json:"timestamp,omitempty"`
+	Line      string `json:"line"`
 }
 
 var replicaColors = []string{
@@ -65,6 +69,7 @@ type LogFormatOptions struct {
 	Fields     []string
 	AllFields  bool
 	CNPGFormat bool
+	Timestamps bool
 }
 
 // Informational messages are written to stderr so they don't pollute
@@ -112,9 +117,13 @@ func PrintLogStream(
 			continue
 		}
 
-		prefix := replicaPrefix(showReplica, entry.Replica, useColor, colorMap, &nextColor)
-
-		mainLine, extras, _ := formatLogLine(entry.Line, useColor, opts)
+		mainLine, extras := formatLogLine(entry.Line, useColor, opts)
+		timestampPart := ""
+		if opts.Timestamps && entry.Timestamp != "" {
+			timestampPart = formatLogTimestamp(entry.Timestamp) + " "
+		}
+		replicaPart := replicaPrefix(showReplica, entry.Replica, useColor, colorMap, &nextColor)
+		prefix := timestampPart + replicaPart
 		if extras != "" {
 			fmt.Fprintf(out, "%s%s  %s\n", prefix, mainLine, extras)
 		} else {
@@ -147,10 +156,10 @@ func formatLogLine(
 	line string,
 	useColor bool,
 	opts LogFormatOptions,
-) (string, string, []string) {
+) (string, string) {
 	var fields map[string]any
 	if err := json.Unmarshal([]byte(line), &fields); err != nil {
-		return line, "", nil
+		return line, ""
 	}
 
 	level := extractString(fields, "level")
@@ -173,7 +182,7 @@ func formatLogLine(
 	}
 
 	if level == "" && msg == "" {
-		return line, "", nil
+		return line, ""
 	}
 
 	var extraKeys []string
@@ -196,7 +205,7 @@ func formatLogLine(
 	}
 	extras := formatExtras(fields, showFields, useColor)
 
-	return b.String(), extras, extraKeys
+	return b.String(), extras
 }
 
 func replicaPrefix(
@@ -209,8 +218,9 @@ func replicaPrefix(
 	if !show || replica == "" {
 		return ""
 	}
+	displayReplica := trimReplicaSuffix(replica)
 	if !useColor {
-		return fmt.Sprintf("[%s] ", replica)
+		return fmt.Sprintf("[%s] ", displayReplica)
 	}
 	c, ok := colorMap[replica]
 	if !ok {
@@ -218,7 +228,14 @@ func replicaPrefix(
 		colorMap[replica] = c
 		*nextColor++
 	}
-	return fmt.Sprintf("%s[%s]%s ", c, replica, colorReset)
+	return fmt.Sprintf("%s[%s]%s ", c, displayReplica, colorReset)
+}
+
+func trimReplicaSuffix(replica string) string {
+	if i := strings.LastIndex(replica, "-"); i >= 0 && i+1 < len(replica) {
+		return replica[i+1:]
+	}
+	return replica
 }
 
 func formatLevel(level string, useColor bool) string {
@@ -275,6 +292,29 @@ func decodeLineField(line []byte) []byte {
 		return line
 	}
 	return encoded
+}
+
+func formatLogTimestamp(timestamp string) string {
+	if t, ok := parseLogUnixTimestamp(timestamp); ok {
+		return t.Local().Format("2006-01-02 15:04:05 MST")
+	}
+	return LocalTime(timestamp)
+}
+
+func parseLogUnixTimestamp(timestamp string) (time.Time, bool) {
+	if i, err := strconv.ParseInt(timestamp, 10, 64); err == nil {
+		if i >= 1e15 || i <= -1e15 {
+			return time.Unix(0, i), true
+		}
+		return time.Unix(i, 0), true
+	}
+
+	f, err := strconv.ParseFloat(timestamp, 64)
+	if err != nil {
+		return time.Time{}, false
+	}
+	sec, frac := math.Modf(f)
+	return time.Unix(int64(sec), int64(frac*1e9)), true
 }
 
 func extractString(m map[string]any, key string) string {

--- a/internal/output/logs_test.go
+++ b/internal/output/logs_test.go
@@ -41,10 +41,10 @@ func TestPrintLogStream(t *testing.T) {
 			want:  "hello\n",
 		},
 		{
-			name:        "JSON entry with replica and showReplica true prints prefix without color",
+			name:        "JSON entry with replica and showReplica true keeps suffix",
 			input:       `{"replica":"pod-1","line":"hello"}` + "\n",
 			showReplica: true,
-			want:        "[pod-1] hello\n",
+			want:        "[1] hello\n",
 		},
 		{
 			name:        "JSON entry with empty replica and showReplica true prints line only",
@@ -58,9 +58,9 @@ func TestPrintLogStream(t *testing.T) {
 				`{"replica":"pod-2","line":"second"}` + "\n" +
 				`{"replica":"pod-1","line":"third"}` + "\n",
 			showReplica: true,
-			want: "[pod-1] first\n" +
-				"[pod-2] second\n" +
-				"[pod-1] third\n",
+			want: "[1] first\n" +
+				"[2] second\n" +
+				"[1] third\n",
 		},
 		{
 			name: "mixed JSON and non-JSON lines",
@@ -94,6 +94,8 @@ func TestPrintLogStream(t *testing.T) {
 }
 
 func TestPrintLogStreamStructuredJSON(t *testing.T) {
+	t.Setenv("TZ", "Europe/Madrid")
+
 	tests := []struct {
 		name        string
 		input       string
@@ -103,8 +105,19 @@ func TestPrintLogStreamStructuredJSON(t *testing.T) {
 	}{
 		{
 			name:  "structured JSON log extracts level and msg",
-			input: `{"line":"{\"level\":\"info\",\"msg\":\"Starting up\",\"ts\":\"2026-01-01T00:00:00Z\"}"}` + "\n",
+			input: `{"line":"{\"level\":\"info\",\"msg\":\"Starting up\",\"ts\":\"ignored\"}"}` + "\n",
 			want:  "INFO  Starting up\n",
+		},
+		{
+			name:  "outer timestamp is hidden by default",
+			input: `{"timestamp":"1749983400000000000","line":"{\"level\":\"info\",\"msg\":\"hello\"}"}` + "\n",
+			want:  "INFO  hello\n",
+		},
+		{
+			name:  "timestamps flag prefixes formatted log",
+			input: `{"timestamp":"1749983400000000000","line":"{\"level\":\"info\",\"msg\":\"hello\"}"}` + "\n",
+			opts:  LogFormatOptions{Timestamps: true},
+			want:  "2025-06-15 12:30:00 CEST INFO  hello\n",
 		},
 		{
 			name:  "structured JSON with message field instead of msg",
@@ -135,6 +148,12 @@ func TestPrintLogStreamStructuredJSON(t *testing.T) {
 			want:  "plain text log\n",
 		},
 		{
+			name:  "timestamps flag prefixes plain text log",
+			input: `{"timestamp":"1749983400000000000","line":"plain text log"}` + "\n",
+			opts:  LogFormatOptions{Timestamps: true},
+			want:  "2025-06-15 12:30:00 CEST plain text log\n",
+		},
+		{
 			name:  "raw with decode preserves plain-text line field",
 			input: `{"line":"plain text","replica":"pod-1"}` + "\n",
 			opts:  LogFormatOptions{Raw: true, Decode: true},
@@ -144,7 +163,7 @@ func TestPrintLogStreamStructuredJSON(t *testing.T) {
 			name:        "structured JSON with replica prefix",
 			input:       `{"replica":"db-1","line":"{\"level\":\"warning\",\"msg\":\"low memory\"}"}` + "\n",
 			showReplica: true,
-			want:        "[db-1] WARNING low memory\n",
+			want:        "[1] WARNING low memory\n",
 		},
 		{
 			name:  "all-fields flag shows all extra fields sorted",


### PR DESCRIPTION
## Summary
- restore timestamps in formatted log output
- convert Unix nanosecond log timestamps to local time
- shorten replica prefixes to the suffix after the last hyphen

## Tests
- go test ./internal/output ./cmd