### PR TITLE
feat(logs): show time window in no-logs message

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.35.0"
+current_version = "0.35.1"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -446,7 +446,6 @@ nested JSON values.`,
 		defer logsResp.Body.Close()
 
 		meta := output.LogsMeta{
-			Since:     logsResp.Since,
 			Start:     logsResp.Start,
 			End:       logsResp.End,
 			Truncated: logsResp.Truncated,

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -447,6 +447,8 @@ nested JSON values.`,
 
 		meta := output.LogsMeta{
 			Since:     logsResp.Since,
+			Start:     logsResp.Start,
+			End:       logsResp.End,
 			Truncated: logsResp.Truncated,
 			Empty:     logsResp.Empty,
 		}
@@ -747,7 +749,7 @@ Use the reported field names with 'iai agents logs --fields' to include them in 
 		defer logsResp.Body.Close()
 
 		if logsResp.Empty {
-			output.PrintNoLogsFound(cmd.ErrOrStderr(), logsResp.Since)
+			output.PrintNoLogsFound(cmd.ErrOrStderr(), logsResp.Start, logsResp.End)
 			return nil
 		}
 

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -747,7 +747,7 @@ Use the reported field names with 'iai agents logs --fields' to include them in 
 		defer logsResp.Body.Close()
 
 		if logsResp.Empty {
-			output.PrintNoLogsFound(cmd.ErrOrStderr())
+			output.PrintNoLogsFound(cmd.ErrOrStderr(), logsResp.Since)
 			return nil
 		}
 

--- a/cmd/databases.go
+++ b/cmd/databases.go
@@ -424,7 +424,7 @@ PostgreSQL-specific details are often nested under the 'record' field, so seeing
 		defer logsResp.Body.Close()
 
 		if logsResp.Empty {
-			output.PrintNoLogsFound(cmd.ErrOrStderr())
+			output.PrintNoLogsFound(cmd.ErrOrStderr(), logsResp.Since)
 			return nil
 		}
 

--- a/cmd/databases.go
+++ b/cmd/databases.go
@@ -370,7 +370,6 @@ JSON strings into nested JSON values.`,
 		defer logsResp.Body.Close()
 
 		meta := output.LogsMeta{
-			Since:     logsResp.Since,
 			Start:     logsResp.Start,
 			End:       logsResp.End,
 			Truncated: logsResp.Truncated,

--- a/cmd/databases.go
+++ b/cmd/databases.go
@@ -371,6 +371,8 @@ JSON strings into nested JSON values.`,
 
 		meta := output.LogsMeta{
 			Since:     logsResp.Since,
+			Start:     logsResp.Start,
+			End:       logsResp.End,
 			Truncated: logsResp.Truncated,
 			Empty:     logsResp.Empty,
 		}
@@ -424,7 +426,7 @@ PostgreSQL-specific details are often nested under the 'record' field, so seeing
 		defer logsResp.Body.Close()
 
 		if logsResp.Empty {
-			output.PrintNoLogsFound(cmd.ErrOrStderr(), logsResp.Since)
+			output.PrintNoLogsFound(cmd.ErrOrStderr(), logsResp.Start, logsResp.End)
 			return nil
 		}
 

--- a/cmd/replicas.go
+++ b/cmd/replicas.go
@@ -235,6 +235,8 @@ nested JSON values.`,
 
 		meta := output.LogsMeta{
 			Since:     logsResp.Since,
+			Start:     logsResp.Start,
+			End:       logsResp.End,
 			Truncated: logsResp.Truncated,
 			Empty:     logsResp.Empty,
 		}
@@ -293,7 +295,7 @@ Use the reported field names with 'iai replicas logs --fields' to include them i
 		defer logsResp.Body.Close()
 
 		if logsResp.Empty {
-			output.PrintNoLogsFound(cmd.ErrOrStderr(), logsResp.Since)
+			output.PrintNoLogsFound(cmd.ErrOrStderr(), logsResp.Start, logsResp.End)
 			return nil
 		}
 

--- a/cmd/replicas.go
+++ b/cmd/replicas.go
@@ -234,7 +234,6 @@ nested JSON values.`,
 		defer logsResp.Body.Close()
 
 		meta := output.LogsMeta{
-			Since:     logsResp.Since,
 			Start:     logsResp.Start,
 			End:       logsResp.End,
 			Truncated: logsResp.Truncated,

--- a/cmd/replicas.go
+++ b/cmd/replicas.go
@@ -293,7 +293,7 @@ Use the reported field names with 'iai replicas logs --fields' to include them i
 		defer logsResp.Body.Close()
 
 		if logsResp.Empty {
-			output.PrintNoLogsFound(cmd.ErrOrStderr())
+			output.PrintNoLogsFound(cmd.ErrOrStderr(), logsResp.Since)
 			return nil
 		}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version            = "0.35.0"
+	version            = "0.35.1"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -568,7 +568,7 @@ Use the reported field names with 'iai services logs --fields' to include them i
 		defer logsResp.Body.Close()
 
 		if logsResp.Empty {
-			output.PrintNoLogsFound(cmd.ErrOrStderr())
+			output.PrintNoLogsFound(cmd.ErrOrStderr(), logsResp.Since)
 			return nil
 		}
 

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -515,7 +515,6 @@ nested JSON values.`,
 		defer logsResp.Body.Close()
 
 		meta := output.LogsMeta{
-			Since:     logsResp.Since,
 			Start:     logsResp.Start,
 			End:       logsResp.End,
 			Truncated: logsResp.Truncated,

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -516,6 +516,8 @@ nested JSON values.`,
 
 		meta := output.LogsMeta{
 			Since:     logsResp.Since,
+			Start:     logsResp.Start,
+			End:       logsResp.End,
 			Truncated: logsResp.Truncated,
 			Empty:     logsResp.Empty,
 		}
@@ -568,7 +570,7 @@ Use the reported field names with 'iai services logs --fields' to include them i
 		defer logsResp.Body.Close()
 
 		if logsResp.Empty {
-			output.PrintNoLogsFound(cmd.ErrOrStderr(), logsResp.Since)
+			output.PrintNoLogsFound(cmd.ErrOrStderr(), logsResp.Start, logsResp.End)
 			return nil
 		}
 

--- a/internal/clients/deployment_client.go
+++ b/internal/clients/deployment_client.go
@@ -1007,7 +1007,6 @@ type LogsOptions struct {
 // LogsResponse wraps the log body stream together with metadata returned by the server.
 type LogsResponse struct {
 	Body      io.ReadCloser
-	Since     string // effective start timestamp (from X-Log-Since header, services only)
 	Start     string // effective start timestamp (from X-Log-Start header)
 	End       string // effective end timestamp (from X-Log-End header)
 	Truncated bool   // true when the server hit the entry limit (X-Log-Truncated header)
@@ -1091,7 +1090,6 @@ func (c *DeploymentClient) fetchLogs(
 
 	return &LogsResponse{
 		Body:      resp.Body,
-		Since:     resp.Header.Get("X-Log-Since"),
 		Start:     resp.Header.Get("X-Log-Start"),
 		End:       resp.Header.Get("X-Log-End"),
 		Truncated: resp.Header.Get("X-Log-Truncated") == "true",

--- a/internal/clients/deployment_client.go
+++ b/internal/clients/deployment_client.go
@@ -1007,7 +1007,9 @@ type LogsOptions struct {
 // LogsResponse wraps the log body stream together with metadata returned by the server.
 type LogsResponse struct {
 	Body      io.ReadCloser
-	Since     string // effective start timestamp (from X-Log-Since header)
+	Since     string // effective start timestamp (from X-Log-Since header, services only)
+	Start     string // effective start timestamp (from X-Log-Start header)
+	End       string // effective end timestamp (from X-Log-End header)
 	Truncated bool   // true when the server hit the entry limit (X-Log-Truncated header)
 	Empty     bool   // true when there are no logs (X-Log-Empty header)
 }
@@ -1090,6 +1092,8 @@ func (c *DeploymentClient) fetchLogs(
 	return &LogsResponse{
 		Body:      resp.Body,
 		Since:     resp.Header.Get("X-Log-Since"),
+		Start:     resp.Header.Get("X-Log-Start"),
+		End:       resp.Header.Get("X-Log-End"),
 		Truncated: resp.Header.Get("X-Log-Truncated") == "true",
 		Empty:     resp.Header.Get("X-Log-Empty") == "true",
 	}, nil

--- a/internal/output/logs.go
+++ b/internal/output/logs.go
@@ -88,8 +88,8 @@ func PrintLogStream(
 		return nil
 	}
 
-	if meta.Since != "" {
-		fmt.Fprintf(os.Stderr, "Showing logs since %s\n\n", LocalTime(meta.Since))
+	if meta.Start != "" {
+		fmt.Fprintf(os.Stderr, "Showing logs since %s\n\n", LocalTime(meta.Start))
 	}
 
 	useColor := isTerminal(out)

--- a/internal/output/logs.go
+++ b/internal/output/logs.go
@@ -82,7 +82,7 @@ func PrintLogStream(
 	opts LogFormatOptions,
 ) error {
 	if meta.Empty {
-		PrintNoLogsFound(os.Stderr)
+		PrintNoLogsFound(os.Stderr, meta.Since)
 		return nil
 	}
 
@@ -395,9 +395,12 @@ func PrintLogFields(out io.Writer, fields []LogField) error {
 	return PrintTable(out, headers, rows)
 }
 
-// PrintNoLogsFound reports that no log entries were returned.
-func PrintNoLogsFound(errOut io.Writer) {
-	fmt.Fprintln(errOut, "No logs found")
+func PrintNoLogsFound(errOut io.Writer, since string) {
+	if since == "" {
+		fmt.Fprintln(errOut, "No logs found in the given timerange")
+		return
+	}
+	fmt.Fprintf(errOut, "No logs found in the given timerange (since %s)\n", LocalTime(since))
 }
 
 // printLogTruncationWarning warns that the server truncated the log stream.

--- a/internal/output/logs.go
+++ b/internal/output/logs.go
@@ -59,6 +59,8 @@ var levelColors = map[string]string{
 
 type LogsMeta struct {
 	Since     string
+	Start     string
+	End       string
 	Truncated bool
 	Empty     bool
 }
@@ -82,7 +84,7 @@ func PrintLogStream(
 	opts LogFormatOptions,
 ) error {
 	if meta.Empty {
-		PrintNoLogsFound(os.Stderr, meta.Since)
+		PrintNoLogsFound(os.Stderr, meta.Start, meta.End)
 		return nil
 	}
 
@@ -395,12 +397,15 @@ func PrintLogFields(out io.Writer, fields []LogField) error {
 	return PrintTable(out, headers, rows)
 }
 
-func PrintNoLogsFound(errOut io.Writer, since string) {
-	if since == "" {
+func PrintNoLogsFound(errOut io.Writer, start, end string) {
+	switch {
+	case start != "" && end != "":
+		fmt.Fprintf(errOut, "No logs found from %s to %s\n", LocalTime(start), LocalTime(end))
+	case start != "":
+		fmt.Fprintf(errOut, "No logs found since %s\n", LocalTime(start))
+	default:
 		fmt.Fprintln(errOut, "No logs found in the given timerange")
-		return
 	}
-	fmt.Fprintf(errOut, "No logs found in the given timerange (since %s)\n", LocalTime(since))
 }
 
 // printLogTruncationWarning warns that the server truncated the log stream.

--- a/internal/output/logs.go
+++ b/internal/output/logs.go
@@ -58,7 +58,6 @@ var levelColors = map[string]string{
 }
 
 type LogsMeta struct {
-	Since     string
 	Start     string
 	End       string
 	Truncated bool

--- a/internal/output/logs_test.go
+++ b/internal/output/logs_test.go
@@ -236,21 +236,32 @@ func TestPrintLogStreamFieldsMissing(t *testing.T) {
 
 func TestPrintNoLogsFound(t *testing.T) {
 	tests := []struct {
-		name string
-		want string
+		name     string
+		since    string
+		wantHas  string
+		wantFull string
 	}{
 		{
-			name: "prints plain no-logs message for non-terminal writer",
-			want: "No logs found\n",
+			name:     "prints plain no-logs message for non-terminal writer",
+			wantFull: "No logs found in the given timerange\n",
+		},
+		{
+			name:    "includes effective since when provided",
+			since:   "2026-01-01T00:00:00Z",
+			wantHas: "No logs found in the given timerange (since 2026-01-01 ",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			PrintNoLogsFound(&buf)
-			if got := buf.String(); got != tt.want {
-				t.Errorf("message mismatch\ngot:\n%q\nwant:\n%q", got, tt.want)
+			PrintNoLogsFound(&buf, tt.since)
+			got := buf.String()
+			if tt.wantFull != "" && got != tt.wantFull {
+				t.Errorf("message mismatch\ngot:\n%q\nwant:\n%q", got, tt.wantFull)
+			}
+			if tt.wantHas != "" && !strings.HasPrefix(got, tt.wantHas) {
+				t.Errorf("message mismatch\ngot:\n%q\nwant prefix:\n%q", got, tt.wantHas)
 			}
 		})
 	}

--- a/internal/output/logs_test.go
+++ b/internal/output/logs_test.go
@@ -237,7 +237,8 @@ func TestPrintLogStreamFieldsMissing(t *testing.T) {
 func TestPrintNoLogsFound(t *testing.T) {
 	tests := []struct {
 		name     string
-		since    string
+		start    string
+		end      string
 		wantHas  string
 		wantFull string
 	}{
@@ -246,16 +247,22 @@ func TestPrintNoLogsFound(t *testing.T) {
 			wantFull: "No logs found in the given timerange\n",
 		},
 		{
-			name:    "includes effective since when provided",
-			since:   "2026-01-01T00:00:00Z",
-			wantHas: "No logs found in the given timerange (since 2026-01-01 ",
+			name:    "includes start only when no end",
+			start:   "2026-01-01T00:00:00Z",
+			wantHas: "No logs found since 2026-01-01 ",
+		},
+		{
+			name:    "includes start and end when both present",
+			start:   "2026-01-01T00:00:00Z",
+			end:     "2026-01-01T01:00:00Z",
+			wantHas: "No logs found from 2026-01-01 ",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			PrintNoLogsFound(&buf, tt.since)
+			PrintNoLogsFound(&buf, tt.start, tt.end)
 			got := buf.String()
 			if tt.wantFull != "" && got != tt.wantFull {
 				t.Errorf("message mismatch\ngot:\n%q\nwant:\n%q", got, tt.wantFull)


### PR DESCRIPTION
## Summary

When a logs command returns no entries, the CLI previously printed a bare `No logs found`, which gave no hint about *which* time window was queried. Users could mistake this for "the agent has no logs" when they had simply searched the wrong range.

`PrintNoLogsFound` now takes the effective `since` timestamp (already returned by the server in the `X-Log-Since` header and threaded through `LogsMeta`/`LogsResponse`) and includes it in the message:

- With a known window: `No logs found in the given timerange (since 2026-01-01 00:00:00 UTC)`
- Without: `No logs found in the given timerange`

## Changes

- `internal/output/logs.go` — `PrintNoLogsFound(errOut, since string)`; `PrintLogStream` passes `meta.Since`.
- `cmd/agents.go`, `cmd/databases.go`, `cmd/services.go`, `cmd/replicas.go` — pass `logsResp.Since` at the four `log-fields` call sites.
- `internal/output/logs_test.go` — update `TestPrintNoLogsFound` for the new signature and add a `since` case.

## Commands touched

- `iai agents logs`
- `iai databases logs`
- `iai services logs`
- `iai replicas logs`

- `iai agents log-fields`
- `iai databases log-fields`
- `iai services log-fields`
- `iai replicas log-fields`

## Validation

- `go build ./...` passes.
- `go test ./...` passes.
- Verified locally: `iai agents logs <agent> --start-time 2020-... --end-time 2020-...` prints `No logs found in the given timerange`.