### PR TITLE
DEV-813: add CLI key management commands

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.34.6"
+current_version = "0.35.0"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
 
       - id: run-unit-tests
         name: Run unit tests
-        entry: go test ./...
+        entry: env TZ=Europe/Berlin go test ./...
         language: system
         pass_filenames: false
         always_run: false

--- a/cmd/api_keys.go
+++ b/cmd/api_keys.go
@@ -1,0 +1,403 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/auth"
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/files"
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/inputs"
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var (
+	apiKeysProject      string
+	apiKeysOrganization string
+	apiKeysJSON         bool
+	apiKeysYAML         bool
+	apiKeysListColumns  []string
+	apiKeyNote          string
+
+	routerKeysProject      string
+	routerKeysOrganization string
+	routerKeysJSON         bool
+	routerKeysYAML         bool
+	routerKeysListColumns  []string
+	routerKeyDescription   string
+	routerKeyLimit         float64
+	routerKeyLimitReset    string
+	routerKeyExpiresAt     string
+)
+
+func requireCLISession() error {
+	if token != "" || apiKey != "" {
+		return auth.KeyManagementLoginRequiredError()
+	}
+
+	cookies, err := files.LoadSessionCookies(cfgDirName, sessionFileName)
+	if err != nil {
+		return fmt.Errorf("failed to load login session: %w", err)
+	}
+	if len(cookies) == 0 {
+		return auth.KeyManagementLoginRequiredError()
+	}
+
+	return nil
+}
+
+var apiKeysCmd = &cobra.Command{
+	Use:     "api-keys",
+	Aliases: []string{"api-key"},
+	Short:   "Project API keys",
+	GroupID: groupAuth,
+	Long: `Manage project API keys. Requires iai login. API key authentication is not supported.
+
+Project API keys authenticate platform/API access for reading and writing project context, such as prompts, routines, policies, variables, glossaries, macros, traces, scores, datasets, and for creating infrastructure resources such as agents, services, and databases.`,
+}
+
+var apiKeysListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List project API keys",
+	Args:    cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireCLISession(); err != nil {
+			return err
+		}
+
+		out := cmd.OutOrStdout()
+		pCtx, apiClient, _, err := resolveProject(
+			cmd.Context(),
+			apiKeysOrganization,
+			apiKeysProject,
+		)
+		if err != nil {
+			return err
+		}
+
+		columns := apiKeysListColumns
+		if len(columns) == 0 {
+			columns = inputs.DefaultProjectAPIKeyColumns
+		}
+		if apiKeysJSON || apiKeysYAML {
+			columns = nil
+		} else if err := inputs.ValidateColumns(columns, inputs.AllProjectAPIKeyColumns); err != nil {
+			return err
+		}
+
+		keys, err := apiClient.ListProjectAPIKeys(cmd.Context(), pCtx.projectId)
+		if err != nil {
+			return err
+		}
+
+		if apiKeysJSON {
+			return output.PrintStructuredJSON(out, keys)
+		}
+		if apiKeysYAML {
+			return output.PrintStructuredYAML(out, keys)
+		}
+		return output.PrintProjectAPIKeyList(out, keys, columns)
+	},
+}
+
+var apiKeysCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a project API key",
+	Long: `Create a project API key.
+
+Project API keys authenticate platform/API access for reading and writing project context, such as prompts, routines, policies, variables, glossaries, macros, traces, scores, datasets, and for creating infrastructure resources such as agents, services, and databases.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireCLISession(); err != nil {
+			return err
+		}
+
+		out := cmd.OutOrStdout()
+		pCtx, apiClient, _, err := resolveProject(
+			cmd.Context(),
+			apiKeysOrganization,
+			apiKeysProject,
+		)
+		if err != nil {
+			return err
+		}
+
+		key, err := apiClient.CreateProjectAPIKey(
+			cmd.Context(),
+			clients.CreateProjectAPIKeyBody{ProjectID: pCtx.projectId, Note: apiKeyNote},
+		)
+		if err != nil {
+			return err
+		}
+
+		if apiKeysJSON {
+			return output.PrintStructuredJSON(out, key)
+		}
+		if apiKeysYAML {
+			return output.PrintStructuredYAML(out, key)
+		}
+		fmt.Fprintln(out)
+		fmt.Fprintf(out, "Public key: %s\n", key.PublicKey)
+		fmt.Fprintf(out, "Secret key: %s\n", key.SecretKey)
+		fmt.Fprintln(out, "Save this secret now; it is only shown once.")
+		return nil
+	},
+}
+
+var apiKeysDeleteCmd = &cobra.Command{
+	Use:   "delete <id>",
+	Short: "Delete a project API key",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireCLISession(); err != nil {
+			return err
+		}
+
+		out := cmd.OutOrStdout()
+		pCtx, apiClient, _, err := resolveProject(
+			cmd.Context(),
+			apiKeysOrganization,
+			apiKeysProject,
+		)
+		if err != nil {
+			return err
+		}
+
+		res, err := apiClient.DeleteProjectAPIKey(cmd.Context(), pCtx.projectId, args[0])
+		if err != nil {
+			return err
+		}
+
+		if !res.Success {
+			if res.Message != "" {
+				return fmt.Errorf("delete failed: %s", res.Message)
+			}
+			return fmt.Errorf("delete failed")
+		}
+
+		if apiKeysJSON {
+			return output.PrintStructuredJSON(out, res)
+		}
+		if apiKeysYAML {
+			return output.PrintStructuredYAML(out, res)
+		}
+
+		fmt.Fprintln(out, "Deleted")
+		return nil
+	},
+}
+
+var routerKeysCmd = &cobra.Command{
+	Use:     "router-keys",
+	Aliases: []string{"router-key"},
+	Short:   "Router API keys",
+	GroupID: groupAuth,
+	Long: `Manage InteractiveAI Router API keys. Requires iai login. API key authentication is not supported.
+
+Router keys authenticate inference requests to the InteractiveAI Router, for example chat completions and model calls. They are used as bearer tokens for runtime inference, not for managing project context or infrastructure.`,
+}
+
+var routerKeysListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List router API keys",
+	Args:    cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireCLISession(); err != nil {
+			return err
+		}
+
+		out := cmd.OutOrStdout()
+		pCtx, apiClient, _, err := resolveProject(
+			cmd.Context(),
+			routerKeysOrganization,
+			routerKeysProject,
+		)
+		if err != nil {
+			return err
+		}
+
+		columns := routerKeysListColumns
+		if len(columns) == 0 {
+			columns = inputs.DefaultRouterAPIKeyColumns
+		}
+		if routerKeysJSON || routerKeysYAML {
+			columns = nil
+		} else if err := inputs.ValidateColumns(columns, inputs.AllRouterAPIKeyColumns); err != nil {
+			return err
+		}
+
+		res, err := apiClient.ListRouterAPIKeys(cmd.Context(), pCtx.projectId)
+		if err != nil {
+			return err
+		}
+
+		if routerKeysJSON {
+			return output.PrintStructuredJSON(out, res)
+		}
+		if routerKeysYAML {
+			return output.PrintStructuredYAML(out, res)
+		}
+		return output.PrintRouterAPIKeyList(out, res.Keys, columns)
+	},
+}
+
+var routerKeysCreateCmd = &cobra.Command{
+	Use:   "create <name>",
+	Short: "Create a router API key",
+	Long: `Create a router API key.
+
+Router keys authenticate inference requests to the InteractiveAI Router, for example chat completions and model calls. They are used as bearer tokens for runtime inference, not for managing project context or infrastructure.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireCLISession(); err != nil {
+			return err
+		}
+
+		name := strings.TrimSpace(args[0])
+		if name == "" {
+			return fmt.Errorf("name is required")
+		}
+		if routerKeyLimit < 0 {
+			return fmt.Errorf("--limit must be greater than or equal to 0")
+		}
+		if routerKeyLimitReset != "" && routerKeyLimitReset != "daily" &&
+			routerKeyLimitReset != "weekly" &&
+			routerKeyLimitReset != "monthly" {
+			return fmt.Errorf("--limit-reset must be one of: daily, weekly, monthly")
+		}
+		if routerKeyLimitReset != "" && routerKeyLimit == 0 {
+			return fmt.Errorf("--limit-reset requires --limit")
+		}
+		if routerKeyExpiresAt != "" {
+			if _, err := time.Parse(time.RFC3339, routerKeyExpiresAt); err != nil {
+				return fmt.Errorf(
+					"--expires-at must be an RFC3339 timestamp, for example 2026-12-31T23:59:59Z",
+				)
+			}
+		}
+		out := cmd.OutOrStdout()
+		pCtx, apiClient, _, err := resolveProject(
+			cmd.Context(),
+			routerKeysOrganization,
+			routerKeysProject,
+		)
+		if err != nil {
+			return err
+		}
+
+		res, err := apiClient.CreateRouterAPIKey(
+			cmd.Context(),
+			pCtx.projectId,
+			clients.CreateRouterAPIKeyBody{
+				Name:               name,
+				Description:        routerKeyDescription,
+				Limit:              routerKeyLimit,
+				LimitReset:         routerKeyLimitReset,
+				IncludeBYOKInLimit: false,
+				ExpiresAt:          routerKeyExpiresAt,
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		if routerKeysJSON {
+			return output.PrintStructuredJSON(out, res)
+		}
+		if routerKeysYAML {
+			return output.PrintStructuredYAML(out, res)
+		}
+		fmt.Fprintln(out)
+		fmt.Fprintf(out, "Router key: %s\n", res.Key)
+		fmt.Fprintln(out, "Save this secret now; it is only shown once.")
+		return nil
+	},
+}
+
+var routerKeysDeleteCmd = &cobra.Command{
+	Use:   "delete <id>",
+	Short: "Delete a router API key",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireCLISession(); err != nil {
+			return err
+		}
+
+		out := cmd.OutOrStdout()
+		pCtx, apiClient, _, err := resolveProject(
+			cmd.Context(),
+			routerKeysOrganization,
+			routerKeysProject,
+		)
+		if err != nil {
+			return err
+		}
+
+		res, err := apiClient.DeleteRouterAPIKey(cmd.Context(), pCtx.projectId, args[0])
+		if err != nil {
+			return err
+		}
+
+		if !res.Success {
+			if res.Message != "" {
+				return fmt.Errorf("delete failed: %s", res.Message)
+			}
+			return fmt.Errorf("delete failed")
+		}
+
+		if routerKeysJSON {
+			return output.PrintStructuredJSON(out, res)
+		}
+		if routerKeysYAML {
+			return output.PrintStructuredYAML(out, res)
+		}
+		if res.Message != "" {
+			fmt.Fprintln(out, res.Message)
+			return nil
+		}
+
+		fmt.Fprintln(out, "Deleted")
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(apiKeysCmd, routerKeysCmd)
+
+	for _, c := range []*cobra.Command{apiKeysListCmd, apiKeysCreateCmd, apiKeysDeleteCmd} {
+		c.Flags().StringVarP(&apiKeysProject, "project", "p", "", "Project name")
+		c.Flags().StringVarP(&apiKeysOrganization, "organization", "o", "", "Organization name")
+		c.Flags().BoolVar(&apiKeysJSON, "json", false, "Output response as JSON")
+		c.Flags().BoolVar(&apiKeysYAML, "yaml", false, "Output response as YAML")
+		c.MarkFlagsMutuallyExclusive("json", "yaml")
+	}
+	apiKeysListCmd.Flags().
+		StringSliceVar(&apiKeysListColumns, "columns", nil, "Columns to display for table output only (comma-separated, default: id,public_key,secret,note,created_at). Cannot be used with --json or --yaml.\nAvailable: id,public_key,secret,note,status,expires_at,last_used_at,created_at")
+	apiKeysListCmd.MarkFlagsMutuallyExclusive("columns", "json", "yaml")
+	apiKeysCreateCmd.Flags().StringVar(&apiKeyNote, "note", "", "API key note")
+	apiKeysCmd.AddCommand(apiKeysListCmd, apiKeysCreateCmd, apiKeysDeleteCmd)
+
+	for _, c := range []*cobra.Command{routerKeysListCmd, routerKeysCreateCmd, routerKeysDeleteCmd} {
+		c.Flags().StringVarP(&routerKeysProject, "project", "p", "", "Project name")
+		c.Flags().StringVarP(&routerKeysOrganization, "organization", "o", "", "Organization name")
+		c.Flags().BoolVar(&routerKeysJSON, "json", false, "Output response as JSON")
+		c.Flags().BoolVar(&routerKeysYAML, "yaml", false, "Output response as YAML")
+		c.MarkFlagsMutuallyExclusive("json", "yaml")
+	}
+	routerKeysListCmd.Flags().
+		StringSliceVar(&routerKeysListColumns, "columns", nil, "Columns to display for table output only (comma-separated, default: id,name,key,limit,created_at). Cannot be used with --json or --yaml.\nAvailable: id,name,description,status,key,disabled,limit,remaining,limit_reset,expires_at,last_used_at,created_at,updated_at,project_id,user_id")
+	routerKeysListCmd.MarkFlagsMutuallyExclusive("columns", "json", "yaml")
+	routerKeysCreateCmd.Flags().
+		StringVar(&routerKeyDescription, "description", "", "Router key description")
+	routerKeysCreateCmd.Flags().
+		Float64Var(&routerKeyLimit, "limit", 0, "Credit limit in USD. If omitted, defaults to $100. Maximum is $2500.")
+	routerKeysCreateCmd.Flags().
+		StringVar(&routerKeyLimitReset, "limit-reset", "", "Limit reset period: daily, weekly, monthly. If omitted, defaults to monthly.")
+	routerKeysCreateCmd.Flags().
+		StringVar(&routerKeyExpiresAt, "expires-at", "", "Expiration timestamp (RFC3339). If omitted, keys do not expire by default.")
+	routerKeysCmd.AddCommand(routerKeysListCmd, routerKeysCreateCmd, routerKeysDeleteCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version            = "0.34.6"
+	version            = "0.35.0"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second

--- a/docs/iai.md
+++ b/docs/iai.md
@@ -86,6 +86,7 @@ Prompt resources (`prompts`, `routines`, `policies`, `variables`, `glossaries`, 
 ### SEE ALSO
 
 * [iai agents](iai_agents.md)	 - Deploy AI agents with policies, routines, and tools
+* [iai api-keys](iai_api-keys.md)	 - Project API keys
 * [iai comments](iai_comments.md)	 - Annotate traces, observations, and sessions
 * [iai completion](iai_completion.md)	 - Generate the autocompletion script for the specified shell
 * [iai connectors](iai_connectors.md)	 - Manage MCP connectors in a project
@@ -107,6 +108,7 @@ Prompt resources (`prompts`, `routines`, `policies`, `variables`, `glossaries`, 
 * [iai queue-items](iai_queue-items.md)	 - Manage items in annotation queues
 * [iai queues](iai_queues.md)	 - Annotation queues for human review workflows
 * [iai replicas](iai_replicas.md)	 - Inspect service replicas
+* [iai router-keys](iai_router-keys.md)	 - Router API keys
 * [iai routines](iai_routines.md)	 - Multi-step behavioral processes for agents
 * [iai run-items](iai_run-items.md)	 - Inspect results of evaluation runs
 * [iai score-configs](iai_score-configs.md)	 - Define scoring schemas for evaluation

--- a/docs/iai_api-keys.md
+++ b/docs/iai_api-keys.md
@@ -1,0 +1,32 @@
+## iai api-keys
+
+Project API keys
+
+### Synopsis
+
+Manage project API keys. Requires iai login. API key authentication is not supported.
+
+Project API keys authenticate platform/API access for reading and writing project context, such as prompts, routines, policies, variables, glossaries, macros, traces, scores, datasets, and for creating infrastructure resources such as agents, services, and databases.
+
+### Options
+
+```
+  -h, --help   help for api-keys
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai](iai.md)	 - InteractiveAI's CLI
+* [iai api-keys create](iai_api-keys_create.md)	 - Create a project API key
+* [iai api-keys delete](iai_api-keys_delete.md)	 - Delete a project API key
+* [iai api-keys list](iai_api-keys_list.md)	 - List project API keys
+

--- a/docs/iai_api-keys_create.md
+++ b/docs/iai_api-keys_create.md
@@ -1,0 +1,38 @@
+## iai api-keys create
+
+Create a project API key
+
+### Synopsis
+
+Create a project API key.
+
+Project API keys authenticate platform/API access for reading and writing project context, such as prompts, routines, policies, variables, glossaries, macros, traces, scores, datasets, and for creating infrastructure resources such as agents, services, and databases.
+
+```
+iai api-keys create [flags]
+```
+
+### Options
+
+```
+  -h, --help                  help for create
+      --json                  Output response as JSON
+      --note string           API key note
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+      --yaml                  Output response as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai api-keys](iai_api-keys.md)	 - Project API keys
+

--- a/docs/iai_api-keys_delete.md
+++ b/docs/iai_api-keys_delete.md
@@ -1,0 +1,31 @@
+## iai api-keys delete
+
+Delete a project API key
+
+```
+iai api-keys delete <id> [flags]
+```
+
+### Options
+
+```
+  -h, --help                  help for delete
+      --json                  Output response as JSON
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+      --yaml                  Output response as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai api-keys](iai_api-keys.md)	 - Project API keys
+

--- a/docs/iai_api-keys_list.md
+++ b/docs/iai_api-keys_list.md
@@ -1,0 +1,33 @@
+## iai api-keys list
+
+List project API keys
+
+```
+iai api-keys list [flags]
+```
+
+### Options
+
+```
+      --columns strings       Columns to display for table output only (comma-separated, default: id,public_key,secret,note,created_at). Cannot be used with --json or --yaml.
+                              Available: id,public_key,secret,note,status,expires_at,last_used_at,created_at
+  -h, --help                  help for list
+      --json                  Output response as JSON
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+      --yaml                  Output response as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai api-keys](iai_api-keys.md)	 - Project API keys
+

--- a/docs/iai_router-keys.md
+++ b/docs/iai_router-keys.md
@@ -1,0 +1,32 @@
+## iai router-keys
+
+Router API keys
+
+### Synopsis
+
+Manage InteractiveAI Router API keys. Requires iai login. API key authentication is not supported.
+
+Router keys authenticate inference requests to the InteractiveAI Router, for example chat completions and model calls. They are used as bearer tokens for runtime inference, not for managing project context or infrastructure.
+
+### Options
+
+```
+  -h, --help   help for router-keys
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai](iai.md)	 - InteractiveAI's CLI
+* [iai router-keys create](iai_router-keys_create.md)	 - Create a router API key
+* [iai router-keys delete](iai_router-keys_delete.md)	 - Delete a router API key
+* [iai router-keys list](iai_router-keys_list.md)	 - List router API keys
+

--- a/docs/iai_router-keys_create.md
+++ b/docs/iai_router-keys_create.md
@@ -1,0 +1,41 @@
+## iai router-keys create
+
+Create a router API key
+
+### Synopsis
+
+Create a router API key.
+
+Router keys authenticate inference requests to the InteractiveAI Router, for example chat completions and model calls. They are used as bearer tokens for runtime inference, not for managing project context or infrastructure.
+
+```
+iai router-keys create <name> [flags]
+```
+
+### Options
+
+```
+      --description string    Router key description
+      --expires-at string     Expiration timestamp (RFC3339). If omitted, keys do not expire by default.
+  -h, --help                  help for create
+      --json                  Output response as JSON
+      --limit float           Credit limit in USD. If omitted, defaults to $100. Maximum is $2500.
+      --limit-reset string    Limit reset period: daily, weekly, monthly. If omitted, defaults to monthly.
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+      --yaml                  Output response as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai router-keys](iai_router-keys.md)	 - Router API keys
+

--- a/docs/iai_router-keys_delete.md
+++ b/docs/iai_router-keys_delete.md
@@ -1,0 +1,31 @@
+## iai router-keys delete
+
+Delete a router API key
+
+```
+iai router-keys delete <id> [flags]
+```
+
+### Options
+
+```
+  -h, --help                  help for delete
+      --json                  Output response as JSON
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+      --yaml                  Output response as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai router-keys](iai_router-keys.md)	 - Router API keys
+

--- a/docs/iai_router-keys_list.md
+++ b/docs/iai_router-keys_list.md
@@ -1,0 +1,33 @@
+## iai router-keys list
+
+List router API keys
+
+```
+iai router-keys list [flags]
+```
+
+### Options
+
+```
+      --columns strings       Columns to display for table output only (comma-separated, default: id,name,key,limit,created_at). Cannot be used with --json or --yaml.
+                              Available: id,name,description,status,key,disabled,limit,remaining,limit_reset,expires_at,last_used_at,created_at,updated_at,project_id,user_id
+  -h, --help                  help for list
+      --json                  Output response as JSON
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+      --yaml                  Output response as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai router-keys](iai_router-keys.md)	 - Router API keys
+

--- a/internal/auth/errors.go
+++ b/internal/auth/errors.go
@@ -1,0 +1,10 @@
+package auth
+
+import "fmt"
+
+// KeyManagementLoginRequiredError reports that key management requires iai login.
+func KeyManagementLoginRequiredError() error {
+	return fmt.Errorf(
+		"this command requires iai login; API key authentication is not supported for key management",
+	)
+}

--- a/internal/clients/api_client_keys.go
+++ b/internal/clients/api_client_keys.go
@@ -1,0 +1,275 @@
+package clients
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/auth"
+)
+
+type ProjectAPIKey struct {
+	ID               string  `json:"id"`
+	CreatedAt        string  `json:"createdAt,omitempty"`
+	ExpiresAt        *string `json:"expiresAt,omitempty"`
+	LastUsedAt       *string `json:"lastUsedAt,omitempty"`
+	Note             *string `json:"note,omitempty"`
+	PublicKey        string  `json:"publicKey"`
+	DisplaySecretKey string  `json:"displaySecretKey"`
+	SecretKey        string  `json:"secretKey,omitempty"`
+}
+
+type CreateProjectAPIKeyBody struct {
+	ProjectID string `json:"projectId"`
+	Note      string `json:"note,omitempty"`
+}
+
+type RouterAPIKey struct {
+	ID             string  `json:"id"`
+	Name           string  `json:"name"`
+	Description    *string `json:"description,omitempty"`
+	KeyPreview     string  `json:"key_preview"`
+	ProjectID      string  `json:"project_id"`
+	UserID         string  `json:"user_id"`
+	Disabled       bool    `json:"disabled"`
+	Limit          any     `json:"limit,omitempty"`
+	LimitRemaining any     `json:"limit_remaining,omitempty"`
+	LimitReset     *string `json:"limit_reset,omitempty"`
+	CreatedAt      string  `json:"created_at"`
+	UpdatedAt      *string `json:"updated_at,omitempty"`
+	LastUsedAt     *string `json:"last_used_at,omitempty"`
+	ExpiresAt      *string `json:"expires_at,omitempty"`
+}
+
+type RouterAPIKeyListResponse struct {
+	Keys   []RouterAPIKey `json:"keys"`
+	Total  int            `json:"total"`
+	Limit  int            `json:"limit"`
+	Offset int            `json:"offset"`
+}
+
+type CreateRouterAPIKeyBody struct {
+	Name               string  `json:"name"`
+	Description        string  `json:"description,omitempty"`
+	Limit              float64 `json:"limit,omitempty"`
+	LimitReset         string  `json:"limit_reset,omitempty"`
+	IncludeBYOKInLimit bool    `json:"include_byok_in_limit"`
+	ExpiresAt          string  `json:"expires_at,omitempty"`
+}
+
+type CreateRouterAPIKeyResponse struct {
+	RouterAPIKey
+	Key     string `json:"key"`
+	Warning string `json:"warning,omitempty"`
+}
+
+type DeleteAPIKeyResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+}
+
+func (c *APIClient) requireCookieMode() error {
+	if c.token != "" || c.apiKey != "" || len(c.cookies) == 0 {
+		return auth.KeyManagementLoginRequiredError()
+	}
+
+	return nil
+}
+
+func (c *APIClient) trpcMutation(ctx context.Context, path string, input any, out any) error {
+	if err := c.requireCookieMode(); err != nil {
+		return err
+	}
+
+	req, err := c.newJSONRequest(
+		ctx,
+		http.MethodPost,
+		"/api/trpc/"+path,
+		map[string]any{"json": input},
+	)
+	if err != nil {
+		return err
+	}
+
+	body, err := c.doAndRead(req, path)
+	if err != nil {
+		return err
+	}
+
+	return decodeTRPCData(body, out)
+}
+
+func (c *APIClient) trpcQuery(ctx context.Context, path string, input any, out any) error {
+	if err := c.requireCookieMode(); err != nil {
+		return err
+	}
+
+	encoded, err := json.Marshal(map[string]any{"json": input})
+	if err != nil {
+		return fmt.Errorf("failed to encode tRPC input: %w", err)
+	}
+	u, err := url.Parse(c.hostname)
+	if err != nil {
+		return fmt.Errorf("failed to parse API hostname: %w", err)
+	}
+	u.Path = "/api/trpc/" + path
+	u.RawQuery = "input=" + url.QueryEscape(string(encoded))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	body, err := c.doAndRead(req, path)
+	if err != nil {
+		return err
+	}
+
+	return decodeTRPCData(body, out)
+}
+
+func decodeTRPCData(body []byte, out any) error {
+	var envelope struct {
+		Result struct {
+			Data json.RawMessage `json:"data"`
+		} `json:"result"`
+		Error any `json:"error"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return fmt.Errorf("failed to decode tRPC response: %w", err)
+	}
+	if envelope.Error != nil {
+		if msg := ExtractServerMessage(body); msg != "" {
+			return fmt.Errorf("tRPC error: %s", msg)
+		}
+		return fmt.Errorf("tRPC error")
+	}
+	if len(envelope.Result.Data) == 0 {
+		return nil
+	}
+
+	var wrapped struct {
+		JSON json.RawMessage `json:"json"`
+	}
+	if err := json.Unmarshal(envelope.Result.Data, &wrapped); err == nil && len(wrapped.JSON) > 0 {
+		return json.Unmarshal(wrapped.JSON, out)
+	}
+	return json.Unmarshal(envelope.Result.Data, out)
+}
+
+func (c *APIClient) ListProjectAPIKeys(
+	ctx context.Context,
+	projectID string,
+) ([]ProjectAPIKey, error) {
+	var keys []ProjectAPIKey
+	err := c.trpcQuery(
+		ctx,
+		"projectApiKeys.byProjectId",
+		map[string]string{"projectId": projectID},
+		&keys,
+	)
+	return keys, err
+}
+
+func (c *APIClient) CreateProjectAPIKey(
+	ctx context.Context,
+	body CreateProjectAPIKeyBody,
+) (ProjectAPIKey, error) {
+	var key ProjectAPIKey
+	err := c.trpcMutation(ctx, "projectApiKeys.create", body, &key)
+	return key, err
+}
+
+func (c *APIClient) DeleteProjectAPIKey(
+	ctx context.Context,
+	projectID, keyID string,
+) (DeleteAPIKeyResponse, error) {
+	var ok bool
+	if err := c.trpcMutation(
+		ctx,
+		"projectApiKeys.delete",
+		map[string]string{"projectId": projectID, "id": keyID},
+		&ok,
+	); err != nil {
+		return DeleteAPIKeyResponse{}, err
+	}
+	return DeleteAPIKeyResponse{Success: ok}, nil
+}
+
+func (c *APIClient) ListRouterAPIKeys(
+	ctx context.Context,
+	projectID string,
+) (RouterAPIKeyListResponse, error) {
+	if err := c.requireCookieMode(); err != nil {
+		return RouterAPIKeyListResponse{}, err
+	}
+
+	path := fmt.Sprintf("/api/v1/projects/%s/openrouter-keys", url.PathEscape(projectID))
+	req, err := c.newRequest(ctx, http.MethodGet, path)
+	if err != nil {
+		return RouterAPIKeyListResponse{}, err
+	}
+	body, err := c.doAndRead(req, "list router keys")
+	if err != nil {
+		return RouterAPIKeyListResponse{}, err
+	}
+	var res RouterAPIKeyListResponse
+	if err := json.Unmarshal(body, &res); err != nil {
+		return RouterAPIKeyListResponse{}, fmt.Errorf("failed to decode router keys: %w", err)
+	}
+	return res, nil
+}
+
+func (c *APIClient) CreateRouterAPIKey(
+	ctx context.Context,
+	projectID string,
+	body CreateRouterAPIKeyBody,
+) (CreateRouterAPIKeyResponse, error) {
+	if err := c.requireCookieMode(); err != nil {
+		return CreateRouterAPIKeyResponse{}, err
+	}
+
+	path := fmt.Sprintf("/api/v1/projects/%s/openrouter-keys", url.PathEscape(projectID))
+	req, err := c.newJSONRequest(ctx, http.MethodPost, path, body)
+	if err != nil {
+		return CreateRouterAPIKeyResponse{}, err
+	}
+	respBody, err := c.doAndRead(req, "create router key")
+	if err != nil {
+		return CreateRouterAPIKeyResponse{}, err
+	}
+	var res CreateRouterAPIKeyResponse
+	if err := json.Unmarshal(respBody, &res); err != nil {
+		return CreateRouterAPIKeyResponse{}, fmt.Errorf("failed to decode router key: %w", err)
+	}
+	return res, nil
+}
+
+func (c *APIClient) DeleteRouterAPIKey(
+	ctx context.Context,
+	projectID, keyID string,
+) (DeleteAPIKeyResponse, error) {
+	if err := c.requireCookieMode(); err != nil {
+		return DeleteAPIKeyResponse{}, err
+	}
+
+	path := fmt.Sprintf(
+		"/api/v1/projects/%s/openrouter-keys/%s",
+		url.PathEscape(projectID),
+		url.PathEscape(keyID),
+	)
+	req, err := c.newRequest(ctx, http.MethodDelete, path)
+	if err != nil {
+		return DeleteAPIKeyResponse{}, err
+	}
+	body, err := c.doAndRead(req, "delete router key")
+	if err != nil {
+		return DeleteAPIKeyResponse{}, err
+	}
+	var res DeleteAPIKeyResponse
+	if err := json.Unmarshal(body, &res); err != nil {
+		return DeleteAPIKeyResponse{}, fmt.Errorf("failed to decode delete response: %w", err)
+	}
+	return res, nil
+}

--- a/internal/clients/api_client_keys_test.go
+++ b/internal/clients/api_client_keys_test.go
@@ -1,0 +1,70 @@
+package clients
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestDecodeTRPCData(t *testing.T) {
+	body := []byte(`{"result":{"data":{"json":{"publicKey":"pk","secretKey":"sk"}}}}`)
+	var got ProjectAPIKey
+	if err := decodeTRPCData(body, &got); err != nil {
+		t.Fatalf("decodeTRPCData() error = %v", err)
+	}
+	if got.PublicKey != "pk" || got.SecretKey != "sk" {
+		t.Fatalf("decoded key = %#v", got)
+	}
+}
+
+func TestCreateRouterAPIKeyUsesCookieAuth(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/projects/project-1/openrouter-keys" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "" {
+			t.Fatalf("unexpected authorization header: %s", r.Header.Get("Authorization"))
+		}
+		if _, err := r.Cookie("next-auth.session-token"); err != nil {
+			t.Fatalf("missing session cookie: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(
+			[]byte(
+				`{"id":"id","key":"sk-or","name":"dev","key_preview":"sk-or-***","project_id":"project-1","user_id":"u","disabled":false,"created_at":"2026-01-01T00:00:00Z"}`,
+			),
+		)
+	}))
+	defer server.Close()
+
+	client, err := NewAPIClient(
+		server.URL,
+		5*time.Second,
+		"",
+		"",
+		[]*http.Cookie{{Name: "next-auth.session-token", Value: "cookie"}},
+	)
+	if err != nil {
+		t.Fatalf("NewAPIClient() error = %v", err)
+	}
+	got, err := client.CreateRouterAPIKey(
+		context.Background(),
+		"project-1",
+		CreateRouterAPIKeyBody{Name: "dev"},
+	)
+	if err != nil {
+		t.Fatalf("CreateRouterAPIKey() error = %v", err)
+	}
+	if got.Key != "sk-or" {
+		t.Fatalf("key = %q", got.Key)
+	}
+}
+
+func TestKeysRejectAPIKeyAuth(t *testing.T) {
+	client := &APIClient{apiKey: "pk:sk"}
+	if err := client.requireCookieMode(); err == nil {
+		t.Fatal("requireCookieMode() expected error")
+	}
+}

--- a/internal/clients/http.go
+++ b/internal/clients/http.go
@@ -40,6 +40,15 @@ type simpleError struct {
 	Detail string `json:"detail"`
 }
 
+type trpcError struct {
+	Error struct {
+		JSON struct {
+			Message string `json:"message"`
+		} `json:"json"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
 // ExtractServerMessage extracts a human-readable error message from an API
 // response body. It handles four formats:
 //
@@ -93,6 +102,16 @@ func ExtractServerMessage(body []byte) string {
 	var sp simpleError
 	if err := json.Unmarshal(body, &sp); err == nil {
 		if msg := strings.TrimSpace(sp.Detail); msg != "" {
+			return msg
+		}
+	}
+
+	var te trpcError
+	if err := json.Unmarshal(body, &te); err == nil {
+		if msg := strings.TrimSpace(te.Error.JSON.Message); msg != "" {
+			return msg
+		}
+		if msg := strings.TrimSpace(te.Error.Message); msg != "" {
 			return msg
 		}
 	}

--- a/internal/clients/http_test.go
+++ b/internal/clients/http_test.go
@@ -83,6 +83,13 @@ func TestExtractServerMessage(t *testing.T) {
 			),
 			want: "Invalid request data",
 		},
+		{
+			name: "trpc json error",
+			body: []byte(
+				`{"error":{"json":{"message":"Unsupported POST-request to query procedure","code":-32005}}}`,
+			),
+			want: "Unsupported POST-request to query procedure",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/inputs/api_keys.go
+++ b/internal/inputs/api_keys.go
@@ -1,0 +1,34 @@
+package inputs
+
+var DefaultProjectAPIKeyColumns = []string{"id", "public_key", "secret", "note", "created_at"}
+
+var AllProjectAPIKeyColumns = []string{
+	"id",
+	"public_key",
+	"secret",
+	"note",
+	"status",
+	"expires_at",
+	"last_used_at",
+	"created_at",
+}
+
+var DefaultRouterAPIKeyColumns = []string{"id", "name", "key", "limit", "created_at"}
+
+var AllRouterAPIKeyColumns = []string{
+	"id",
+	"name",
+	"description",
+	"status",
+	"key",
+	"disabled",
+	"limit",
+	"remaining",
+	"limit_reset",
+	"expires_at",
+	"last_used_at",
+	"created_at",
+	"updated_at",
+	"project_id",
+	"user_id",
+}

--- a/internal/output/api_keys.go
+++ b/internal/output/api_keys.go
@@ -1,0 +1,159 @@
+package output
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
+)
+
+var projectAPIKeyColumnMap = map[string]struct {
+	Header string
+	Value  func(clients.ProjectAPIKey) string
+}{
+	"id":         {"ID", func(k clients.ProjectAPIKey) string { return k.ID }},
+	"public_key": {"PUBLIC KEY", func(k clients.ProjectAPIKey) string { return k.PublicKey }},
+	"secret":     {"SECRET", func(k clients.ProjectAPIKey) string { return k.DisplaySecretKey }},
+	"note":       {"NOTE", func(k clients.ProjectAPIKey) string { return stringValue(k.Note) }},
+	"status": {
+		"STATUS",
+		func(k clients.ProjectAPIKey) string { return expiryStatus(k.ExpiresAt) },
+	},
+	"expires_at": {
+		"EXPIRES",
+		func(k clients.ProjectAPIKey) string { return formatExpiresAt(k.ExpiresAt) },
+	},
+	"last_used_at": {
+		"LAST USED",
+		func(k clients.ProjectAPIKey) string { return formatOptionalTime(k.LastUsedAt) },
+	},
+	"created_at": {
+		"CREATED",
+		func(k clients.ProjectAPIKey) string { return LocalTime(k.CreatedAt) },
+	},
+}
+
+var routerAPIKeyColumnMap = map[string]struct {
+	Header string
+	Value  func(clients.RouterAPIKey) string
+}{
+	"id":   {"ID", func(k clients.RouterAPIKey) string { return k.ID }},
+	"name": {"NAME", func(k clients.RouterAPIKey) string { return k.Name }},
+	"description": {
+		"DESCRIPTION",
+		func(k clients.RouterAPIKey) string { return stringValue(k.Description) },
+	},
+	"status": {"STATUS", keyStatus},
+	"key":    {"KEY", func(k clients.RouterAPIKey) string { return k.KeyPreview }},
+	"disabled": {
+		"DISABLED",
+		func(k clients.RouterAPIKey) string { return fmt.Sprint(k.Disabled) },
+	},
+	"limit": {"LIMIT", func(k clients.RouterAPIKey) string { return formatUSD(k.Limit) }},
+	"remaining": {
+		"REMAINING",
+		func(k clients.RouterAPIKey) string { return formatUSD(k.LimitRemaining) },
+	},
+	"limit_reset": {
+		"RESET",
+		func(k clients.RouterAPIKey) string { return stringValue(k.LimitReset) },
+	},
+	"expires_at": {
+		"EXPIRES",
+		func(k clients.RouterAPIKey) string { return formatExpiresAt(k.ExpiresAt) },
+	},
+	"last_used_at": {
+		"LAST USED",
+		func(k clients.RouterAPIKey) string { return formatOptionalTime(k.LastUsedAt) },
+	},
+	"created_at": {
+		"CREATED",
+		func(k clients.RouterAPIKey) string { return LocalTime(k.CreatedAt) },
+	},
+	"updated_at": {
+		"UPDATED",
+		func(k clients.RouterAPIKey) string { return formatOptionalTime(k.UpdatedAt) },
+	},
+	"project_id": {"PROJECT ID", func(k clients.RouterAPIKey) string { return k.ProjectID }},
+	"user_id":    {"USER ID", func(k clients.RouterAPIKey) string { return k.UserID }},
+}
+
+func PrintProjectAPIKeyList(out io.Writer, keys []clients.ProjectAPIKey, columns []string) error {
+	fmt.Fprintln(out)
+	headers := make([]string, len(columns))
+	for i, col := range columns {
+		headers[i] = projectAPIKeyColumnMap[col].Header
+	}
+	rows := make([][]string, 0, len(keys))
+	for _, key := range keys {
+		row := make([]string, len(columns))
+		for i, col := range columns {
+			row[i] = projectAPIKeyColumnMap[col].Value(key)
+		}
+		rows = append(rows, row)
+	}
+	return PrintTable(out, headers, rows)
+}
+
+func PrintRouterAPIKeyList(out io.Writer, keys []clients.RouterAPIKey, columns []string) error {
+	fmt.Fprintln(out)
+	headers := make([]string, len(columns))
+	for i, col := range columns {
+		headers[i] = routerAPIKeyColumnMap[col].Header
+	}
+	rows := make([][]string, 0, len(keys))
+	for _, key := range keys {
+		row := make([]string, len(columns))
+		for i, col := range columns {
+			row[i] = routerAPIKeyColumnMap[col].Value(key)
+		}
+		rows = append(rows, row)
+	}
+	return PrintTable(out, headers, rows)
+}
+
+func keyStatus(key clients.RouterAPIKey) string {
+	if key.Disabled {
+		return "disabled"
+	}
+	return expiryStatus(key.ExpiresAt)
+}
+
+func expiryStatus(expiresAt *string) string {
+	if expiresAt == nil || *expiresAt == "" {
+		return "active"
+	}
+	for _, layout := range []string{time.RFC3339, time.RFC3339Nano} {
+		parsed, err := time.Parse(layout, *expiresAt)
+		if err == nil && time.Now().After(parsed) {
+			return "expired"
+		}
+		if err == nil {
+			return "active"
+		}
+	}
+	return "active"
+}
+
+func formatExpiresAt(expiresAt *string) string {
+	if expiresAt == nil || *expiresAt == "" {
+		return "never"
+	}
+	return LocalTime(*expiresAt)
+}
+
+func formatOptionalTime(value *string) string {
+	if value == nil || *value == "" {
+		return "never"
+	}
+	return LocalTime(*value)
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(*value)
+}

--- a/internal/output/api_keys_test.go
+++ b/internal/output/api_keys_test.go
@@ -1,0 +1,56 @@
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
+)
+
+func TestPrintRouterAPIKeyListFormatsMoney(t *testing.T) {
+	oldExpiry := "2000-01-01T00:00:00Z"
+	keys := []clients.RouterAPIKey{
+		{
+			ID:             "1",
+			Name:           "a",
+			KeyPreview:     "sk",
+			Limit:          "100",
+			LimitRemaining: "99",
+			CreatedAt:      "2026-01-01T00:00:00Z",
+		},
+		{
+			ID:         "2",
+			Name:       "b",
+			KeyPreview: "sk",
+			Limit:      "100.00",
+			ExpiresAt:  &oldExpiry,
+			CreatedAt:  "2026-01-01T00:00:00Z",
+		},
+		{
+			ID:         "3",
+			Name:       "c",
+			KeyPreview: "sk",
+			Limit:      float64(1.5),
+			CreatedAt:  "2026-01-01T00:00:00Z",
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := PrintRouterAPIKeyList(
+		&buf,
+		keys,
+		[]string{"id", "name", "status", "key", "limit", "remaining", "expires_at", "created_at"},
+	); err != nil {
+		t.Fatalf("PrintRouterAPIKeyList() error = %v", err)
+	}
+	got := buf.String()
+	for _, want := range []string{"STATUS", "REMAINING", "EXPIRES", "$100.00", "$99.00", "$1.50", "expired", "never"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "\t100\t") || strings.Contains(got, "\t100.00\t") {
+		t.Fatalf("output used raw limit formatting:\n%s", got)
+	}
+}

--- a/internal/output/fmt.go
+++ b/internal/output/fmt.go
@@ -1,0 +1,109 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// formatCost formats a pointer cost as dollars for terminal output.
+func formatCost(v *float64) string {
+	if v == nil {
+		return "-"
+	}
+	return fmt.Sprintf("$%.6f", *v)
+}
+
+// formatFloat formats a pointer float with a suffix for terminal output.
+func formatFloat(v *float64, suffix string) string {
+	if v == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%.2f%s", *v, suffix)
+}
+
+// formatInt formats a pointer int for terminal output.
+func formatInt(v *int) string {
+	if v == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%d", *v)
+}
+
+// formatLatencyMs formats milliseconds as ms or seconds for terminal output.
+func formatLatencyMs(v *float64) string {
+	if v == nil {
+		return "-"
+	}
+	if *v <= 1000 {
+		return fmt.Sprintf("%.0fms", *v)
+	}
+	return fmt.Sprintf("%.2fs", *v/1000)
+}
+
+// formatOptionalFloat formats an optional float without forced trailing zeros.
+func formatOptionalFloat(v *float64) string {
+	if v == nil {
+		return "-"
+	}
+	return strconv.FormatFloat(*v, 'f', -1, 64)
+}
+
+// formatSecretKeys formats a truncated comma-separated key list.
+func formatSecretKeys(keys []string, maxVisible int) string {
+	if len(keys) == 0 {
+		return ""
+	}
+	if len(keys) <= maxVisible {
+		return strings.Join(keys, ", ")
+	}
+	visible := strings.Join(keys[:maxVisible], ", ")
+	return fmt.Sprintf("%s (+%d more)", visible, len(keys)-maxVisible)
+}
+
+// formatSummaryValue renders decoded JSON values compactly.
+func formatSummaryValue(v any) string {
+	switch t := v.(type) {
+	case string:
+		return fmt.Sprintf("%q", t)
+	case float64:
+		if t == math.Trunc(t) && t >= math.MinInt64 && t <= math.MaxInt64 {
+			return fmt.Sprintf("%d", int64(t))
+		}
+		return fmt.Sprintf("%g", t)
+	case nil:
+		return "null"
+	default:
+		b, _ := json.Marshal(t)
+		return string(b)
+	}
+}
+
+// formatUSD formats numeric values as dollars for table display.
+func formatUSD(value any) string {
+	if value == nil {
+		return ""
+	}
+	var n float64
+	switch v := value.(type) {
+	case float64:
+		n = v
+	case float32:
+		n = float64(v)
+	case int:
+		n = float64(v)
+	case int64:
+		n = float64(v)
+	case string:
+		parsed, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return v
+		}
+		n = parsed
+	default:
+		return fmt.Sprint(value)
+	}
+	return fmt.Sprintf("$%.2f", n)
+}

--- a/internal/output/fmt_test.go
+++ b/internal/output/fmt_test.go
@@ -1,0 +1,22 @@
+package output
+
+import "testing"
+
+func TestFormatUSD(t *testing.T) {
+	cases := []struct {
+		in   any
+		want string
+	}{
+		{nil, ""},
+		{"100", "$100.00"},
+		{"100.00", "$100.00"},
+		{1.5, "$1.50"},
+		{"n/a", "n/a"},
+	}
+
+	for _, tt := range cases {
+		if got := formatUSD(tt.in); got != tt.want {
+			t.Fatalf("formatUSD(%v) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/output/score_configs.go
+++ b/internal/output/score_configs.go
@@ -41,13 +41,6 @@ var scoreConfigColumnMap = map[string]struct {
 	},
 }
 
-func formatOptionalFloat(v *float64) string {
-	if v == nil {
-		return "-"
-	}
-	return strconv.FormatFloat(*v, 'f', -1, 64)
-}
-
 func PrintScoreConfigList(
 	out io.Writer,
 	configs []clients.ScoreConfigInfo,

--- a/internal/output/secrets.go
+++ b/internal/output/secrets.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"sort"
-	"strings"
 
 	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
 )
@@ -54,15 +53,4 @@ func PrintSecretData(out io.Writer, data map[string]string) error {
 	}
 
 	return PrintTable(out, headers, rows)
-}
-
-func formatSecretKeys(keys []string, maxVisible int) string {
-	if len(keys) == 0 {
-		return ""
-	}
-	if len(keys) <= maxVisible {
-		return strings.Join(keys, ", ")
-	}
-	visible := strings.Join(keys[:maxVisible], ", ")
-	return fmt.Sprintf("%s (+%d more)", visible, len(keys)-maxVisible)
 }

--- a/internal/output/summary.go
+++ b/internal/output/summary.go
@@ -3,7 +3,6 @@ package output
 import (
 	"encoding/json"
 	"fmt"
-	"math"
 	"sort"
 	"strings"
 
@@ -55,27 +54,7 @@ func compactArgs(raw json.RawMessage) string {
 	sort.Strings(keys)
 	parts := make([]string, 0, len(keys))
 	for _, k := range keys {
-		parts = append(parts, fmt.Sprintf("%s=%s", k, formatValue(m[k])))
+		parts = append(parts, fmt.Sprintf("%s=%s", k, formatSummaryValue(m[k])))
 	}
 	return strings.Join(parts, ", ")
-}
-
-// formatValue renders decoded JSON values compactly.
-func formatValue(v any) string {
-	switch t := v.(type) {
-	case string:
-		return fmt.Sprintf("%q", t)
-	case float64:
-		// JSON numbers decode to float64; print integers without trailing zeros.
-		// Guard the int64 conversion: out-of-range floats overflow undefined.
-		if t == math.Trunc(t) && t >= math.MinInt64 && t <= math.MaxInt64 {
-			return fmt.Sprintf("%d", int64(t))
-		}
-		return fmt.Sprintf("%g", t)
-	case nil:
-		return "null"
-	default:
-		b, _ := json.Marshal(t)
-		return string(b)
-	}
 }

--- a/internal/output/summary_test.go
+++ b/internal/output/summary_test.go
@@ -63,8 +63,8 @@ func TestFormatValue(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := formatValue(tc.in); got != tc.want {
-				t.Fatalf("formatValue(%v) = %q, want %q", tc.in, got, tc.want)
+			if got := formatSummaryValue(tc.in); got != tc.want {
+				t.Fatalf("formatSummaryValue(%v) = %q, want %q", tc.in, got, tc.want)
 			}
 		})
 	}

--- a/internal/output/traces.go
+++ b/internal/output/traces.go
@@ -180,39 +180,6 @@ func colorHeader(useColor bool, label string, color string) string {
 	return color + label + colorReset
 }
 
-func formatFloat(v *float64, suffix string) string {
-	if v == nil {
-		return "-"
-	}
-	return fmt.Sprintf("%.2f%s", *v, suffix)
-}
-
-func formatCost(v *float64) string {
-	if v == nil {
-		return "-"
-	}
-	return fmt.Sprintf("$%.6f", *v)
-}
-
-// formatLatencyMs formats a latency value given in milliseconds.
-// If <= 1000ms, shows as "Xms"; otherwise converts to seconds "X.XXs".
-func formatLatencyMs(v *float64) string {
-	if v == nil {
-		return "-"
-	}
-	if *v <= 1000 {
-		return fmt.Sprintf("%.0fms", *v)
-	}
-	return fmt.Sprintf("%.2fs", *v/1000)
-}
-
-func formatInt(v *int) string {
-	if v == nil {
-		return "-"
-	}
-	return fmt.Sprintf("%d", *v)
-}
-
 // jsonUnescaper performs a single-pass unescape of JSON escape sequences for
 // human-readable terminal output. NewReplacer matches left-to-right without
 // re-processing replaced text, so \\n correctly becomes literal \n (not a newline).


### PR DESCRIPTION
## Summary
- add project API key list/create/delete commands
- add router API key list/create/delete commands
- require login-session cookie auth for key management
- consolidate shared output formatting helpers and show router limits as USD

## Test plan
- go test ./...
- go run main.go api-keys list/create/delete
- go run main.go router-keys list/create/delete
- go run main.go --api-key pk:sk router-keys list