### PR TITLE
feat(summary): render full untruncated trace/session content

### DIFF
--- a/internal/output/summary.go
+++ b/internal/output/summary.go
@@ -10,28 +10,6 @@ import (
 	"github.com/Interactive-AI-Labs/interactive-cli/internal/summary"
 )
 
-// Display limits for the summary views.
-const (
-	maxValueLen      = 500 // tool args/results and trace input/reply
-	maxSessionMsgLen = 160 // per-turn messages in the session overview
-	maxKBTitleLen    = 80  // an individual retrieved knowledge-base document title
-)
-
-// truncateValue trims whitespace and caps s to max runes, appending a marker.
-func truncateValue(s string, max int) string {
-	s = strings.TrimSpace(s)
-	// Byte length is an upper bound on rune count, so a short string needs no
-	// rune conversion (the common case for ASCII content).
-	if len(s) <= max {
-		return s
-	}
-	r := []rune(s)
-	if len(r) <= max {
-		return s
-	}
-	return string(r[:max]) + "… (truncated)"
-}
-
 // compactArgs renders tool arguments as `k=v, k=v` (keys sorted) for a flat
 // object, falling back to compact JSON for anything else.
 func compactArgs(raw json.RawMessage) string {

--- a/internal/output/summary_sessions.go
+++ b/internal/output/summary_sessions.go
@@ -40,7 +40,7 @@ func PrintSessionSummary(out io.Writer, m *summary.SessionSummaryModel) error {
 			fmt.Sprintf(
 				"Turn %-3d Customer: %s\n",
 				turn.Number,
-				truncateValue(turn.Customer, maxSessionMsgLen),
+				strings.TrimSpace(turn.Customer),
 			),
 		)
 
@@ -55,7 +55,7 @@ func PrintSessionSummary(out io.Writer, m *summary.SessionSummaryModel) error {
 			b.WriteString(sessionIndent + strings.Join(tags, " ") + "\n")
 		}
 
-		if agent := truncateValue(turn.Agent, maxSessionMsgLen); agent != "" {
+		if agent := strings.TrimSpace(turn.Agent); agent != "" {
 			b.WriteString(sessionIndent + "Agent: " + agent + "\n")
 		}
 	}

--- a/internal/output/summary_test.go
+++ b/internal/output/summary_test.go
@@ -5,26 +5,6 @@ import (
 	"testing"
 )
 
-func TestTruncateValue(t *testing.T) {
-	cases := []struct {
-		name string
-		in   string
-		max  int
-		want string
-	}{
-		{"trims and truncates with marker", "  abcdef  ", 3, "abc… (truncated)"},
-		{"short multibyte string untouched", "héllo", 10, "héllo"},
-		{"exact length untouched", "abc", 3, "abc"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := truncateValue(tc.in, tc.max); got != tc.want {
-				t.Fatalf("truncateValue(%q, %d) = %q, want %q", tc.in, tc.max, got, tc.want)
-			}
-		})
-	}
-}
-
 func TestCompactArgs(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/output/summary_traces.go
+++ b/internal/output/summary_traces.go
@@ -48,7 +48,7 @@ func PrintTraceSummary(out io.Writer, m *summary.TraceSummaryModel) error {
 			b.WriteString("  Conditions met:\n")
 			for _, c := range it.Conditions {
 				b.WriteString(
-					fmt.Sprintf("    ✓ %s (%d)\n", c.Text, c.Score),
+					fmt.Sprintf("    ✓ %s (%d)\n", strings.TrimSpace(c.Text), c.Score),
 				)
 			}
 		}

--- a/internal/output/summary_traces.go
+++ b/internal/output/summary_traces.go
@@ -34,7 +34,7 @@ func PrintTraceSummary(out io.Writer, m *summary.TraceSummaryModel) error {
 	)
 	b.WriteString(header + "\n\n")
 
-	if input := truncateValue(m.Input, maxValueLen); input != "" {
+	if input := strings.TrimSpace(m.Input); input != "" {
 		b.WriteString("Customer: " + input + "\n\n")
 	}
 
@@ -48,18 +48,17 @@ func PrintTraceSummary(out io.Writer, m *summary.TraceSummaryModel) error {
 			b.WriteString("  Conditions met:\n")
 			for _, c := range it.Conditions {
 				b.WriteString(
-					fmt.Sprintf("    ✓ %s (%d)\n", truncateValue(c.Text, maxValueLen), c.Score),
+					fmt.Sprintf("    ✓ %s (%d)\n", c.Text, c.Score),
 				)
 			}
 		}
 		if len(it.Tools) > 0 {
 			b.WriteString("  Tools called:\n")
 			for _, tc := range it.Tools {
-				args := truncateValue(compactArgs(tc.Args), maxValueLen)
-				line := fmt.Sprintf("    → %s(%s)", tc.Name, args)
+				line := fmt.Sprintf("    → %s(%s)", tc.Name, compactArgs(tc.Args))
 				if tc.Errored {
 					line += " → ERROR: " + tc.ErrMsg
-				} else if result := truncateValue(summary.CompactJSON(tc.Result), maxValueLen); result != "" {
+				} else if result := summary.CompactJSON(tc.Result); result != "" {
 					line += " → " + result
 				}
 				b.WriteString(line + "\n")
@@ -69,7 +68,7 @@ func PrintTraceSummary(out io.Writer, m *summary.TraceSummaryModel) error {
 		}
 	}
 
-	if reply := truncateValue(m.Reply, maxValueLen); reply != "" {
+	if reply := strings.TrimSpace(m.Reply); reply != "" {
 		b.WriteString("\nAgent: " + reply + "\n")
 	}
 
@@ -94,9 +93,9 @@ func formatKB(kb *summary.KBRetrieval) string {
 	if len(kb.Docs) > 0 {
 		quoted := make([]string, len(kb.Docs))
 		for i, d := range kb.Docs {
-			quoted[i] = fmt.Sprintf("%q", truncateValue(d, maxKBTitleLen))
+			quoted[i] = fmt.Sprintf("%q", d)
 		}
-		return fmt.Sprintf("%d %s retrieved — %s", kb.Count, noun, TruncateList(quoted, 6))
+		return fmt.Sprintf("%d %s retrieved — %s", kb.Count, noun, strings.Join(quoted, ", "))
 	}
 	return fmt.Sprintf("%d %s retrieved", kb.Count, noun)
 }


### PR DESCRIPTION
## What

Removes all length/list truncation from the human-readable `--summary` **text** view for traces and sessions, so the complete content renders:

| Cap removed | Was | Applied to |
|---|---|---|
| Value cap | 500 chars | input, reply, conditions, tool args/results |
| KB title cap | 80 chars | retrieved doc titles |
| KB list cap | 6 items (`+N more`) | retrieved-docs list (now joins all) |
| Session message cap | 160 chars | per-turn customer/agent messages |

## Why

The text summary clipped long values at 500 chars with `… (truncated)`, which loses content when feeding turns to an LLM or reading them directly. (There was no "32k" limit anywhere — the real cap was 500.) The `--summary --json`/`--yaml` output and raw `traces get` were already untruncated; this brings the text view in line.

## Notes

- Free-text fields (input / reply / customer / agent) keep `strings.TrimSpace`, so whitespace-only sections are still omitted — only the length cap is gone.
- Removes the now-dead `truncateValue` helper, its three constants, and `TestTruncateValue`.
- `go build`, `go vet`, full `go test ./...`, and `golines`/`gofumpt`/`gci` all clean. No `cmd/` changes, so generated docs are unaffected.

Stacks on top of #(feature PR) — base is `feature/llm-readable-trace-summaries`, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)