### PR TITLE
DEV-813: allow JWT key management auth

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.35.1"
+current_version = "0.35.2"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/api_keys.go
+++ b/cmd/api_keys.go
@@ -32,9 +32,12 @@ var (
 	routerKeyExpiresAt     string
 )
 
-func requireCLISession() error {
-	if token != "" || apiKey != "" {
+func requireKeyManagementAuth() error {
+	if apiKey != "" {
 		return auth.KeyManagementLoginRequiredError()
+	}
+	if token != "" {
+		return nil
 	}
 
 	cookies, err := files.LoadSessionCookies(cfgDirName, sessionFileName)
@@ -53,7 +56,7 @@ var apiKeysCmd = &cobra.Command{
 	Aliases: []string{"api-key"},
 	Short:   "Project API keys",
 	GroupID: groupAuth,
-	Long: `Manage project API keys. Requires iai login. API key authentication is not supported.
+	Long: `Manage project API keys. Requires iai login or JWT authentication. API key authentication is not supported.
 
 Project API keys authenticate platform/API access for reading and writing project context, such as prompts, routines, policies, variables, glossaries, macros, traces, scores, datasets, and for creating infrastructure resources such as agents, services, and databases.`,
 }
@@ -64,7 +67,7 @@ var apiKeysListCmd = &cobra.Command{
 	Short:   "List project API keys",
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := requireCLISession(); err != nil {
+		if err := requireKeyManagementAuth(); err != nil {
 			return err
 		}
 
@@ -88,7 +91,7 @@ var apiKeysListCmd = &cobra.Command{
 			return err
 		}
 
-		keys, err := apiClient.ListProjectAPIKeys(cmd.Context(), pCtx.projectId)
+		keys, err := apiClient.ListProjectAPIKeys(cmd.Context(), pCtx.orgId, pCtx.projectId)
 		if err != nil {
 			return err
 		}
@@ -111,7 +114,7 @@ var apiKeysCreateCmd = &cobra.Command{
 Project API keys authenticate platform/API access for reading and writing project context, such as prompts, routines, policies, variables, glossaries, macros, traces, scores, datasets, and for creating infrastructure resources such as agents, services, and databases.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := requireCLISession(); err != nil {
+		if err := requireKeyManagementAuth(); err != nil {
 			return err
 		}
 
@@ -127,7 +130,9 @@ Project API keys authenticate platform/API access for reading and writing projec
 
 		key, err := apiClient.CreateProjectAPIKey(
 			cmd.Context(),
-			clients.CreateProjectAPIKeyBody{ProjectID: pCtx.projectId, Note: apiKeyNote},
+			pCtx.orgId,
+			pCtx.projectId,
+			clients.CreateProjectAPIKeyBody{Note: apiKeyNote},
 		)
 		if err != nil {
 			return err
@@ -152,7 +157,7 @@ var apiKeysDeleteCmd = &cobra.Command{
 	Short: "Delete a project API key",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := requireCLISession(); err != nil {
+		if err := requireKeyManagementAuth(); err != nil {
 			return err
 		}
 
@@ -166,7 +171,12 @@ var apiKeysDeleteCmd = &cobra.Command{
 			return err
 		}
 
-		res, err := apiClient.DeleteProjectAPIKey(cmd.Context(), pCtx.projectId, args[0])
+		res, err := apiClient.DeleteProjectAPIKey(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			args[0],
+		)
 		if err != nil {
 			return err
 		}
@@ -195,7 +205,7 @@ var routerKeysCmd = &cobra.Command{
 	Aliases: []string{"router-key"},
 	Short:   "Router API keys",
 	GroupID: groupAuth,
-	Long: `Manage InteractiveAI Router API keys. Requires iai login. API key authentication is not supported.
+	Long: `Manage InteractiveAI Router API keys. Requires iai login or JWT authentication. API key authentication is not supported.
 
 Router keys authenticate inference requests to the InteractiveAI Router, for example chat completions and model calls. They are used as bearer tokens for runtime inference, not for managing project context or infrastructure.`,
 }
@@ -206,7 +216,7 @@ var routerKeysListCmd = &cobra.Command{
 	Short:   "List router API keys",
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := requireCLISession(); err != nil {
+		if err := requireKeyManagementAuth(); err != nil {
 			return err
 		}
 
@@ -253,7 +263,7 @@ var routerKeysCreateCmd = &cobra.Command{
 Router keys authenticate inference requests to the InteractiveAI Router, for example chat completions and model calls. They are used as bearer tokens for runtime inference, not for managing project context or infrastructure.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := requireCLISession(); err != nil {
+		if err := requireKeyManagementAuth(); err != nil {
 			return err
 		}
 
@@ -323,7 +333,7 @@ var routerKeysDeleteCmd = &cobra.Command{
 	Short: "Delete a router API key",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := requireCLISession(); err != nil {
+		if err := requireKeyManagementAuth(); err != nil {
 			return err
 		}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version            = "0.35.1"
+	version            = "0.35.2"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second

--- a/docs/iai_api-keys.md
+++ b/docs/iai_api-keys.md
@@ -4,7 +4,7 @@ Project API keys
 
 ### Synopsis
 
-Manage project API keys. Requires iai login. API key authentication is not supported.
+Manage project API keys. Requires iai login or JWT authentication. API key authentication is not supported.
 
 Project API keys authenticate platform/API access for reading and writing project context, such as prompts, routines, policies, variables, glossaries, macros, traces, scores, datasets, and for creating infrastructure resources such as agents, services, and databases.
 

--- a/docs/iai_router-keys.md
+++ b/docs/iai_router-keys.md
@@ -4,7 +4,7 @@ Router API keys
 
 ### Synopsis
 
-Manage InteractiveAI Router API keys. Requires iai login. API key authentication is not supported.
+Manage InteractiveAI Router API keys. Requires iai login or JWT authentication. API key authentication is not supported.
 
 Router keys authenticate inference requests to the InteractiveAI Router, for example chat completions and model calls. They are used as bearer tokens for runtime inference, not for managing project context or infrastructure.
 

--- a/internal/auth/errors.go
+++ b/internal/auth/errors.go
@@ -2,9 +2,9 @@ package auth
 
 import "fmt"
 
-// KeyManagementLoginRequiredError reports that key management requires iai login.
+// KeyManagementLoginRequiredError reports that key management requires user auth.
 func KeyManagementLoginRequiredError() error {
 	return fmt.Errorf(
-		"this command requires iai login; API key authentication is not supported for key management",
+		"this command requires iai login or JWT authentication; API key authentication is not supported for key management",
 	)
 }

--- a/internal/clients/api_client_keys.go
+++ b/internal/clients/api_client_keys.go
@@ -22,8 +22,7 @@ type ProjectAPIKey struct {
 }
 
 type CreateProjectAPIKeyBody struct {
-	ProjectID string `json:"projectId"`
-	Note      string `json:"note,omitempty"`
+	Note string `json:"note,omitempty"`
 }
 
 type RouterAPIKey struct {
@@ -70,138 +69,106 @@ type DeleteAPIKeyResponse struct {
 	Message string `json:"message"`
 }
 
-func (c *APIClient) requireCookieMode() error {
-	if c.token != "" || c.apiKey != "" || len(c.cookies) == 0 {
+func (c *APIClient) requireKeyManagementAuth() error {
+	if c.apiKey != "" || (c.token == "" && len(c.cookies) == 0) {
 		return auth.KeyManagementLoginRequiredError()
 	}
 
 	return nil
 }
 
-func (c *APIClient) trpcMutation(ctx context.Context, path string, input any, out any) error {
-	if err := c.requireCookieMode(); err != nil {
-		return err
-	}
-
-	req, err := c.newJSONRequest(
-		ctx,
-		http.MethodPost,
-		"/api/trpc/"+path,
-		map[string]any{"json": input},
+func projectAPIKeysPath(orgID, projectID string) string {
+	return fmt.Sprintf(
+		"/api/platform/v1/organizations/%s/projects/%s/api-keys",
+		url.PathEscape(orgID),
+		url.PathEscape(projectID),
 	)
-	if err != nil {
-		return err
-	}
-
-	body, err := c.doAndRead(req, path)
-	if err != nil {
-		return err
-	}
-
-	return decodeTRPCData(body, out)
 }
 
-func (c *APIClient) trpcQuery(ctx context.Context, path string, input any, out any) error {
-	if err := c.requireCookieMode(); err != nil {
-		return err
-	}
-
-	encoded, err := json.Marshal(map[string]any{"json": input})
-	if err != nil {
-		return fmt.Errorf("failed to encode tRPC input: %w", err)
-	}
-	u, err := url.Parse(c.hostname)
-	if err != nil {
-		return fmt.Errorf("failed to parse API hostname: %w", err)
-	}
-	u.Path = "/api/trpc/" + path
-	u.RawQuery = "input=" + url.QueryEscape(string(encoded))
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
-	if err != nil {
-		return err
-	}
-
-	body, err := c.doAndRead(req, path)
-	if err != nil {
-		return err
-	}
-
-	return decodeTRPCData(body, out)
-}
-
-func decodeTRPCData(body []byte, out any) error {
-	var envelope struct {
-		Result struct {
-			Data json.RawMessage `json:"data"`
-		} `json:"result"`
-		Error any `json:"error"`
-	}
-	if err := json.Unmarshal(body, &envelope); err != nil {
-		return fmt.Errorf("failed to decode tRPC response: %w", err)
-	}
-	if envelope.Error != nil {
-		if msg := ExtractServerMessage(body); msg != "" {
-			return fmt.Errorf("tRPC error: %s", msg)
-		}
-		return fmt.Errorf("tRPC error")
-	}
-	if len(envelope.Result.Data) == 0 {
-		return nil
-	}
-
-	var wrapped struct {
-		JSON json.RawMessage `json:"json"`
-	}
-	if err := json.Unmarshal(envelope.Result.Data, &wrapped); err == nil && len(wrapped.JSON) > 0 {
-		return json.Unmarshal(wrapped.JSON, out)
-	}
-	return json.Unmarshal(envelope.Result.Data, out)
+func projectAPIKeyPath(orgID, projectID, keyID string) string {
+	return fmt.Sprintf(
+		"/api/platform/v1/organizations/%s/projects/%s/api-keys/%s",
+		url.PathEscape(orgID),
+		url.PathEscape(projectID),
+		url.PathEscape(keyID),
+	)
 }
 
 func (c *APIClient) ListProjectAPIKeys(
 	ctx context.Context,
-	projectID string,
+	orgID, projectID string,
 ) ([]ProjectAPIKey, error) {
-	var keys []ProjectAPIKey
-	err := c.trpcQuery(
-		ctx,
-		"projectApiKeys.byProjectId",
-		map[string]string{"projectId": projectID},
-		&keys,
-	)
-	return keys, err
+	if err := c.requireKeyManagementAuth(); err != nil {
+		return nil, err
+	}
+
+	req, err := c.newRequest(ctx, http.MethodGet, projectAPIKeysPath(orgID, projectID))
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := c.doAndRead(req, "list project API keys")
+	if err != nil {
+		return nil, err
+	}
+	return decodeSuccess[[]ProjectAPIKey](body, "list project API keys")
 }
 
 func (c *APIClient) CreateProjectAPIKey(
 	ctx context.Context,
+	orgID, projectID string,
 	body CreateProjectAPIKeyBody,
 ) (ProjectAPIKey, error) {
-	var key ProjectAPIKey
-	err := c.trpcMutation(ctx, "projectApiKeys.create", body, &key)
-	return key, err
+	if err := c.requireKeyManagementAuth(); err != nil {
+		return ProjectAPIKey{}, err
+	}
+
+	payload := map[string]string{}
+	if body.Note != "" {
+		payload["note"] = body.Note
+	}
+	req, err := c.newJSONRequest(
+		ctx,
+		http.MethodPost,
+		projectAPIKeysPath(orgID, projectID),
+		payload,
+	)
+	if err != nil {
+		return ProjectAPIKey{}, err
+	}
+
+	respBody, err := c.doAndRead(req, "create project API key")
+	if err != nil {
+		return ProjectAPIKey{}, err
+	}
+	return decodeSuccess[ProjectAPIKey](respBody, "create project API key")
 }
 
 func (c *APIClient) DeleteProjectAPIKey(
 	ctx context.Context,
-	projectID, keyID string,
+	orgID, projectID, keyID string,
 ) (DeleteAPIKeyResponse, error) {
-	var ok bool
-	if err := c.trpcMutation(
-		ctx,
-		"projectApiKeys.delete",
-		map[string]string{"projectId": projectID, "id": keyID},
-		&ok,
-	); err != nil {
+	if err := c.requireKeyManagementAuth(); err != nil {
 		return DeleteAPIKeyResponse{}, err
 	}
-	return DeleteAPIKeyResponse{Success: ok}, nil
+
+	req, err := c.newRequest(ctx, http.MethodDelete, projectAPIKeyPath(orgID, projectID, keyID))
+	if err != nil {
+		return DeleteAPIKeyResponse{}, err
+	}
+
+	body, err := c.doAndRead(req, "delete project API key")
+	if err != nil {
+		return DeleteAPIKeyResponse{}, err
+	}
+	return decodeSuccess[DeleteAPIKeyResponse](body, "delete project API key")
 }
 
 func (c *APIClient) ListRouterAPIKeys(
 	ctx context.Context,
 	projectID string,
 ) (RouterAPIKeyListResponse, error) {
-	if err := c.requireCookieMode(); err != nil {
+	if err := c.requireKeyManagementAuth(); err != nil {
 		return RouterAPIKeyListResponse{}, err
 	}
 
@@ -226,7 +193,7 @@ func (c *APIClient) CreateRouterAPIKey(
 	projectID string,
 	body CreateRouterAPIKeyBody,
 ) (CreateRouterAPIKeyResponse, error) {
-	if err := c.requireCookieMode(); err != nil {
+	if err := c.requireKeyManagementAuth(); err != nil {
 		return CreateRouterAPIKeyResponse{}, err
 	}
 
@@ -250,7 +217,7 @@ func (c *APIClient) DeleteRouterAPIKey(
 	ctx context.Context,
 	projectID, keyID string,
 ) (DeleteAPIKeyResponse, error) {
-	if err := c.requireCookieMode(); err != nil {
+	if err := c.requireKeyManagementAuth(); err != nil {
 		return DeleteAPIKeyResponse{}, err
 	}
 

--- a/internal/clients/api_client_keys_test.go
+++ b/internal/clients/api_client_keys_test.go
@@ -1,70 +1,98 @@
 package clients
 
 import (
-	"context"
 	"net/http"
-	"net/http/httptest"
 	"testing"
-	"time"
 )
 
-func TestDecodeTRPCData(t *testing.T) {
-	body := []byte(`{"result":{"data":{"json":{"publicKey":"pk","secretKey":"sk"}}}}`)
-	var got ProjectAPIKey
-	if err := decodeTRPCData(body, &got); err != nil {
-		t.Fatalf("decodeTRPCData() error = %v", err)
+func TestProjectAPIKeysPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		orgID     string
+		projectID string
+		want      string
+	}{
+		{
+			name:      "plain ids",
+			orgID:     "org-1",
+			projectID: "project-1",
+			want:      "/api/platform/v1/organizations/org-1/projects/project-1/api-keys",
+		},
+		{
+			name:      "escapes path segments",
+			orgID:     "org/1",
+			projectID: "project 1",
+			want:      "/api/platform/v1/organizations/org%2F1/projects/project%201/api-keys",
+		},
 	}
-	if got.PublicKey != "pk" || got.SecretKey != "sk" {
-		t.Fatalf("decoded key = %#v", got)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := projectAPIKeysPath(tt.orgID, tt.projectID); got != tt.want {
+				t.Fatalf("projectAPIKeysPath() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
-func TestCreateRouterAPIKeyUsesCookieAuth(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v1/projects/project-1/openrouter-keys" {
-			t.Fatalf("path = %s", r.URL.Path)
-		}
-		if r.Header.Get("Authorization") != "" {
-			t.Fatalf("unexpected authorization header: %s", r.Header.Get("Authorization"))
-		}
-		if _, err := r.Cookie("next-auth.session-token"); err != nil {
-			t.Fatalf("missing session cookie: %v", err)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(
-			[]byte(
-				`{"id":"id","key":"sk-or","name":"dev","key_preview":"sk-or-***","project_id":"project-1","user_id":"u","disabled":false,"created_at":"2026-01-01T00:00:00Z"}`,
-			),
-		)
-	}))
-	defer server.Close()
+func TestProjectAPIKeyPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		orgID     string
+		projectID string
+		keyID     string
+		want      string
+	}{
+		{
+			name:      "plain ids",
+			orgID:     "org-1",
+			projectID: "project-1",
+			keyID:     "key-1",
+			want:      "/api/platform/v1/organizations/org-1/projects/project-1/api-keys/key-1",
+		},
+		{
+			name:      "escapes path segments",
+			orgID:     "org/1",
+			projectID: "project 1",
+			keyID:     "key/1",
+			want:      "/api/platform/v1/organizations/org%2F1/projects/project%201/api-keys/key%2F1",
+		},
+	}
 
-	client, err := NewAPIClient(
-		server.URL,
-		5*time.Second,
-		"",
-		"",
-		[]*http.Cookie{{Name: "next-auth.session-token", Value: "cookie"}},
-	)
-	if err != nil {
-		t.Fatalf("NewAPIClient() error = %v", err)
-	}
-	got, err := client.CreateRouterAPIKey(
-		context.Background(),
-		"project-1",
-		CreateRouterAPIKeyBody{Name: "dev"},
-	)
-	if err != nil {
-		t.Fatalf("CreateRouterAPIKey() error = %v", err)
-	}
-	if got.Key != "sk-or" {
-		t.Fatalf("key = %q", got.Key)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := projectAPIKeyPath(tt.orgID, tt.projectID, tt.keyID); got != tt.want {
+				t.Fatalf("projectAPIKeyPath() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
-func TestKeysRejectAPIKeyAuth(t *testing.T) {
-	client := &APIClient{apiKey: "pk:sk"}
-	if err := client.requireCookieMode(); err == nil {
-		t.Fatal("requireCookieMode() expected error")
+func TestRequireKeyManagementAuth(t *testing.T) {
+	tests := []struct {
+		name    string
+		client  *APIClient
+		wantErr bool
+	}{
+		{name: "rejects api key", client: &APIClient{apiKey: "pk:sk"}, wantErr: true},
+		{name: "allows jwt", client: &APIClient{token: "jwt"}},
+		{name: "allows cookies", client: &APIClient{cookies: nonEmptyCookies()}},
+		{name: "rejects missing auth", client: &APIClient{}, wantErr: true},
 	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.client.requireKeyManagementAuth()
+			if tt.wantErr && err == nil {
+				t.Fatal("requireKeyManagementAuth() expected error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("requireKeyManagementAuth() error = %v", err)
+			}
+		})
+	}
+}
+
+func nonEmptyCookies() []*http.Cookie {
+	return []*http.Cookie{{Name: "next-auth.session-token", Value: "cookie"}}
 }


### PR DESCRIPTION
## Summary
- allow JWT auth for api-keys/router-keys while still rejecting API-key auth
- switch project API key commands to the new Platform API endpoints
- update generated docs and client tests

## Depends on
- https://github.com/Interactive-AI-Labs/platform/pull/1193

## Checks
- go test ./internal/clients ./cmd
- pre-commit run --all-files
- local JWT smoke tested router-keys list