### PR TITLE
feat(collections): iai collections CLI commands (DEV-822)

### DIFF
--- a/cmd/collections.go
+++ b/cmd/collections.go
@@ -1,0 +1,281 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/inputs"
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var (
+	collProject      string
+	collOrganization string
+	collDatabase     string
+	collFile         string
+	collJSON         bool
+	collYAML         bool
+)
+
+var collectionsCmd = &cobra.Command{
+	Use:     "collections",
+	Aliases: []string{"collection", "coll"},
+	Short:   "Vector collections (knowledge bases) inside a pgvector database",
+	GroupID: groupInfra,
+	Long: `Manage vector collections within a database.
+
+A collection is a vector store (knowledge base) that lives inside an existing
+pgvector database, so every command requires --database. Use 'iai databases
+create' first to provision the database.`,
+}
+
+var collListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List collections in a database",
+	Example: `  iai collections list -d my-db
+  iai collections list -d my-db --json`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
+		if err != nil {
+			return err
+		}
+
+		collections, err := deployClient.ListCollections(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			collDatabase,
+		)
+		if err != nil {
+			return err
+		}
+
+		if collJSON {
+			return output.PrintStructuredJSON(out, collections)
+		}
+		if collYAML {
+			return output.PrintStructuredYAML(out, collections)
+		}
+		return output.PrintCollectionList(out, collections)
+	},
+}
+
+var collDescribeCmd = &cobra.Command{
+	Use:     "describe <collection>",
+	Aliases: []string{"desc"},
+	Short:   "Describe a collection's configuration",
+	Example: `  iai collections describe docs -d my-db
+  iai collections describe docs -d my-db --json`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		name := strings.TrimSpace(args[0])
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
+		if err != nil {
+			return err
+		}
+
+		coll, err := deployClient.DescribeCollection(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			collDatabase,
+			name,
+		)
+		if err != nil {
+			return err
+		}
+
+		if collJSON {
+			return output.PrintStructuredJSON(out, coll)
+		}
+		if collYAML {
+			return output.PrintStructuredYAML(out, coll)
+		}
+		return output.PrintCollectionDescribe(out, coll)
+	},
+}
+
+var collStatsCmd = &cobra.Command{
+	Use:   "stats <collection>",
+	Short: "Show a collection's chunk count, size, and index status",
+	Example: `  iai collections stats docs -d my-db
+  iai collections stats docs -d my-db --json`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		name := strings.TrimSpace(args[0])
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
+		if err != nil {
+			return err
+		}
+
+		stats, err := deployClient.GetCollectionStats(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			collDatabase,
+			name,
+		)
+		if err != nil {
+			return err
+		}
+
+		if collJSON {
+			return output.PrintStructuredJSON(out, stats)
+		}
+		if collYAML {
+			return output.PrintStructuredYAML(out, stats)
+		}
+		return output.PrintCollectionStats(out, stats)
+	},
+}
+
+var collCreateCmd = &cobra.Command{
+	Use:   "create <collection>",
+	Short: "Create a collection from a config file",
+	Long: `Create a vector collection from a YAML or JSON config file (--file).
+
+The config declares the vector slot(s) — either an embedding-backed slot
+("embedding": {model, dimension}) or a raw vector slot ({type, dimension,
+distance}) — and optional full-text search.`,
+	Example: `  iai collections create docs -d my-db --file collection.yaml`,
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		name := strings.TrimSpace(args[0])
+
+		body, err := inputs.ReadCollectionBodyFile(collFile)
+		if err != nil {
+			return err
+		}
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
+		if err != nil {
+			return err
+		}
+
+		msg, err := deployClient.CreateCollection(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			collDatabase,
+			name,
+			body,
+		)
+		if err != nil {
+			return err
+		}
+		if msg != "" {
+			fmt.Fprintln(out, msg)
+		}
+		return nil
+	},
+}
+
+var collPatchCmd = &cobra.Command{
+	Use:   "patch <collection>",
+	Short: "Update a collection's mutable config from a file",
+	Long: `Update a collection's mutable configuration from a YAML or JSON file (--file):
+full-text settings and per-slot ef_search_default. Slot type/dimension/distance
+and the embedding model are immutable.`,
+	Example: `  iai collections patch docs -d my-db --file patch.yaml`,
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		name := strings.TrimSpace(args[0])
+
+		body, err := inputs.ReadCollectionBodyFile(collFile)
+		if err != nil {
+			return err
+		}
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
+		if err != nil {
+			return err
+		}
+
+		msg, err := deployClient.PatchCollection(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			collDatabase,
+			name,
+			body,
+		)
+		if err != nil {
+			return err
+		}
+		if msg != "" {
+			fmt.Fprintln(out, msg)
+		}
+		return nil
+	},
+}
+
+var collDeleteCmd = &cobra.Command{
+	Use:     "delete <collection>",
+	Aliases: []string{"rm"},
+	Short:   "Delete a collection and all its data",
+	Example: `  iai collections delete docs -d my-db`,
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		name := strings.TrimSpace(args[0])
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
+		if err != nil {
+			return err
+		}
+
+		msg, err := deployClient.DeleteCollection(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			collDatabase,
+			name,
+		)
+		if err != nil {
+			return err
+		}
+		if msg != "" {
+			fmt.Fprintln(out, msg)
+		}
+		return nil
+	},
+}
+
+func init() {
+	// Shared scope flags on every subcommand: -o org, -p project, -d database.
+	for _, c := range []*cobra.Command{
+		collListCmd, collDescribeCmd, collStatsCmd, collCreateCmd, collPatchCmd, collDeleteCmd,
+	} {
+		c.Flags().StringVarP(&collOrganization, "organization", "o", "", "Organization name")
+		c.Flags().StringVarP(&collProject, "project", "p", "", "Project name")
+		c.Flags().
+			StringVarP(&collDatabase, "database", "d", "", "Database that holds the collection (required)")
+		_ = c.MarkFlagRequired("database")
+	}
+
+	for _, c := range []*cobra.Command{collListCmd, collDescribeCmd, collStatsCmd} {
+		c.Flags().BoolVar(&collJSON, "json", false, "Output raw API response as JSON")
+		c.Flags().BoolVar(&collYAML, "yaml", false, "Output raw API response as YAML")
+	}
+
+	collCreateCmd.Flags().StringVar(&collFile, "file", "", "Path to a YAML/JSON collection config")
+	_ = collCreateCmd.MarkFlagRequired("file")
+	collPatchCmd.Flags().StringVar(&collFile, "file", "", "Path to a YAML/JSON patch config")
+	_ = collPatchCmd.MarkFlagRequired("file")
+
+	collectionsCmd.AddCommand(
+		collListCmd, collDescribeCmd, collStatsCmd, collCreateCmd, collPatchCmd, collDeleteCmd,
+	)
+	rootCmd.AddCommand(collectionsCmd)
+}

--- a/cmd/collections_chunks.go
+++ b/cmd/collections_chunks.go
@@ -1,0 +1,351 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/inputs"
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var (
+	chunkFile          string
+	chunkLimit         int
+	chunkCursor        string
+	chunkPrefix        string
+	chunkIncludeVector bool
+	chunkIDs           []string
+	chunkFilter        string
+	chunkAll           bool
+)
+
+var chunksCmd = &cobra.Command{
+	Use:   "chunks",
+	Short: "Manage the chunks (rows) in a collection",
+	Long:  `Upsert, inspect, and delete the chunks stored in a collection.`,
+}
+
+var chunksUpsertCmd = &cobra.Command{
+	Use:   "upsert <collection>",
+	Short: "Upsert chunks from a file",
+	Long: `Upsert a batch of chunks from a YAML or JSON file (--file).
+
+Chunks with text and no client vector are embedded server-side (set
+defer_embedding=true with client-supplied vectors to skip embedding).`,
+	Example: `  iai collections chunks upsert docs -d my-db --file chunks.json`,
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		collection := strings.TrimSpace(args[0])
+
+		body, err := inputs.ReadCollectionBodyFile(chunkFile)
+		if err != nil {
+			return err
+		}
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
+		if err != nil {
+			return err
+		}
+
+		result, err := deployClient.UpsertChunks(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			collDatabase,
+			collection,
+			body,
+		)
+		if err != nil {
+			return err
+		}
+
+		if collJSON {
+			return output.PrintStructuredJSON(out, result)
+		}
+		if collYAML {
+			return output.PrintStructuredYAML(out, result)
+		}
+		return output.PrintChunkUpsertResult(out, result)
+	},
+}
+
+var chunksListCmd = &cobra.Command{
+	Use:     "list <collection>",
+	Aliases: []string{"ls"},
+	Short:   "List chunks (keyset-paginated)",
+	Example: `  iai collections chunks list docs -d my-db --limit 20
+  iai collections chunks list docs -d my-db --cursor <token>`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		collection := strings.TrimSpace(args[0])
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
+		if err != nil {
+			return err
+		}
+
+		list, err := deployClient.ListChunks(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			collDatabase,
+			collection,
+			clients.ListChunksOpts{Limit: chunkLimit, Cursor: chunkCursor, Prefix: chunkPrefix},
+		)
+		if err != nil {
+			return err
+		}
+
+		if collJSON {
+			return output.PrintStructuredJSON(out, list)
+		}
+		if collYAML {
+			return output.PrintStructuredYAML(out, list)
+		}
+		return output.PrintChunkList(out, list)
+	},
+}
+
+var chunksGetCmd = &cobra.Command{
+	Use:   "get <collection> <id>",
+	Short: "Get a single chunk",
+	Example: `  iai collections chunks get docs chunk-1 -d my-db
+  iai collections chunks get docs chunk-1 -d my-db --include-vector`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		collection := strings.TrimSpace(args[0])
+		id := strings.TrimSpace(args[1])
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
+		if err != nil {
+			return err
+		}
+
+		chunk, err := deployClient.GetChunk(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			collDatabase,
+			collection,
+			id,
+			chunkIncludeVector,
+		)
+		if err != nil {
+			return err
+		}
+
+		if collJSON {
+			return output.PrintStructuredJSON(out, chunk)
+		}
+		if collYAML {
+			return output.PrintStructuredYAML(out, chunk)
+		}
+		return output.PrintChunk(out, chunk)
+	},
+}
+
+var chunksCountCmd = &cobra.Command{
+	Use:     "count <collection>",
+	Short:   "Count chunks, optionally scoped by a metadata filter or id prefix",
+	Example: `  iai collections chunks count docs -d my-db --filter '{"lang":"en"}'`,
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		collection := strings.TrimSpace(args[0])
+
+		body, err := inputs.BuildChunkCountBody(chunkFilter, chunkPrefix)
+		if err != nil {
+			return err
+		}
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
+		if err != nil {
+			return err
+		}
+
+		count, err := deployClient.CountChunks(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			collDatabase,
+			collection,
+			body,
+		)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintf(out, "%d\n", count)
+		return nil
+	},
+}
+
+var chunksPatchCmd = &cobra.Command{
+	Use:     "patch <collection> <id>",
+	Short:   "Update a chunk's metadata and/or text from a file",
+	Example: `  iai collections chunks patch docs chunk-1 -d my-db --file patch.json`,
+	Args:    cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		collection := strings.TrimSpace(args[0])
+		id := strings.TrimSpace(args[1])
+
+		body, err := inputs.ReadCollectionBodyFile(chunkFile)
+		if err != nil {
+			return err
+		}
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
+		if err != nil {
+			return err
+		}
+
+		chunk, err := deployClient.PatchChunk(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			collDatabase,
+			collection,
+			id,
+			body,
+		)
+		if err != nil {
+			return err
+		}
+
+		if collJSON {
+			return output.PrintStructuredJSON(out, chunk)
+		}
+		if collYAML {
+			return output.PrintStructuredYAML(out, chunk)
+		}
+		return output.PrintChunk(out, chunk)
+	},
+}
+
+var chunksDeleteCmd = &cobra.Command{
+	Use:     "delete <collection> <id>",
+	Aliases: []string{"rm"},
+	Short:   "Delete a single chunk by id",
+	Example: `  iai collections chunks delete docs chunk-1 -d my-db`,
+	Args:    cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		collection := strings.TrimSpace(args[0])
+		id := strings.TrimSpace(args[1])
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
+		if err != nil {
+			return err
+		}
+
+		msg, err := deployClient.DeleteChunk(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			collDatabase,
+			collection,
+			id,
+		)
+		if err != nil {
+			return err
+		}
+		if msg != "" {
+			fmt.Fprintln(out, msg)
+		}
+		return nil
+	},
+}
+
+var chunksBulkDeleteCmd = &cobra.Command{
+	Use:   "bulk-delete <collection>",
+	Short: "Delete many chunks by ids, metadata filter, or all",
+	Long: `Delete chunks by exactly one selector: --ids, --filter, or --all.
+
+--all deletes every chunk and requires confirmation.`,
+	Example: `  iai collections chunks bulk-delete docs -d my-db --ids a,b,c
+  iai collections chunks bulk-delete docs -d my-db --filter '{"lang":"en"}'
+  iai collections chunks bulk-delete docs -d my-db --all`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		collection := strings.TrimSpace(args[0])
+
+		body, err := inputs.BuildBulkDeleteBody(chunkIDs, chunkFilter, chunkAll)
+		if err != nil {
+			return err
+		}
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
+		if err != nil {
+			return err
+		}
+
+		result, err := deployClient.BulkDeleteChunks(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			collDatabase,
+			collection,
+			body,
+			chunkAll,
+		)
+		if err != nil {
+			return err
+		}
+		return output.PrintBulkDeleteResult(out, result)
+	},
+}
+
+func init() {
+	chunkSubcommands := []*cobra.Command{
+		chunksUpsertCmd, chunksListCmd, chunksGetCmd, chunksCountCmd,
+		chunksPatchCmd, chunksDeleteCmd, chunksBulkDeleteCmd,
+	}
+	for _, c := range chunkSubcommands {
+		c.Flags().StringVarP(&collOrganization, "organization", "o", "", "Organization name")
+		c.Flags().StringVarP(&collProject, "project", "p", "", "Project name")
+		c.Flags().
+			StringVarP(&collDatabase, "database", "d", "", "Database that holds the collection (required)")
+		_ = c.MarkFlagRequired("database")
+	}
+
+	for _, c := range []*cobra.Command{chunksUpsertCmd, chunksListCmd, chunksGetCmd, chunksPatchCmd} {
+		c.Flags().BoolVar(&collJSON, "json", false, "Output raw API response as JSON")
+		c.Flags().BoolVar(&collYAML, "yaml", false, "Output raw API response as YAML")
+	}
+
+	chunksUpsertCmd.Flags().StringVar(&chunkFile, "file", "", "Path to a YAML/JSON chunks file")
+	_ = chunksUpsertCmd.MarkFlagRequired("file")
+
+	chunksListCmd.Flags().IntVar(&chunkLimit, "limit", 0, "Page size (1-1000, default 100)")
+	chunksListCmd.Flags().
+		StringVar(&chunkCursor, "cursor", "", "Opaque cursor from a previous page")
+	chunksListCmd.Flags().
+		StringVar(&chunkPrefix, "prefix", "", "Only chunks whose id has this prefix")
+
+	chunksGetCmd.Flags().
+		BoolVar(&chunkIncludeVector, "include-vector", false, "Include the stored vector(s)")
+
+	chunksCountCmd.Flags().StringVar(&chunkFilter, "filter", "", "Metadata filter as a JSON object")
+	chunksCountCmd.Flags().
+		StringVar(&chunkPrefix, "prefix", "", "Only count chunks with this id prefix")
+
+	chunksPatchCmd.Flags().StringVar(&chunkFile, "file", "", "Path to a YAML/JSON patch file")
+	_ = chunksPatchCmd.MarkFlagRequired("file")
+
+	chunksBulkDeleteCmd.Flags().
+		StringSliceVar(&chunkIDs, "ids", nil, "Comma-separated chunk ids to delete")
+	chunksBulkDeleteCmd.Flags().
+		StringVar(&chunkFilter, "filter", "", "Metadata filter as a JSON object")
+	chunksBulkDeleteCmd.Flags().
+		BoolVar(&chunkAll, "all", false, "Delete every chunk (requires confirm)")
+
+	chunksCmd.AddCommand(chunkSubcommands...)
+	collectionsCmd.AddCommand(chunksCmd)
+}

--- a/cmd/collections_chunks.go
+++ b/cmd/collections_chunks.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"strings"
 
@@ -19,6 +20,7 @@ var (
 	chunkIDs           []string
 	chunkFilter        string
 	chunkAll           bool
+	chunkYes           bool
 )
 
 var chunksCmd = &cobra.Command{
@@ -281,6 +283,15 @@ var chunksBulkDeleteCmd = &cobra.Command{
 			return err
 		}
 
+		if chunkAll && !chunkYes {
+			fmt.Fprintf(out, "Delete ALL chunks in %q? This cannot be undone. [y/N]: ", collection)
+			line, _ := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
+			if ans := strings.ToLower(strings.TrimSpace(line)); ans != "y" && ans != "yes" {
+				fmt.Fprintln(out, "Aborted.")
+				return nil
+			}
+		}
+
 		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
 		if err != nil {
 			return err
@@ -345,6 +356,8 @@ func init() {
 		StringVar(&chunkFilter, "filter", "", "Metadata filter as a JSON object")
 	chunksBulkDeleteCmd.Flags().
 		BoolVar(&chunkAll, "all", false, "Delete every chunk (requires confirm)")
+	chunksBulkDeleteCmd.Flags().
+		BoolVar(&chunkYes, "yes", false, "Skip the --all confirmation prompt")
 
 	chunksCmd.AddCommand(chunkSubcommands...)
 	collectionsCmd.AddCommand(chunksCmd)

--- a/cmd/collections_documents.go
+++ b/cmd/collections_documents.go
@@ -1,0 +1,154 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var (
+	docLimit         int
+	docCursor        string
+	docIncludeVector bool
+)
+
+var documentsCmd = &cobra.Command{
+	Use:     "documents",
+	Aliases: []string{"document", "docs"},
+	Short:   "Inspect documents (chunks grouped by documentId)",
+	Long:    `A document is the set of chunks sharing a documentId. These are read/delete views over chunks.`,
+}
+
+var documentsListCmd = &cobra.Command{
+	Use:     "list <collection>",
+	Aliases: []string{"ls"},
+	Short:   "List documents in a collection",
+	Example: `  iai collections documents list docs -d my-db`,
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		collection := strings.TrimSpace(args[0])
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
+		if err != nil {
+			return err
+		}
+
+		list, err := deployClient.ListDocuments(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			collDatabase,
+			collection,
+			docLimit,
+			docCursor,
+		)
+		if err != nil {
+			return err
+		}
+
+		if collJSON {
+			return output.PrintStructuredJSON(out, list)
+		}
+		if collYAML {
+			return output.PrintStructuredYAML(out, list)
+		}
+		return output.PrintDocumentList(out, list)
+	},
+}
+
+var documentsGetCmd = &cobra.Command{
+	Use:     "get <collection> <documentId>",
+	Short:   "Get a document's chunks",
+	Example: `  iai collections documents get docs support-faq -d my-db`,
+	Args:    cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		collection := strings.TrimSpace(args[0])
+		documentID := strings.TrimSpace(args[1])
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
+		if err != nil {
+			return err
+		}
+
+		doc, err := deployClient.GetDocument(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			collDatabase,
+			collection,
+			documentID,
+			docLimit,
+			docCursor,
+			docIncludeVector,
+		)
+		if err != nil {
+			return err
+		}
+
+		if collJSON {
+			return output.PrintStructuredJSON(out, doc)
+		}
+		if collYAML {
+			return output.PrintStructuredYAML(out, doc)
+		}
+		return output.PrintDocumentChunks(out, doc)
+	},
+}
+
+var documentsDeleteCmd = &cobra.Command{
+	Use:     "delete <collection> <documentId>",
+	Aliases: []string{"rm"},
+	Short:   "Delete a document (all chunks sharing the documentId)",
+	Example: `  iai collections documents delete docs support-faq -d my-db`,
+	Args:    cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		collection := strings.TrimSpace(args[0])
+		documentID := strings.TrimSpace(args[1])
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
+		if err != nil {
+			return err
+		}
+
+		result, err := deployClient.DeleteDocument(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			collDatabase,
+			collection,
+			documentID,
+		)
+		if err != nil {
+			return err
+		}
+		return output.PrintDeleteDocumentResult(out, result)
+	},
+}
+
+func init() {
+	docSubcommands := []*cobra.Command{documentsListCmd, documentsGetCmd, documentsDeleteCmd}
+	for _, c := range docSubcommands {
+		c.Flags().StringVarP(&collOrganization, "organization", "o", "", "Organization name")
+		c.Flags().StringVarP(&collProject, "project", "p", "", "Project name")
+		c.Flags().
+			StringVarP(&collDatabase, "database", "d", "", "Database that holds the collection (required)")
+		_ = c.MarkFlagRequired("database")
+	}
+
+	for _, c := range []*cobra.Command{documentsListCmd, documentsGetCmd} {
+		c.Flags().BoolVar(&collJSON, "json", false, "Output raw API response as JSON")
+		c.Flags().BoolVar(&collYAML, "yaml", false, "Output raw API response as YAML")
+		c.Flags().IntVar(&docLimit, "limit", 0, "Page size (1-1000, default 100)")
+		c.Flags().StringVar(&docCursor, "cursor", "", "Opaque cursor from a previous page")
+	}
+
+	documentsGetCmd.Flags().
+		BoolVar(&docIncludeVector, "include-vector", false, "Include the stored vector(s)")
+
+	documentsCmd.AddCommand(docSubcommands...)
+	collectionsCmd.AddCommand(documentsCmd)
+}

--- a/cmd/collections_documents.go
+++ b/cmd/collections_documents.go
@@ -17,7 +17,7 @@ var documentsCmd = &cobra.Command{
 	Use:     "documents",
 	Aliases: []string{"document", "docs"},
 	Short:   "Inspect documents (chunks grouped by documentId)",
-	Long:    `A document is the set of chunks sharing a documentId. These are read/delete views over chunks.`,
+	Long:    `A document groups chunks by documentId; these commands read or delete them.`,
 }
 
 var documentsListCmd = &cobra.Command{

--- a/cmd/collections_search.go
+++ b/cmd/collections_search.go
@@ -1,0 +1,243 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/inputs"
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var (
+	searchQuery       string
+	searchVector      string
+	searchUsing       string
+	searchLimit       int
+	searchFilter      string
+	searchExact       bool
+	searchFile        string
+	searchID          string
+	searchExcludeSelf bool
+)
+
+var searchCmd = &cobra.Command{
+	Use:   "search <collection>",
+	Short: "Search a collection (single-lane vector search)",
+	Long: `Run a single-lane search: --query (text, embedded server-side) or --vector
+(comma-separated floats). --exact runs an exhaustive scan instead of the index.
+
+Sub-commands cover the other modes: batch, by-id, hybrid.`,
+	Example: `  iai collections search docs -d my-db --query "reset my password"
+  iai collections search docs -d my-db --query "..." --exact --limit 5`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		collection := strings.TrimSpace(args[0])
+
+		var vector []float64
+		if searchVector != "" {
+			v, err := inputs.ParseVector(searchVector)
+			if err != nil {
+				return err
+			}
+			vector = v
+		}
+		body, err := inputs.BuildSearchBody(
+			searchQuery,
+			vector,
+			searchUsing,
+			searchLimit,
+			searchFilter,
+		)
+		if err != nil {
+			return err
+		}
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
+		if err != nil {
+			return err
+		}
+
+		res, err := deployClient.Search(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			collDatabase,
+			collection,
+			body,
+			searchExact,
+		)
+		if err != nil {
+			return err
+		}
+		return printSearch(cmd, res)
+	},
+}
+
+var searchBatchCmd = &cobra.Command{
+	Use:     "batch <collection>",
+	Short:   "Run several searches in one request (from a file)",
+	Example: `  iai collections search batch docs -d my-db --file searches.json`,
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		collection := strings.TrimSpace(args[0])
+
+		body, err := inputs.ReadCollectionBodyFile(searchFile)
+		if err != nil {
+			return err
+		}
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
+		if err != nil {
+			return err
+		}
+
+		res, err := deployClient.SearchBatch(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			collDatabase,
+			collection,
+			body,
+		)
+		if err != nil {
+			return err
+		}
+
+		if collJSON {
+			return output.PrintStructuredJSON(out, res)
+		}
+		if collYAML {
+			return output.PrintStructuredYAML(out, res)
+		}
+		return output.PrintBatchSearchResults(out, res)
+	},
+}
+
+var searchByIDCmd = &cobra.Command{
+	Use:     "by-id <collection>",
+	Short:   "Find neighbors of an existing chunk by its stored vector",
+	Example: `  iai collections search by-id docs -d my-db --id chunk-1 --exclude-self`,
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		collection := strings.TrimSpace(args[0])
+
+		body, err := inputs.BuildQueryByIDBody(
+			searchID,
+			searchUsing,
+			searchLimit,
+			searchExcludeSelf,
+			searchFilter,
+		)
+		if err != nil {
+			return err
+		}
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
+		if err != nil {
+			return err
+		}
+
+		res, err := deployClient.QueryByID(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			collDatabase,
+			collection,
+			body,
+		)
+		if err != nil {
+			return err
+		}
+		return printSearch(cmd, res)
+	},
+}
+
+var searchHybridCmd = &cobra.Command{
+	Use:   "hybrid <collection>",
+	Short: "Run a multi-lane hybrid search (RRF) from a file",
+	Long: `Run a hybrid search from a YAML/JSON file whose body holds a "queries" array
+(dense and/or full_text lanes) and an optional "fusion" config.`,
+	Example: `  iai collections search hybrid docs -d my-db --file hybrid.json`,
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		collection := strings.TrimSpace(args[0])
+
+		body, err := inputs.ReadCollectionBodyFile(searchFile)
+		if err != nil {
+			return err
+		}
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
+		if err != nil {
+			return err
+		}
+
+		res, err := deployClient.HybridSearch(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			collDatabase,
+			collection,
+			body,
+		)
+		if err != nil {
+			return err
+		}
+		return printSearch(cmd, res)
+	},
+}
+
+// printSearch renders a SearchResponse honoring the --json/--yaml flags.
+func printSearch(cmd *cobra.Command, res *clients.SearchResponse) error {
+	out := cmd.OutOrStdout()
+	if collJSON {
+		return output.PrintStructuredJSON(out, res)
+	}
+	if collYAML {
+		return output.PrintStructuredYAML(out, res)
+	}
+	return output.PrintSearchResults(out, res)
+}
+
+func init() {
+	searchSubs := []*cobra.Command{searchCmd, searchBatchCmd, searchByIDCmd, searchHybridCmd}
+	for _, c := range searchSubs {
+		c.Flags().StringVarP(&collOrganization, "organization", "o", "", "Organization name")
+		c.Flags().StringVarP(&collProject, "project", "p", "", "Project name")
+		c.Flags().
+			StringVarP(&collDatabase, "database", "d", "", "Database that holds the collection (required)")
+		_ = c.MarkFlagRequired("database")
+		c.Flags().BoolVar(&collJSON, "json", false, "Output raw API response as JSON")
+		c.Flags().BoolVar(&collYAML, "yaml", false, "Output raw API response as YAML")
+	}
+
+	searchCmd.Flags().StringVar(&searchQuery, "query", "", "Query text (embedded server-side)")
+	searchCmd.Flags().
+		StringVar(&searchVector, "vector", "", "Query vector as comma-separated floats")
+	searchCmd.Flags().
+		StringVar(&searchUsing, "using", "", "Vector slot to search (default: default)")
+	searchCmd.Flags().IntVar(&searchLimit, "limit", 0, "Max results")
+	searchCmd.Flags().StringVar(&searchFilter, "filter", "", "Metadata filter as a JSON object")
+	searchCmd.Flags().BoolVar(&searchExact, "exact", false, "Exhaustive scan instead of the index")
+
+	searchBatchCmd.Flags().
+		StringVar(&searchFile, "file", "", "Path to a YAML/JSON batch-search file")
+	_ = searchBatchCmd.MarkFlagRequired("file")
+
+	searchByIDCmd.Flags().StringVar(&searchID, "id", "", "Seed chunk id (required)")
+	_ = searchByIDCmd.MarkFlagRequired("id")
+	searchByIDCmd.Flags().StringVar(&searchUsing, "using", "", "Vector slot to search")
+	searchByIDCmd.Flags().IntVar(&searchLimit, "limit", 0, "Max results")
+	searchByIDCmd.Flags().
+		BoolVar(&searchExcludeSelf, "exclude-self", false, "Exclude the seed chunk")
+	searchByIDCmd.Flags().StringVar(&searchFilter, "filter", "", "Metadata filter as a JSON object")
+
+	searchHybridCmd.Flags().
+		StringVar(&searchFile, "file", "", "Path to a YAML/JSON hybrid-search file")
+	_ = searchHybridCmd.MarkFlagRequired("file")
+
+	searchCmd.AddCommand(searchBatchCmd, searchByIDCmd, searchHybridCmd)
+	collectionsCmd.AddCommand(searchCmd)
+}

--- a/cmd/collections_slots.go
+++ b/cmd/collections_slots.go
@@ -235,7 +235,8 @@ func init() {
 	}
 
 	slotsAddCmd.Flags().StringVar(&slotType, "type", "float32", "Vector slot type")
-	slotsAddCmd.Flags().IntVar(&slotDimension, "dimension", 0, "Vector dimension (with flag form)")
+	slotsAddCmd.Flags().
+		IntVar(&slotDimension, "dimension", 0, "Vector dimension (required unless --file is provided)")
 	slotsAddCmd.Flags().
 		StringVar(&slotDistance, "distance", "", "Distance metric (default: cosine)")
 	slotsAddCmd.Flags().StringVar(&slotFile, "file", "", "Path to a YAML/JSON slot config")

--- a/cmd/collections_slots.go
+++ b/cmd/collections_slots.go
@@ -1,0 +1,252 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/inputs"
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var (
+	slotType      string
+	slotDimension int
+	slotDistance  string
+	slotFile      string
+)
+
+var slotsCmd = &cobra.Command{
+	Use:     "slots",
+	Aliases: []string{"slot", "vectors"},
+	Short:   "Manage a collection's vector slots and their indexes",
+	Long:    `Add, reindex, vacuum, inspect, and remove the vector slots of a collection.`,
+}
+
+var slotsAddCmd = &cobra.Command{
+	Use:   "add <collection> <slot>",
+	Short: "Add a vector slot",
+	Long: `Add a vector slot. Provide a raw vector slot via flags (--type, --dimension,
+--distance) or a full slot config via --file (e.g. for an embedding-backed slot
+or custom index tuning). --file takes precedence.`,
+	Example: `  iai collections slots add docs title -d my-db --dimension 1536
+  iai collections slots add docs title -d my-db --file slot.yaml`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		collection := strings.TrimSpace(args[0])
+		slot := strings.TrimSpace(args[1])
+
+		body, err := slotAddBody()
+		if err != nil {
+			return err
+		}
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
+		if err != nil {
+			return err
+		}
+
+		res, err := deployClient.AddSlot(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			collDatabase,
+			collection,
+			slot,
+			body,
+		)
+		if err != nil {
+			return err
+		}
+
+		if collJSON {
+			return output.PrintStructuredJSON(out, res)
+		}
+		if collYAML {
+			return output.PrintStructuredYAML(out, res)
+		}
+		return output.PrintSlotAddResult(out, res)
+	},
+}
+
+var slotsReindexCmd = &cobra.Command{
+	Use:   "reindex <collection> <slot>",
+	Short: "Rebuild a slot's index (online)",
+	Long: `Rebuild a slot's index. With no --file it rebuilds with the current config;
+--file (YAML/JSON) can change index params or quantization.`,
+	Example: `  iai collections slots reindex docs title -d my-db
+  iai collections slots reindex docs title -d my-db --file reindex.yaml`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		collection := strings.TrimSpace(args[0])
+		slot := strings.TrimSpace(args[1])
+
+		body := []byte("{}")
+		if slotFile != "" {
+			b, err := inputs.ReadCollectionBodyFile(slotFile)
+			if err != nil {
+				return err
+			}
+			body = b
+		}
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
+		if err != nil {
+			return err
+		}
+
+		res, err := deployClient.ReindexSlot(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			collDatabase,
+			collection,
+			slot,
+			body,
+		)
+		if err != nil {
+			return err
+		}
+		return output.PrintSlotOpResult(out, res)
+	},
+}
+
+var slotsVacuumCmd = &cobra.Command{
+	Use:     "vacuum <collection> <slot>",
+	Short:   "Vacuum a slot (reclaim space, refresh stats)",
+	Example: `  iai collections slots vacuum docs title -d my-db`,
+	Args:    cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		collection := strings.TrimSpace(args[0])
+		slot := strings.TrimSpace(args[1])
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
+		if err != nil {
+			return err
+		}
+
+		res, err := deployClient.VacuumSlot(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			collDatabase,
+			collection,
+			slot,
+		)
+		if err != nil {
+			return err
+		}
+		return output.PrintSlotOpResult(out, res)
+	},
+}
+
+var slotsProgressCmd = &cobra.Command{
+	Use:     "progress <collection> <slot>",
+	Short:   "Show a slot's index build progress",
+	Example: `  iai collections slots progress docs title -d my-db`,
+	Args:    cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		collection := strings.TrimSpace(args[0])
+		slot := strings.TrimSpace(args[1])
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
+		if err != nil {
+			return err
+		}
+
+		res, err := deployClient.SlotIndexProgressStatus(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			collDatabase,
+			collection,
+			slot,
+		)
+		if err != nil {
+			return err
+		}
+
+		if collJSON {
+			return output.PrintStructuredJSON(out, res)
+		}
+		if collYAML {
+			return output.PrintStructuredYAML(out, res)
+		}
+		return output.PrintSlotIndexProgress(out, res)
+	},
+}
+
+var slotsDeleteCmd = &cobra.Command{
+	Use:     "delete <collection> <slot>",
+	Aliases: []string{"rm"},
+	Short:   "Delete a vector slot",
+	Example: `  iai collections slots delete docs title -d my-db`,
+	Args:    cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		collection := strings.TrimSpace(args[0])
+		slot := strings.TrimSpace(args[1])
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), collOrganization, collProject)
+		if err != nil {
+			return err
+		}
+
+		msg, err := deployClient.DeleteSlot(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			collDatabase,
+			collection,
+			slot,
+		)
+		if err != nil {
+			return err
+		}
+		if msg != "" {
+			fmt.Fprintln(out, msg)
+		}
+		return nil
+	},
+}
+
+// slotAddBody builds the add-slot body from --file (if set) or the flags.
+func slotAddBody() ([]byte, error) {
+	if slotFile != "" {
+		return inputs.ReadCollectionBodyFile(slotFile)
+	}
+	return inputs.BuildAddSlotBody(slotType, slotDimension, slotDistance)
+}
+
+func init() {
+	slotSubs := []*cobra.Command{
+		slotsAddCmd, slotsReindexCmd, slotsVacuumCmd, slotsProgressCmd, slotsDeleteCmd,
+	}
+	for _, c := range slotSubs {
+		c.Flags().StringVarP(&collOrganization, "organization", "o", "", "Organization name")
+		c.Flags().StringVarP(&collProject, "project", "p", "", "Project name")
+		c.Flags().
+			StringVarP(&collDatabase, "database", "d", "", "Database that holds the collection (required)")
+		_ = c.MarkFlagRequired("database")
+	}
+
+	slotsAddCmd.Flags().StringVar(&slotType, "type", "float32", "Vector slot type")
+	slotsAddCmd.Flags().IntVar(&slotDimension, "dimension", 0, "Vector dimension (with flag form)")
+	slotsAddCmd.Flags().
+		StringVar(&slotDistance, "distance", "", "Distance metric (default: cosine)")
+	slotsAddCmd.Flags().StringVar(&slotFile, "file", "", "Path to a YAML/JSON slot config")
+	slotsAddCmd.Flags().BoolVar(&collJSON, "json", false, "Output raw API response as JSON")
+	slotsAddCmd.Flags().BoolVar(&collYAML, "yaml", false, "Output raw API response as YAML")
+
+	slotsReindexCmd.Flags().StringVar(&slotFile, "file", "", "Path to a YAML/JSON reindex config")
+
+	slotsProgressCmd.Flags().BoolVar(&collJSON, "json", false, "Output raw API response as JSON")
+	slotsProgressCmd.Flags().BoolVar(&collYAML, "yaml", false, "Output raw API response as YAML")
+
+	slotsCmd.AddCommand(slotSubs...)
+	collectionsCmd.AddCommand(slotsCmd)
+}

--- a/docs/iai.md
+++ b/docs/iai.md
@@ -87,6 +87,7 @@ Prompt resources (`prompts`, `routines`, `policies`, `variables`, `glossaries`, 
 
 * [iai agents](iai_agents.md)	 - Deploy AI agents with policies, routines, and tools
 * [iai api-keys](iai_api-keys.md)	 - Project API keys
+* [iai collections](iai_collections.md)	 - Vector collections (knowledge bases) inside a pgvector database
 * [iai comments](iai_comments.md)	 - Annotate traces, observations, and sessions
 * [iai completion](iai_completion.md)	 - Generate the autocompletion script for the specified shell
 * [iai connectors](iai_connectors.md)	 - Manage MCP connectors in a project

--- a/docs/iai_collections.md
+++ b/docs/iai_collections.md
@@ -1,0 +1,41 @@
+## iai collections
+
+Vector collections (knowledge bases) inside a pgvector database
+
+### Synopsis
+
+Manage vector collections within a database.
+
+A collection is a vector store (knowledge base) that lives inside an existing
+pgvector database, so every command requires --database. Use 'iai databases
+create' first to provision the database.
+
+### Options
+
+```
+  -h, --help   help for collections
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai](iai.md)	 - InteractiveAI's CLI
+* [iai collections chunks](iai_collections_chunks.md)	 - Manage the chunks (rows) in a collection
+* [iai collections create](iai_collections_create.md)	 - Create a collection from a config file
+* [iai collections delete](iai_collections_delete.md)	 - Delete a collection and all its data
+* [iai collections describe](iai_collections_describe.md)	 - Describe a collection's configuration
+* [iai collections documents](iai_collections_documents.md)	 - Inspect documents (chunks grouped by documentId)
+* [iai collections list](iai_collections_list.md)	 - List collections in a database
+* [iai collections patch](iai_collections_patch.md)	 - Update a collection's mutable config from a file
+* [iai collections search](iai_collections_search.md)	 - Search a collection (single-lane vector search)
+* [iai collections slots](iai_collections_slots.md)	 - Manage a collection's vector slots and their indexes
+* [iai collections stats](iai_collections_stats.md)	 - Show a collection's chunk count, size, and index status
+

--- a/docs/iai_collections_chunks.md
+++ b/docs/iai_collections_chunks.md
@@ -1,0 +1,34 @@
+## iai collections chunks
+
+Manage the chunks (rows) in a collection
+
+### Synopsis
+
+Upsert, inspect, and delete the chunks stored in a collection.
+
+### Options
+
+```
+  -h, --help   help for chunks
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections](iai_collections.md)	 - Vector collections (knowledge bases) inside a pgvector database
+* [iai collections chunks bulk-delete](iai_collections_chunks_bulk-delete.md)	 - Delete many chunks by ids, metadata filter, or all
+* [iai collections chunks count](iai_collections_chunks_count.md)	 - Count chunks, optionally scoped by a metadata filter or id prefix
+* [iai collections chunks delete](iai_collections_chunks_delete.md)	 - Delete a single chunk by id
+* [iai collections chunks get](iai_collections_chunks_get.md)	 - Get a single chunk
+* [iai collections chunks list](iai_collections_chunks_list.md)	 - List chunks (keyset-paginated)
+* [iai collections chunks patch](iai_collections_chunks_patch.md)	 - Update a chunk's metadata and/or text from a file
+* [iai collections chunks upsert](iai_collections_chunks_upsert.md)	 - Upsert chunks from a file
+

--- a/docs/iai_collections_chunks_bulk-delete.md
+++ b/docs/iai_collections_chunks_bulk-delete.md
@@ -30,6 +30,7 @@ iai collections chunks bulk-delete <collection> [flags]
       --ids strings           Comma-separated chunk ids to delete
   -o, --organization string   Organization name
   -p, --project string        Project name
+      --yes                   Skip the --all confirmation prompt
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_collections_chunks_bulk-delete.md
+++ b/docs/iai_collections_chunks_bulk-delete.md
@@ -1,0 +1,47 @@
+## iai collections chunks bulk-delete
+
+Delete many chunks by ids, metadata filter, or all
+
+### Synopsis
+
+Delete chunks by exactly one selector: --ids, --filter, or --all.
+
+--all deletes every chunk and requires confirmation.
+
+```
+iai collections chunks bulk-delete <collection> [flags]
+```
+
+### Examples
+
+```
+  iai collections chunks bulk-delete docs -d my-db --ids a,b,c
+  iai collections chunks bulk-delete docs -d my-db --filter '{"lang":"en"}'
+  iai collections chunks bulk-delete docs -d my-db --all
+```
+
+### Options
+
+```
+      --all                   Delete every chunk (requires confirm)
+  -d, --database string       Database that holds the collection (required)
+      --filter string         Metadata filter as a JSON object
+  -h, --help                  help for bulk-delete
+      --ids strings           Comma-separated chunk ids to delete
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections chunks](iai_collections_chunks.md)	 - Manage the chunks (rows) in a collection
+

--- a/docs/iai_collections_chunks_count.md
+++ b/docs/iai_collections_chunks_count.md
@@ -1,0 +1,38 @@
+## iai collections chunks count
+
+Count chunks, optionally scoped by a metadata filter or id prefix
+
+```
+iai collections chunks count <collection> [flags]
+```
+
+### Examples
+
+```
+  iai collections chunks count docs -d my-db --filter '{"lang":"en"}'
+```
+
+### Options
+
+```
+  -d, --database string       Database that holds the collection (required)
+      --filter string         Metadata filter as a JSON object
+  -h, --help                  help for count
+  -o, --organization string   Organization name
+      --prefix string         Only count chunks with this id prefix
+  -p, --project string        Project name
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections chunks](iai_collections_chunks.md)	 - Manage the chunks (rows) in a collection
+

--- a/docs/iai_collections_chunks_delete.md
+++ b/docs/iai_collections_chunks_delete.md
@@ -1,0 +1,36 @@
+## iai collections chunks delete
+
+Delete a single chunk by id
+
+```
+iai collections chunks delete <collection> <id> [flags]
+```
+
+### Examples
+
+```
+  iai collections chunks delete docs chunk-1 -d my-db
+```
+
+### Options
+
+```
+  -d, --database string       Database that holds the collection (required)
+  -h, --help                  help for delete
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections chunks](iai_collections_chunks.md)	 - Manage the chunks (rows) in a collection
+

--- a/docs/iai_collections_chunks_get.md
+++ b/docs/iai_collections_chunks_get.md
@@ -1,0 +1,40 @@
+## iai collections chunks get
+
+Get a single chunk
+
+```
+iai collections chunks get <collection> <id> [flags]
+```
+
+### Examples
+
+```
+  iai collections chunks get docs chunk-1 -d my-db
+  iai collections chunks get docs chunk-1 -d my-db --include-vector
+```
+
+### Options
+
+```
+  -d, --database string       Database that holds the collection (required)
+  -h, --help                  help for get
+      --include-vector        Include the stored vector(s)
+      --json                  Output raw API response as JSON
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+      --yaml                  Output raw API response as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections chunks](iai_collections_chunks.md)	 - Manage the chunks (rows) in a collection
+

--- a/docs/iai_collections_chunks_list.md
+++ b/docs/iai_collections_chunks_list.md
@@ -1,0 +1,42 @@
+## iai collections chunks list
+
+List chunks (keyset-paginated)
+
+```
+iai collections chunks list <collection> [flags]
+```
+
+### Examples
+
+```
+  iai collections chunks list docs -d my-db --limit 20
+  iai collections chunks list docs -d my-db --cursor <token>
+```
+
+### Options
+
+```
+      --cursor string         Opaque cursor from a previous page
+  -d, --database string       Database that holds the collection (required)
+  -h, --help                  help for list
+      --json                  Output raw API response as JSON
+      --limit int             Page size (1-1000, default 100)
+  -o, --organization string   Organization name
+      --prefix string         Only chunks whose id has this prefix
+  -p, --project string        Project name
+      --yaml                  Output raw API response as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections chunks](iai_collections_chunks.md)	 - Manage the chunks (rows) in a collection
+

--- a/docs/iai_collections_chunks_patch.md
+++ b/docs/iai_collections_chunks_patch.md
@@ -1,0 +1,39 @@
+## iai collections chunks patch
+
+Update a chunk's metadata and/or text from a file
+
+```
+iai collections chunks patch <collection> <id> [flags]
+```
+
+### Examples
+
+```
+  iai collections chunks patch docs chunk-1 -d my-db --file patch.json
+```
+
+### Options
+
+```
+  -d, --database string       Database that holds the collection (required)
+      --file string           Path to a YAML/JSON patch file
+  -h, --help                  help for patch
+      --json                  Output raw API response as JSON
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+      --yaml                  Output raw API response as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections chunks](iai_collections_chunks.md)	 - Manage the chunks (rows) in a collection
+

--- a/docs/iai_collections_chunks_upsert.md
+++ b/docs/iai_collections_chunks_upsert.md
@@ -1,0 +1,46 @@
+## iai collections chunks upsert
+
+Upsert chunks from a file
+
+### Synopsis
+
+Upsert a batch of chunks from a YAML or JSON file (--file).
+
+Chunks with text and no client vector are embedded server-side (set
+defer_embedding=true with client-supplied vectors to skip embedding).
+
+```
+iai collections chunks upsert <collection> [flags]
+```
+
+### Examples
+
+```
+  iai collections chunks upsert docs -d my-db --file chunks.json
+```
+
+### Options
+
+```
+  -d, --database string       Database that holds the collection (required)
+      --file string           Path to a YAML/JSON chunks file
+  -h, --help                  help for upsert
+      --json                  Output raw API response as JSON
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+      --yaml                  Output raw API response as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections chunks](iai_collections_chunks.md)	 - Manage the chunks (rows) in a collection
+

--- a/docs/iai_collections_create.md
+++ b/docs/iai_collections_create.md
@@ -1,0 +1,45 @@
+## iai collections create
+
+Create a collection from a config file
+
+### Synopsis
+
+Create a vector collection from a YAML or JSON config file (--file).
+
+The config declares the vector slot(s) — either an embedding-backed slot
+("embedding": {model, dimension}) or a raw vector slot ({type, dimension,
+distance}) — and optional full-text search.
+
+```
+iai collections create <collection> [flags]
+```
+
+### Examples
+
+```
+  iai collections create docs -d my-db --file collection.yaml
+```
+
+### Options
+
+```
+  -d, --database string       Database that holds the collection (required)
+      --file string           Path to a YAML/JSON collection config
+  -h, --help                  help for create
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections](iai_collections.md)	 - Vector collections (knowledge bases) inside a pgvector database
+

--- a/docs/iai_collections_delete.md
+++ b/docs/iai_collections_delete.md
@@ -1,0 +1,36 @@
+## iai collections delete
+
+Delete a collection and all its data
+
+```
+iai collections delete <collection> [flags]
+```
+
+### Examples
+
+```
+  iai collections delete docs -d my-db
+```
+
+### Options
+
+```
+  -d, --database string       Database that holds the collection (required)
+  -h, --help                  help for delete
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections](iai_collections.md)	 - Vector collections (knowledge bases) inside a pgvector database
+

--- a/docs/iai_collections_describe.md
+++ b/docs/iai_collections_describe.md
@@ -1,0 +1,39 @@
+## iai collections describe
+
+Describe a collection's configuration
+
+```
+iai collections describe <collection> [flags]
+```
+
+### Examples
+
+```
+  iai collections describe docs -d my-db
+  iai collections describe docs -d my-db --json
+```
+
+### Options
+
+```
+  -d, --database string       Database that holds the collection (required)
+  -h, --help                  help for describe
+      --json                  Output raw API response as JSON
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+      --yaml                  Output raw API response as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections](iai_collections.md)	 - Vector collections (knowledge bases) inside a pgvector database
+

--- a/docs/iai_collections_documents.md
+++ b/docs/iai_collections_documents.md
@@ -1,0 +1,30 @@
+## iai collections documents
+
+Inspect documents (chunks grouped by documentId)
+
+### Synopsis
+
+A document is the set of chunks sharing a documentId. These are read/delete views over chunks.
+
+### Options
+
+```
+  -h, --help   help for documents
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections](iai_collections.md)	 - Vector collections (knowledge bases) inside a pgvector database
+* [iai collections documents delete](iai_collections_documents_delete.md)	 - Delete a document (all chunks sharing the documentId)
+* [iai collections documents get](iai_collections_documents_get.md)	 - Get a document's chunks
+* [iai collections documents list](iai_collections_documents_list.md)	 - List documents in a collection
+

--- a/docs/iai_collections_documents.md
+++ b/docs/iai_collections_documents.md
@@ -4,7 +4,7 @@ Inspect documents (chunks grouped by documentId)
 
 ### Synopsis
 
-A document is the set of chunks sharing a documentId. These are read/delete views over chunks.
+A document groups chunks by documentId; these commands read or delete them.
 
 ### Options
 

--- a/docs/iai_collections_documents_delete.md
+++ b/docs/iai_collections_documents_delete.md
@@ -1,0 +1,36 @@
+## iai collections documents delete
+
+Delete a document (all chunks sharing the documentId)
+
+```
+iai collections documents delete <collection> <documentId> [flags]
+```
+
+### Examples
+
+```
+  iai collections documents delete docs support-faq -d my-db
+```
+
+### Options
+
+```
+  -d, --database string       Database that holds the collection (required)
+  -h, --help                  help for delete
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections documents](iai_collections_documents.md)	 - Inspect documents (chunks grouped by documentId)
+

--- a/docs/iai_collections_documents_get.md
+++ b/docs/iai_collections_documents_get.md
@@ -1,0 +1,41 @@
+## iai collections documents get
+
+Get a document's chunks
+
+```
+iai collections documents get <collection> <documentId> [flags]
+```
+
+### Examples
+
+```
+  iai collections documents get docs support-faq -d my-db
+```
+
+### Options
+
+```
+      --cursor string         Opaque cursor from a previous page
+  -d, --database string       Database that holds the collection (required)
+  -h, --help                  help for get
+      --include-vector        Include the stored vector(s)
+      --json                  Output raw API response as JSON
+      --limit int             Page size (1-1000, default 100)
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+      --yaml                  Output raw API response as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections documents](iai_collections_documents.md)	 - Inspect documents (chunks grouped by documentId)
+

--- a/docs/iai_collections_documents_list.md
+++ b/docs/iai_collections_documents_list.md
@@ -1,0 +1,40 @@
+## iai collections documents list
+
+List documents in a collection
+
+```
+iai collections documents list <collection> [flags]
+```
+
+### Examples
+
+```
+  iai collections documents list docs -d my-db
+```
+
+### Options
+
+```
+      --cursor string         Opaque cursor from a previous page
+  -d, --database string       Database that holds the collection (required)
+  -h, --help                  help for list
+      --json                  Output raw API response as JSON
+      --limit int             Page size (1-1000, default 100)
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+      --yaml                  Output raw API response as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections documents](iai_collections_documents.md)	 - Inspect documents (chunks grouped by documentId)
+

--- a/docs/iai_collections_list.md
+++ b/docs/iai_collections_list.md
@@ -1,0 +1,39 @@
+## iai collections list
+
+List collections in a database
+
+```
+iai collections list [flags]
+```
+
+### Examples
+
+```
+  iai collections list -d my-db
+  iai collections list -d my-db --json
+```
+
+### Options
+
+```
+  -d, --database string       Database that holds the collection (required)
+  -h, --help                  help for list
+      --json                  Output raw API response as JSON
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+      --yaml                  Output raw API response as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections](iai_collections.md)	 - Vector collections (knowledge bases) inside a pgvector database
+

--- a/docs/iai_collections_patch.md
+++ b/docs/iai_collections_patch.md
@@ -1,0 +1,43 @@
+## iai collections patch
+
+Update a collection's mutable config from a file
+
+### Synopsis
+
+Update a collection's mutable configuration from a YAML or JSON file (--file):
+full-text settings and per-slot ef_search_default. Slot type/dimension/distance
+and the embedding model are immutable.
+
+```
+iai collections patch <collection> [flags]
+```
+
+### Examples
+
+```
+  iai collections patch docs -d my-db --file patch.yaml
+```
+
+### Options
+
+```
+  -d, --database string       Database that holds the collection (required)
+      --file string           Path to a YAML/JSON patch config
+  -h, --help                  help for patch
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections](iai_collections.md)	 - Vector collections (knowledge bases) inside a pgvector database
+

--- a/docs/iai_collections_search.md
+++ b/docs/iai_collections_search.md
@@ -1,0 +1,55 @@
+## iai collections search
+
+Search a collection (single-lane vector search)
+
+### Synopsis
+
+Run a single-lane search: --query (text, embedded server-side) or --vector
+(comma-separated floats). --exact runs an exhaustive scan instead of the index.
+
+Sub-commands cover the other modes: batch, by-id, hybrid.
+
+```
+iai collections search <collection> [flags]
+```
+
+### Examples
+
+```
+  iai collections search docs -d my-db --query "reset my password"
+  iai collections search docs -d my-db --query "..." --exact --limit 5
+```
+
+### Options
+
+```
+  -d, --database string       Database that holds the collection (required)
+      --exact                 Exhaustive scan instead of the index
+      --filter string         Metadata filter as a JSON object
+  -h, --help                  help for search
+      --json                  Output raw API response as JSON
+      --limit int             Max results
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+      --query string          Query text (embedded server-side)
+      --using string          Vector slot to search (default: default)
+      --vector string         Query vector as comma-separated floats
+      --yaml                  Output raw API response as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections](iai_collections.md)	 - Vector collections (knowledge bases) inside a pgvector database
+* [iai collections search batch](iai_collections_search_batch.md)	 - Run several searches in one request (from a file)
+* [iai collections search by-id](iai_collections_search_by-id.md)	 - Find neighbors of an existing chunk by its stored vector
+* [iai collections search hybrid](iai_collections_search_hybrid.md)	 - Run a multi-lane hybrid search (RRF) from a file
+

--- a/docs/iai_collections_search_batch.md
+++ b/docs/iai_collections_search_batch.md
@@ -1,0 +1,39 @@
+## iai collections search batch
+
+Run several searches in one request (from a file)
+
+```
+iai collections search batch <collection> [flags]
+```
+
+### Examples
+
+```
+  iai collections search batch docs -d my-db --file searches.json
+```
+
+### Options
+
+```
+  -d, --database string       Database that holds the collection (required)
+      --file string           Path to a YAML/JSON batch-search file
+  -h, --help                  help for batch
+      --json                  Output raw API response as JSON
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+      --yaml                  Output raw API response as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections search](iai_collections_search.md)	 - Search a collection (single-lane vector search)
+

--- a/docs/iai_collections_search_by-id.md
+++ b/docs/iai_collections_search_by-id.md
@@ -1,0 +1,43 @@
+## iai collections search by-id
+
+Find neighbors of an existing chunk by its stored vector
+
+```
+iai collections search by-id <collection> [flags]
+```
+
+### Examples
+
+```
+  iai collections search by-id docs -d my-db --id chunk-1 --exclude-self
+```
+
+### Options
+
+```
+  -d, --database string       Database that holds the collection (required)
+      --exclude-self          Exclude the seed chunk
+      --filter string         Metadata filter as a JSON object
+  -h, --help                  help for by-id
+      --id string             Seed chunk id (required)
+      --json                  Output raw API response as JSON
+      --limit int             Max results
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+      --using string          Vector slot to search
+      --yaml                  Output raw API response as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections search](iai_collections_search.md)	 - Search a collection (single-lane vector search)
+

--- a/docs/iai_collections_search_hybrid.md
+++ b/docs/iai_collections_search_hybrid.md
@@ -1,0 +1,44 @@
+## iai collections search hybrid
+
+Run a multi-lane hybrid search (RRF) from a file
+
+### Synopsis
+
+Run a hybrid search from a YAML/JSON file whose body holds a "queries" array
+(dense and/or full_text lanes) and an optional "fusion" config.
+
+```
+iai collections search hybrid <collection> [flags]
+```
+
+### Examples
+
+```
+  iai collections search hybrid docs -d my-db --file hybrid.json
+```
+
+### Options
+
+```
+  -d, --database string       Database that holds the collection (required)
+      --file string           Path to a YAML/JSON hybrid-search file
+  -h, --help                  help for hybrid
+      --json                  Output raw API response as JSON
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+      --yaml                  Output raw API response as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections search](iai_collections_search.md)	 - Search a collection (single-lane vector search)
+

--- a/docs/iai_collections_slots.md
+++ b/docs/iai_collections_slots.md
@@ -1,0 +1,32 @@
+## iai collections slots
+
+Manage a collection's vector slots and their indexes
+
+### Synopsis
+
+Add, reindex, vacuum, inspect, and remove the vector slots of a collection.
+
+### Options
+
+```
+  -h, --help   help for slots
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections](iai_collections.md)	 - Vector collections (knowledge bases) inside a pgvector database
+* [iai collections slots add](iai_collections_slots_add.md)	 - Add a vector slot
+* [iai collections slots delete](iai_collections_slots_delete.md)	 - Delete a vector slot
+* [iai collections slots progress](iai_collections_slots_progress.md)	 - Show a slot's index build progress
+* [iai collections slots reindex](iai_collections_slots_reindex.md)	 - Rebuild a slot's index (online)
+* [iai collections slots vacuum](iai_collections_slots_vacuum.md)	 - Vacuum a slot (reclaim space, refresh stats)
+

--- a/docs/iai_collections_slots_add.md
+++ b/docs/iai_collections_slots_add.md
@@ -1,0 +1,49 @@
+## iai collections slots add
+
+Add a vector slot
+
+### Synopsis
+
+Add a vector slot. Provide a raw vector slot via flags (--type, --dimension,
+--distance) or a full slot config via --file (e.g. for an embedding-backed slot
+or custom index tuning). --file takes precedence.
+
+```
+iai collections slots add <collection> <slot> [flags]
+```
+
+### Examples
+
+```
+  iai collections slots add docs title -d my-db --dimension 1536
+  iai collections slots add docs title -d my-db --file slot.yaml
+```
+
+### Options
+
+```
+  -d, --database string       Database that holds the collection (required)
+      --dimension int         Vector dimension (with flag form)
+      --distance string       Distance metric (default: cosine)
+      --file string           Path to a YAML/JSON slot config
+  -h, --help                  help for add
+      --json                  Output raw API response as JSON
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+      --type string           Vector slot type (default "float32")
+      --yaml                  Output raw API response as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections slots](iai_collections_slots.md)	 - Manage a collection's vector slots and their indexes
+

--- a/docs/iai_collections_slots_add.md
+++ b/docs/iai_collections_slots_add.md
@@ -23,7 +23,7 @@ iai collections slots add <collection> <slot> [flags]
 
 ```
   -d, --database string       Database that holds the collection (required)
-      --dimension int         Vector dimension (with flag form)
+      --dimension int         Vector dimension (required unless --file is provided)
       --distance string       Distance metric (default: cosine)
       --file string           Path to a YAML/JSON slot config
   -h, --help                  help for add

--- a/docs/iai_collections_slots_delete.md
+++ b/docs/iai_collections_slots_delete.md
@@ -1,0 +1,36 @@
+## iai collections slots delete
+
+Delete a vector slot
+
+```
+iai collections slots delete <collection> <slot> [flags]
+```
+
+### Examples
+
+```
+  iai collections slots delete docs title -d my-db
+```
+
+### Options
+
+```
+  -d, --database string       Database that holds the collection (required)
+  -h, --help                  help for delete
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections slots](iai_collections_slots.md)	 - Manage a collection's vector slots and their indexes
+

--- a/docs/iai_collections_slots_progress.md
+++ b/docs/iai_collections_slots_progress.md
@@ -1,0 +1,38 @@
+## iai collections slots progress
+
+Show a slot's index build progress
+
+```
+iai collections slots progress <collection> <slot> [flags]
+```
+
+### Examples
+
+```
+  iai collections slots progress docs title -d my-db
+```
+
+### Options
+
+```
+  -d, --database string       Database that holds the collection (required)
+  -h, --help                  help for progress
+      --json                  Output raw API response as JSON
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+      --yaml                  Output raw API response as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections slots](iai_collections_slots.md)	 - Manage a collection's vector slots and their indexes
+

--- a/docs/iai_collections_slots_reindex.md
+++ b/docs/iai_collections_slots_reindex.md
@@ -1,0 +1,43 @@
+## iai collections slots reindex
+
+Rebuild a slot's index (online)
+
+### Synopsis
+
+Rebuild a slot's index. With no --file it rebuilds with the current config;
+--file (YAML/JSON) can change index params or quantization.
+
+```
+iai collections slots reindex <collection> <slot> [flags]
+```
+
+### Examples
+
+```
+  iai collections slots reindex docs title -d my-db
+  iai collections slots reindex docs title -d my-db --file reindex.yaml
+```
+
+### Options
+
+```
+  -d, --database string       Database that holds the collection (required)
+      --file string           Path to a YAML/JSON reindex config
+  -h, --help                  help for reindex
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections slots](iai_collections_slots.md)	 - Manage a collection's vector slots and their indexes
+

--- a/docs/iai_collections_slots_vacuum.md
+++ b/docs/iai_collections_slots_vacuum.md
@@ -1,0 +1,36 @@
+## iai collections slots vacuum
+
+Vacuum a slot (reclaim space, refresh stats)
+
+```
+iai collections slots vacuum <collection> <slot> [flags]
+```
+
+### Examples
+
+```
+  iai collections slots vacuum docs title -d my-db
+```
+
+### Options
+
+```
+  -d, --database string       Database that holds the collection (required)
+  -h, --help                  help for vacuum
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections slots](iai_collections_slots.md)	 - Manage a collection's vector slots and their indexes
+

--- a/docs/iai_collections_stats.md
+++ b/docs/iai_collections_stats.md
@@ -1,0 +1,39 @@
+## iai collections stats
+
+Show a collection's chunk count, size, and index status
+
+```
+iai collections stats <collection> [flags]
+```
+
+### Examples
+
+```
+  iai collections stats docs -d my-db
+  iai collections stats docs -d my-db --json
+```
+
+### Options
+
+```
+  -d, --database string       Database that holds the collection (required)
+  -h, --help                  help for stats
+      --json                  Output raw API response as JSON
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+      --yaml                  Output raw API response as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections](iai_collections.md)	 - Vector collections (knowledge bases) inside a pgvector database
+

--- a/internal/clients/collections.go
+++ b/internal/clients/collections.go
@@ -1,0 +1,244 @@
+package clients
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// CollectionSummary is one entry in a collections list response.
+type CollectionSummary struct {
+	Name      string `json:"name"`
+	CreatedAt string `json:"createdAt"`
+	UpdatedAt string `json:"updatedAt"`
+}
+
+type listCollectionsResponse struct {
+	Collections []CollectionSummary `json:"collections"`
+}
+
+// CollectionSlot describes one vector slot in a collection's config.
+type CollectionSlot struct {
+	Type      string `json:"type"`
+	Dimension int    `json:"dimension"`
+	Distance  string `json:"distance"`
+	Embedding *struct {
+		Model string `json:"model"`
+	} `json:"embedding"`
+	Index *struct {
+		Type string `json:"type"`
+	} `json:"index"`
+}
+
+// CollectionFullText is the optional full-text search config.
+type CollectionFullText struct {
+	Enabled  bool   `json:"enabled"`
+	Language string `json:"language"`
+}
+
+// CollectionConfig is the stored, normalized collection configuration.
+type CollectionConfig struct {
+	Vectors  map[string]CollectionSlot `json:"vectors"`
+	FullText *CollectionFullText       `json:"full_text"`
+}
+
+// DescribeCollectionResponse is the full describe payload.
+type DescribeCollectionResponse struct {
+	Name      string           `json:"name"`
+	Config    CollectionConfig `json:"config"`
+	CreatedAt string           `json:"createdAt"`
+	UpdatedAt string           `json:"updatedAt"`
+}
+
+// CollectionStats holds operational stats for a collection.
+type CollectionStats struct {
+	ChunkCount int64           `json:"chunkCount"`
+	IndexValid map[string]bool `json:"indexValid"`
+	SizeBytes  int64           `json:"sizeBytes"`
+}
+
+// collectionsPath builds the base collections path for a database.
+func collectionsPath(orgId, projectId, database string) string {
+	return fmt.Sprintf(
+		"/v1/organizations/%s/projects/%s/databases/%s/collections",
+		url.PathEscape(orgId),
+		url.PathEscape(projectId),
+		url.PathEscape(database),
+	)
+}
+
+// collectionErr turns a non-2xx collections response into an error, preferring
+// the server's message.
+func collectionErr(resp *http.Response, action string) error {
+	respBody, _ := io.ReadAll(resp.Body)
+	if msg := ExtractServerMessage(respBody); msg != "" {
+		return fmt.Errorf("%s", msg)
+	}
+	return fmt.Errorf("failed to %s: server returned %s", action, resp.Status)
+}
+
+// ListCollections returns the collections in a database.
+func (c *DeploymentClient) ListCollections(
+	ctx context.Context,
+	orgId, projectId, database string,
+) ([]CollectionSummary, error) {
+	req, err := c.newRequest(ctx, http.MethodGet, collectionsPath(orgId, projectId, database))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list collections request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, collectionErr(resp, "list collections")
+	}
+
+	var result listCollectionsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode collections response: %w", err)
+	}
+	return result.Collections, nil
+}
+
+// DescribeCollection returns a collection's normalized config.
+func (c *DeploymentClient) DescribeCollection(
+	ctx context.Context,
+	orgId, projectId, database, name string,
+) (*DescribeCollectionResponse, error) {
+	path := collectionsPath(orgId, projectId, database) + "/" + url.PathEscape(name)
+	req, err := c.newRequest(ctx, http.MethodGet, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("describe collection request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, collectionErr(resp, "describe collection")
+	}
+
+	var result DescribeCollectionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode collection response: %w", err)
+	}
+	return &result, nil
+}
+
+// GetCollectionStats returns operational stats for a collection.
+func (c *DeploymentClient) GetCollectionStats(
+	ctx context.Context,
+	orgId, projectId, database, name string,
+) (*CollectionStats, error) {
+	path := collectionsPath(orgId, projectId, database) + "/" + url.PathEscape(name) + "/stats"
+	req, err := c.newRequest(ctx, http.MethodGet, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("collection stats request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, collectionErr(resp, "get collection stats")
+	}
+
+	var result CollectionStats
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode stats response: %w", err)
+	}
+	return &result, nil
+}
+
+// CreateCollection creates a collection from a raw JSON config body.
+func (c *DeploymentClient) CreateCollection(
+	ctx context.Context,
+	orgId, projectId, database, name string,
+	body []byte,
+) (string, error) {
+	path := collectionsPath(orgId, projectId, database) + "/" + url.PathEscape(name)
+	return c.sendCollectionBody(ctx, http.MethodPost, path, body, "create collection")
+}
+
+// PatchCollection updates a collection's mutable config from a raw JSON body.
+func (c *DeploymentClient) PatchCollection(
+	ctx context.Context,
+	orgId, projectId, database, name string,
+	body []byte,
+) (string, error) {
+	path := collectionsPath(orgId, projectId, database) + "/" + url.PathEscape(name)
+	return c.sendCollectionBody(ctx, http.MethodPatch, path, body, "update collection")
+}
+
+// DeleteCollection deletes a collection and its data.
+func (c *DeploymentClient) DeleteCollection(
+	ctx context.Context,
+	orgId, projectId, database, name string,
+) (string, error) {
+	path := collectionsPath(orgId, projectId, database) + "/" + url.PathEscape(name)
+	req, err := c.newRequest(ctx, http.MethodDelete, path)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.do(req)
+	if err != nil {
+		return "", fmt.Errorf("delete collection request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	msg := ExtractServerMessage(respBody)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if msg != "" {
+			return "", fmt.Errorf("%s", msg)
+		}
+		return "", fmt.Errorf("failed to delete collection: server returned %s", resp.Status)
+	}
+	return msg, nil
+}
+
+// sendCollectionBody issues a JSON-body request and returns the server message.
+func (c *DeploymentClient) sendCollectionBody(
+	ctx context.Context,
+	method, path string,
+	body []byte,
+	action string,
+) (string, error) {
+	req, err := c.newRequest(ctx, method, path)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Body = io.NopCloser(bytes.NewReader(body))
+
+	resp, err := c.do(req)
+	if err != nil {
+		return "", fmt.Errorf("%s request failed: %w", action, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	msg := ExtractServerMessage(respBody)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if msg != "" {
+			return "", fmt.Errorf("%s", msg)
+		}
+		return "", fmt.Errorf("failed to %s: server returned %s", action, resp.Status)
+	}
+	return msg, nil
+}

--- a/internal/clients/collections.go
+++ b/internal/clients/collections.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -76,7 +77,7 @@ func collectionsPath(orgId, projectId, database string) string {
 func collectionErr(resp *http.Response, action string) error {
 	respBody, _ := io.ReadAll(resp.Body)
 	if msg := ExtractServerMessage(respBody); msg != "" {
-		return fmt.Errorf("%s", msg)
+		return errors.New(msg)
 	}
 	return fmt.Errorf("failed to %s: server returned %s", action, resp.Status)
 }
@@ -205,7 +206,7 @@ func (c *DeploymentClient) DeleteCollection(
 	msg := ExtractServerMessage(respBody)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		if msg != "" {
-			return "", fmt.Errorf("%s", msg)
+			return "", errors.New(msg)
 		}
 		return "", fmt.Errorf("failed to delete collection: server returned %s", resp.Status)
 	}
@@ -236,7 +237,7 @@ func (c *DeploymentClient) sendCollectionBody(
 	msg := ExtractServerMessage(respBody)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		if msg != "" {
-			return "", fmt.Errorf("%s", msg)
+			return "", errors.New(msg)
 		}
 		return "", fmt.Errorf("failed to %s: server returned %s", action, resp.Status)
 	}

--- a/internal/clients/collections_chunks.go
+++ b/internal/clients/collections_chunks.go
@@ -1,0 +1,297 @@
+package clients
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+// Chunk is a single stored chunk (a row in a collection).
+type Chunk struct {
+	ID         string         `json:"id"`
+	DocumentID string         `json:"documentId"`
+	Text       string         `json:"text"`
+	Metadata   map[string]any `json:"metadata"`
+	// Vector / Vectors are only populated by Get with includeVector.
+	Vector  []float64                  `json:"vector,omitempty"`
+	Vectors map[string]json.RawMessage `json:"vectors,omitempty"`
+}
+
+// ChunkList is a paginated list of chunks.
+type ChunkList struct {
+	Chunks     []Chunk `json:"chunks"`
+	NextCursor *string `json:"nextCursor"`
+	HasMore    bool    `json:"hasMore"`
+}
+
+// ChunkResult is one entry in an upsert response.
+type ChunkResult struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+}
+
+// ChunkUpsertResult is the response from a batch upsert.
+type ChunkUpsertResult struct {
+	Results []ChunkResult    `json:"results"`
+	Errors  []map[string]any `json:"errors"`
+}
+
+// BulkDeleteResult is the response from a bulk delete.
+type BulkDeleteResult struct {
+	DeletedCount int64    `json:"deletedCount"`
+	DeletedIds   []string `json:"deletedIds"`
+}
+
+// ListChunksOpts carries the optional list query parameters.
+type ListChunksOpts struct {
+	Limit  int
+	Cursor string
+	Prefix string
+}
+
+func chunksPath(orgId, projectId, database, collection string) string {
+	base := collectionsPath(orgId, projectId, database)
+	return base + "/" + url.PathEscape(collection) + "/chunks"
+}
+
+// UpsertChunks upserts a batch of chunks from a raw JSON body.
+func (c *DeploymentClient) UpsertChunks(
+	ctx context.Context,
+	orgId, projectId, database, collection string,
+	body []byte,
+) (*ChunkUpsertResult, error) {
+	path := chunksPath(orgId, projectId, database, collection)
+	req, err := c.newRequest(ctx, http.MethodPut, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Body = io.NopCloser(bytes.NewReader(body))
+
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("upsert chunks request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, collectionErr(resp, "upsert chunks")
+	}
+
+	var result ChunkUpsertResult
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode upsert response: %w", err)
+	}
+	return &result, nil
+}
+
+// ListChunks returns a page of chunks.
+func (c *DeploymentClient) ListChunks(
+	ctx context.Context,
+	orgId, projectId, database, collection string,
+	opts ListChunksOpts,
+) (*ChunkList, error) {
+	req, err := c.newRequest(
+		ctx,
+		http.MethodGet,
+		chunksPath(orgId, projectId, database, collection),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	q := req.URL.Query()
+	if opts.Limit > 0 {
+		q.Set("limit", strconv.Itoa(opts.Limit))
+	}
+	if opts.Cursor != "" {
+		q.Set("cursor", opts.Cursor)
+	}
+	if opts.Prefix != "" {
+		q.Set("prefix", opts.Prefix)
+	}
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list chunks request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, collectionErr(resp, "list chunks")
+	}
+
+	var result ChunkList
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode chunks response: %w", err)
+	}
+	return &result, nil
+}
+
+// GetChunk fetches a single chunk, optionally including its vector(s).
+func (c *DeploymentClient) GetChunk(
+	ctx context.Context,
+	orgId, projectId, database, collection, id string,
+	includeVector bool,
+) (*Chunk, error) {
+	path := chunksPath(orgId, projectId, database, collection) + "/" + url.PathEscape(id)
+	req, err := c.newRequest(ctx, http.MethodGet, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	if includeVector {
+		q := req.URL.Query()
+		q.Set("include_vector", "true")
+		req.URL.RawQuery = q.Encode()
+	}
+
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("get chunk request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, collectionErr(resp, "get chunk")
+	}
+
+	var result Chunk
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode chunk response: %w", err)
+	}
+	return &result, nil
+}
+
+// CountChunks returns the chunk count, optionally scoped by a filter/prefix body.
+func (c *DeploymentClient) CountChunks(
+	ctx context.Context,
+	orgId, projectId, database, collection string,
+	body []byte,
+) (int64, error) {
+	path := chunksPath(orgId, projectId, database, collection) + "/count"
+	req, err := c.newRequest(ctx, http.MethodPost, path)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Body = io.NopCloser(bytes.NewReader(body))
+
+	resp, err := c.do(req)
+	if err != nil {
+		return 0, fmt.Errorf("count chunks request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return 0, collectionErr(resp, "count chunks")
+	}
+
+	var result struct {
+		Count int64 `json:"count"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return 0, fmt.Errorf("failed to decode count response: %w", err)
+	}
+	return result.Count, nil
+}
+
+// PatchChunk updates a chunk's metadata and/or text from a raw JSON body.
+func (c *DeploymentClient) PatchChunk(
+	ctx context.Context,
+	orgId, projectId, database, collection, id string,
+	body []byte,
+) (*Chunk, error) {
+	path := chunksPath(orgId, projectId, database, collection) + "/" + url.PathEscape(id)
+	req, err := c.newRequest(ctx, http.MethodPatch, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Body = io.NopCloser(bytes.NewReader(body))
+
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("patch chunk request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, collectionErr(resp, "patch chunk")
+	}
+
+	var result Chunk
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode chunk response: %w", err)
+	}
+	return &result, nil
+}
+
+// DeleteChunk deletes a single chunk by id.
+func (c *DeploymentClient) DeleteChunk(
+	ctx context.Context,
+	orgId, projectId, database, collection, id string,
+) (string, error) {
+	path := chunksPath(orgId, projectId, database, collection) + "/" + url.PathEscape(id)
+	req, err := c.newRequest(ctx, http.MethodDelete, path)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.do(req)
+	if err != nil {
+		return "", fmt.Errorf("delete chunk request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	msg := ExtractServerMessage(respBody)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if msg != "" {
+			return "", fmt.Errorf("%s", msg)
+		}
+		return "", fmt.Errorf("failed to delete chunk: server returned %s", resp.Status)
+	}
+	return msg, nil
+}
+
+// BulkDeleteChunks deletes chunks by ids/filter/all. confirmAll sets the
+// X-Confirm-Delete header required by the "all" selector.
+func (c *DeploymentClient) BulkDeleteChunks(
+	ctx context.Context,
+	orgId, projectId, database, collection string,
+	body []byte,
+	confirmAll bool,
+) (*BulkDeleteResult, error) {
+	path := chunksPath(orgId, projectId, database, collection)
+	req, err := c.newRequest(ctx, http.MethodDelete, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if confirmAll {
+		req.Header.Set("X-Confirm-Delete", "yes")
+	}
+	req.Body = io.NopCloser(bytes.NewReader(body))
+
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("bulk delete request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, collectionErr(resp, "bulk delete chunks")
+	}
+
+	var result BulkDeleteResult
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode bulk delete response: %w", err)
+	}
+	return &result, nil
+}

--- a/internal/clients/collections_chunks.go
+++ b/internal/clients/collections_chunks.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -253,7 +254,7 @@ func (c *DeploymentClient) DeleteChunk(
 	msg := ExtractServerMessage(respBody)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		if msg != "" {
-			return "", fmt.Errorf("%s", msg)
+			return "", errors.New(msg)
 		}
 		return "", fmt.Errorf("failed to delete chunk: server returned %s", resp.Status)
 	}

--- a/internal/clients/collections_documents.go
+++ b/internal/clients/collections_documents.go
@@ -1,0 +1,155 @@
+package clients
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+// DocumentSummary is one entry in a documents list (chunks grouped by documentId).
+type DocumentSummary struct {
+	DocumentID string `json:"documentId"`
+	ChunkCount int64  `json:"chunkCount"`
+}
+
+// DocumentList is a paginated list of documents.
+type DocumentList struct {
+	Documents  []DocumentSummary `json:"documents"`
+	NextCursor *string           `json:"nextCursor"`
+	HasMore    bool              `json:"hasMore"`
+}
+
+// DocumentChunks is a single document's chunks (paginated).
+type DocumentChunks struct {
+	DocumentID string  `json:"documentId"`
+	Chunks     []Chunk `json:"chunks"`
+	NextCursor *string `json:"nextCursor"`
+	HasMore    bool    `json:"hasMore"`
+}
+
+// DeleteDocumentResult is the response from deleting a document.
+type DeleteDocumentResult struct {
+	DocumentID   string `json:"documentId"`
+	DeletedCount int64  `json:"deletedCount"`
+}
+
+func documentsPath(orgId, projectId, database, collection string) string {
+	base := collectionsPath(orgId, projectId, database)
+	return base + "/" + url.PathEscape(collection) + "/documents"
+}
+
+// ListDocuments returns a page of documents (chunks grouped by documentId).
+func (c *DeploymentClient) ListDocuments(
+	ctx context.Context,
+	orgId, projectId, database, collection string,
+	limit int,
+	cursor string,
+) (*DocumentList, error) {
+	req, err := c.newRequest(
+		ctx,
+		http.MethodGet,
+		documentsPath(orgId, projectId, database, collection),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	q := req.URL.Query()
+	if limit > 0 {
+		q.Set("limit", strconv.Itoa(limit))
+	}
+	if cursor != "" {
+		q.Set("cursor", cursor)
+	}
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list documents request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, collectionErr(resp, "list documents")
+	}
+
+	var result DocumentList
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode documents response: %w", err)
+	}
+	return &result, nil
+}
+
+// GetDocument returns a document's chunks, optionally including vectors.
+func (c *DeploymentClient) GetDocument(
+	ctx context.Context,
+	orgId, projectId, database, collection, documentID string,
+	limit int,
+	cursor string,
+	includeVector bool,
+) (*DocumentChunks, error) {
+	path := documentsPath(orgId, projectId, database, collection) + "/" + url.PathEscape(documentID)
+	req, err := c.newRequest(ctx, http.MethodGet, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	q := req.URL.Query()
+	if limit > 0 {
+		q.Set("limit", strconv.Itoa(limit))
+	}
+	if cursor != "" {
+		q.Set("cursor", cursor)
+	}
+	if includeVector {
+		q.Set("include_vector", "true")
+	}
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("get document request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, collectionErr(resp, "get document")
+	}
+
+	var result DocumentChunks
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode document response: %w", err)
+	}
+	return &result, nil
+}
+
+// DeleteDocument deletes every chunk belonging to a document.
+func (c *DeploymentClient) DeleteDocument(
+	ctx context.Context,
+	orgId, projectId, database, collection, documentID string,
+) (*DeleteDocumentResult, error) {
+	path := documentsPath(orgId, projectId, database, collection) + "/" + url.PathEscape(documentID)
+	req, err := c.newRequest(ctx, http.MethodDelete, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("delete document request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, collectionErr(resp, "delete document")
+	}
+
+	var result DeleteDocumentResult
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode delete response: %w", err)
+	}
+	return &result, nil
+}

--- a/internal/clients/collections_search.go
+++ b/internal/clients/collections_search.go
@@ -91,7 +91,10 @@ func (c *DeploymentClient) Search(
 	return c.postSearch(ctx, path, body, "search")
 }
 
-// HybridSearch runs a multi-lane (RRF-fused) search via the /search endpoint.
+// HybridSearch runs a multi-lane (RRF-fused) search. Note it POSTs to the same
+// /search endpoint as Search — the server dispatches to single-lane vs hybrid
+// based on the request body (a top-level "queries" array selects hybrid), so the
+// `search` and `search hybrid` sub-commands hit the same URL with different bodies.
 func (c *DeploymentClient) HybridSearch(
 	ctx context.Context,
 	orgId, projectId, database, collection string,

--- a/internal/clients/collections_search.go
+++ b/internal/clients/collections_search.go
@@ -1,0 +1,126 @@
+package clients
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// SearchHit is one ranked result.
+type SearchHit struct {
+	ID       string         `json:"id"`
+	Score    float64        `json:"score"`
+	Text     string         `json:"text"`
+	Metadata map[string]any `json:"metadata"`
+}
+
+// SearchResponse is a single search's ranked results.
+type SearchResponse struct {
+	Results []SearchHit `json:"results"`
+	HasMore bool        `json:"hasMore"`
+}
+
+// BatchSearchResponse is one SearchResponse per sub-search.
+type BatchSearchResponse struct {
+	Responses []SearchResponse `json:"responses"`
+}
+
+func searchBase(orgId, projectId, database, collection string) string {
+	return collectionsPath(orgId, projectId, database) + "/" + url.PathEscape(collection)
+}
+
+// postSearch POSTs a JSON body and decodes a SearchResponse.
+func (c *DeploymentClient) postSearch(
+	ctx context.Context,
+	path string,
+	body []byte,
+	action string,
+) (*SearchResponse, error) {
+	var result SearchResponse
+	if err := c.postJSONInto(ctx, path, body, action, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// postJSONInto POSTs a JSON body and decodes the response into dst.
+func (c *DeploymentClient) postJSONInto(
+	ctx context.Context,
+	path string,
+	body []byte,
+	action string,
+	dst any,
+) error {
+	req, err := c.newRequest(ctx, http.MethodPost, path)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Body = io.NopCloser(bytes.NewReader(body))
+
+	resp, err := c.do(req)
+	if err != nil {
+		return fmt.Errorf("%s request failed: %w", action, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return collectionErr(resp, action)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
+		return fmt.Errorf("failed to decode %s response: %w", action, err)
+	}
+	return nil
+}
+
+// Search runs a single-lane search; exact routes to the exhaustive scan.
+func (c *DeploymentClient) Search(
+	ctx context.Context,
+	orgId, projectId, database, collection string,
+	body []byte,
+	exact bool,
+) (*SearchResponse, error) {
+	path := searchBase(orgId, projectId, database, collection) + "/search"
+	if exact {
+		path += "/exact"
+	}
+	return c.postSearch(ctx, path, body, "search")
+}
+
+// HybridSearch runs a multi-lane (RRF-fused) search via the /search endpoint.
+func (c *DeploymentClient) HybridSearch(
+	ctx context.Context,
+	orgId, projectId, database, collection string,
+	body []byte,
+) (*SearchResponse, error) {
+	path := searchBase(orgId, projectId, database, collection) + "/search"
+	return c.postSearch(ctx, path, body, "hybrid search")
+}
+
+// QueryByID finds neighbors of an existing chunk by its stored vector.
+func (c *DeploymentClient) QueryByID(
+	ctx context.Context,
+	orgId, projectId, database, collection string,
+	body []byte,
+) (*SearchResponse, error) {
+	path := searchBase(orgId, projectId, database, collection) + "/query-by-id"
+	return c.postSearch(ctx, path, body, "query-by-id")
+}
+
+// SearchBatch runs several searches in one request.
+func (c *DeploymentClient) SearchBatch(
+	ctx context.Context,
+	orgId, projectId, database, collection string,
+	body []byte,
+) (*BatchSearchResponse, error) {
+	path := searchBase(orgId, projectId, database, collection) + "/search/batch"
+	var result BatchSearchResponse
+	if err := c.postJSONInto(ctx, path, body, "batch search", &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/internal/clients/collections_slots.go
+++ b/internal/clients/collections_slots.go
@@ -1,0 +1,153 @@
+package clients
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// SlotAddResult is the response from adding a slot.
+type SlotAddResult struct {
+	Slot        string `json:"slot"`
+	Type        string `json:"type"`
+	Dimension   int    `json:"dimension"`
+	Distance    string `json:"distance"`
+	IndexStatus string `json:"indexStatus"`
+}
+
+// SlotIndexProgress is the response from index-progress.
+type SlotIndexProgress struct {
+	Slot      string `json:"slot"`
+	IndexType string `json:"indexType"`
+	Status    string `json:"status"`
+}
+
+// SlotOpResult is the response from reindex/vacuum.
+type SlotOpResult struct {
+	Slot        string `json:"slot"`
+	IndexStatus string `json:"indexStatus,omitempty"`
+	Status      string `json:"status,omitempty"`
+}
+
+func slotPath(orgId, projectId, database, collection, slot string) string {
+	base := collectionsPath(orgId, projectId, database)
+	return base + "/" + url.PathEscape(collection) + "/vectors/" + url.PathEscape(slot)
+}
+
+// sendSlotBody issues a method+body request to a slot path and decodes dst.
+func (c *DeploymentClient) sendSlotBody(
+	ctx context.Context,
+	method, path string,
+	body []byte,
+	action string,
+	dst any,
+) error {
+	req, err := c.newRequest(ctx, method, path)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+		req.Body = io.NopCloser(bytes.NewReader(body))
+	}
+
+	resp, err := c.do(req)
+	if err != nil {
+		return fmt.Errorf("%s request failed: %w", action, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return collectionErr(resp, action)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
+		return fmt.Errorf("failed to decode %s response: %w", action, err)
+	}
+	return nil
+}
+
+// AddSlot adds a vector slot from a raw JSON body.
+func (c *DeploymentClient) AddSlot(
+	ctx context.Context,
+	orgId, projectId, database, collection, slot string,
+	body []byte,
+) (*SlotAddResult, error) {
+	var result SlotAddResult
+	path := slotPath(orgId, projectId, database, collection, slot)
+	if err := c.sendSlotBody(ctx, http.MethodPut, path, body, "add slot", &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// ReindexSlot rebuilds a slot's index from an optional config body.
+func (c *DeploymentClient) ReindexSlot(
+	ctx context.Context,
+	orgId, projectId, database, collection, slot string,
+	body []byte,
+) (*SlotOpResult, error) {
+	var result SlotOpResult
+	path := slotPath(orgId, projectId, database, collection, slot) + "/reindex"
+	if err := c.sendSlotBody(ctx, http.MethodPost, path, body, "reindex slot", &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// VacuumSlot reclaims space and refreshes stats for a slot.
+func (c *DeploymentClient) VacuumSlot(
+	ctx context.Context,
+	orgId, projectId, database, collection, slot string,
+) (*SlotOpResult, error) {
+	var result SlotOpResult
+	path := slotPath(orgId, projectId, database, collection, slot) + "/vacuum"
+	if err := c.sendSlotBody(ctx, http.MethodPost, path, nil, "vacuum slot", &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// SlotIndexProgressStatus reads a slot's index build progress.
+func (c *DeploymentClient) SlotIndexProgressStatus(
+	ctx context.Context,
+	orgId, projectId, database, collection, slot string,
+) (*SlotIndexProgress, error) {
+	var result SlotIndexProgress
+	path := slotPath(orgId, projectId, database, collection, slot) + "/index-progress"
+	if err := c.sendSlotBody(ctx, http.MethodGet, path, nil, "index progress", &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// DeleteSlot drops a vector slot (its column and index).
+func (c *DeploymentClient) DeleteSlot(
+	ctx context.Context,
+	orgId, projectId, database, collection, slot string,
+) (string, error) {
+	path := slotPath(orgId, projectId, database, collection, slot)
+	req, err := c.newRequest(ctx, http.MethodDelete, path)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.do(req)
+	if err != nil {
+		return "", fmt.Errorf("delete slot request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	msg := ExtractServerMessage(respBody)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if msg != "" {
+			return "", fmt.Errorf("%s", msg)
+		}
+		return "", fmt.Errorf("failed to delete slot: server returned %s", resp.Status)
+	}
+	return msg, nil
+}

--- a/internal/clients/collections_slots.go
+++ b/internal/clients/collections_slots.go
@@ -93,7 +93,14 @@ func (c *DeploymentClient) ReindexSlot(
 ) (*SlotOpResult, error) {
 	var result SlotOpResult
 	path := slotPath(orgId, projectId, database, collection, slot) + "/reindex"
-	if err := c.sendSlotBody(ctx, http.MethodPost, path, body, "reindex slot", &result); err != nil {
+	if err := c.sendSlotBody(
+		ctx,
+		http.MethodPost,
+		path,
+		body,
+		"reindex slot",
+		&result,
+	); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -119,7 +126,14 @@ func (c *DeploymentClient) SlotIndexProgressStatus(
 ) (*SlotIndexProgress, error) {
 	var result SlotIndexProgress
 	path := slotPath(orgId, projectId, database, collection, slot) + "/index-progress"
-	if err := c.sendSlotBody(ctx, http.MethodGet, path, nil, "index progress", &result); err != nil {
+	if err := c.sendSlotBody(
+		ctx,
+		http.MethodGet,
+		path,
+		nil,
+		"index progress",
+		&result,
+	); err != nil {
 		return nil, err
 	}
 	return &result, nil

--- a/internal/clients/collections_slots.go
+++ b/internal/clients/collections_slots.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -145,7 +146,7 @@ func (c *DeploymentClient) DeleteSlot(
 	msg := ExtractServerMessage(respBody)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		if msg != "" {
-			return "", fmt.Errorf("%s", msg)
+			return "", errors.New(msg)
 		}
 		return "", fmt.Errorf("failed to delete slot: server returned %s", resp.Status)
 	}

--- a/internal/inputs/collections.go
+++ b/internal/inputs/collections.go
@@ -33,3 +33,51 @@ func ReadCollectionBodyFile(path string) ([]byte, error) {
 	}
 	return body, nil
 }
+
+// BuildChunkCountBody builds the count request body from an optional metadata
+// filter (a JSON object string) and an optional id prefix.
+func BuildChunkCountBody(filterJSON, prefix string) ([]byte, error) {
+	body := map[string]any{}
+	if filterJSON != "" {
+		var filter map[string]any
+		if err := json.Unmarshal([]byte(filterJSON), &filter); err != nil {
+			return nil, fmt.Errorf("--filter must be a JSON object: %w", err)
+		}
+		body["filter"] = filter
+	}
+	if prefix != "" {
+		body["prefix"] = prefix
+	}
+	return json.Marshal(body)
+}
+
+// BuildBulkDeleteBody builds the bulk-delete body from exactly one selector:
+// ids, a metadata filter (JSON object string), or all.
+func BuildBulkDeleteBody(ids []string, filterJSON string, all bool) ([]byte, error) {
+	set := 0
+	if len(ids) > 0 {
+		set++
+	}
+	if filterJSON != "" {
+		set++
+	}
+	if all {
+		set++
+	}
+	if set != 1 {
+		return nil, fmt.Errorf("provide exactly one of --ids, --filter, or --all")
+	}
+
+	switch {
+	case len(ids) > 0:
+		return json.Marshal(map[string]any{"ids": ids})
+	case filterJSON != "":
+		var filter map[string]any
+		if err := json.Unmarshal([]byte(filterJSON), &filter); err != nil {
+			return nil, fmt.Errorf("--filter must be a JSON object: %w", err)
+		}
+		return json.Marshal(map[string]any{"filter": filter})
+	default:
+		return json.Marshal(map[string]any{"all": true})
+	}
+}

--- a/internal/inputs/collections.go
+++ b/internal/inputs/collections.go
@@ -1,0 +1,35 @@
+package inputs
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ReadCollectionBodyFile reads a YAML or JSON file and returns it as JSON bytes
+// suitable for a collection create/patch request body. YAML is a superset of
+// JSON, so both parse; yaml.v3 decodes mappings into string-keyed maps, so the
+// result re-marshals cleanly to JSON.
+func ReadCollectionBodyFile(path string) ([]byte, error) {
+	if path == "" {
+		return nil, fmt.Errorf("a config file is required; provide --file")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %q: %w", path, err)
+	}
+
+	var doc any
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("failed to parse %q as YAML/JSON: %w", path, err)
+	}
+
+	body, err := json.Marshal(doc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode config: %w", err)
+	}
+	return body, nil
+}

--- a/internal/inputs/collections.go
+++ b/internal/inputs/collections.go
@@ -64,8 +64,14 @@ func BuildBulkDeleteBody(ids []string, filterJSON string, all bool) ([]byte, err
 	if all {
 		set++
 	}
-	if set != 1 {
+	if set == 0 {
 		return nil, fmt.Errorf("provide exactly one of --ids, --filter, or --all")
+	}
+	if set > 1 {
+		return nil, fmt.Errorf(
+			"provide exactly one of --ids, --filter, or --all (got %d selectors)",
+			set,
+		)
 	}
 
 	switch {

--- a/internal/inputs/collections.go
+++ b/internal/inputs/collections.go
@@ -81,3 +81,15 @@ func BuildBulkDeleteBody(ids []string, filterJSON string, all bool) ([]byte, err
 		return json.Marshal(map[string]any{"all": true})
 	}
 }
+
+// BuildAddSlotBody builds an add-slot body from flags (a raw vector slot).
+func BuildAddSlotBody(slotType string, dimension int, distance string) ([]byte, error) {
+	if dimension <= 0 {
+		return nil, fmt.Errorf("--dimension must be a positive integer (or use --file)")
+	}
+	body := map[string]any{"type": slotType, "dimension": dimension}
+	if distance != "" {
+		body["distance"] = distance
+	}
+	return json.Marshal(body)
+}

--- a/internal/inputs/collections_search.go
+++ b/internal/inputs/collections_search.go
@@ -37,8 +37,11 @@ func BuildSearchBody(
 	limit int,
 	filterJSON string,
 ) ([]byte, error) {
-	if (query == "") == (len(vector) == 0) {
+	if query == "" && len(vector) == 0 {
 		return nil, fmt.Errorf("provide exactly one of --query or --vector")
+	}
+	if query != "" && len(vector) > 0 {
+		return nil, fmt.Errorf("--query and --vector are mutually exclusive")
 	}
 
 	body := map[string]any{}

--- a/internal/inputs/collections_search.go
+++ b/internal/inputs/collections_search.go
@@ -1,0 +1,97 @@
+package inputs
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ParseVector parses a comma-separated list of floats (e.g. "0.1,0.2,0.3").
+func ParseVector(s string) ([]float64, error) {
+	parts := strings.Split(s, ",")
+	vec := make([]float64, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		f, err := strconv.ParseFloat(p, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid vector component %q: %w", p, err)
+		}
+		vec = append(vec, f)
+	}
+	if len(vec) == 0 {
+		return nil, fmt.Errorf("--vector is empty")
+	}
+	return vec, nil
+}
+
+// BuildSearchBody builds a single-lane search body from exactly one of query
+// (text, embedded server-side) or vector.
+func BuildSearchBody(
+	query string,
+	vector []float64,
+	using string,
+	limit int,
+	filterJSON string,
+) ([]byte, error) {
+	if (query == "") == (len(vector) == 0) {
+		return nil, fmt.Errorf("provide exactly one of --query or --vector")
+	}
+
+	body := map[string]any{}
+	if query != "" {
+		body["query"] = query
+	} else {
+		body["vector"] = vector
+	}
+	if using != "" {
+		body["using"] = using
+	}
+	if limit > 0 {
+		body["limit"] = limit
+	}
+	if err := addFilter(body, filterJSON); err != nil {
+		return nil, err
+	}
+	return json.Marshal(body)
+}
+
+// BuildQueryByIDBody builds a query-by-id body.
+func BuildQueryByIDBody(
+	id, using string,
+	limit int,
+	excludeSelf bool,
+	filterJSON string,
+) ([]byte, error) {
+	if id == "" {
+		return nil, fmt.Errorf("--id is required")
+	}
+
+	body := map[string]any{"id": id, "exclude_self": excludeSelf}
+	if using != "" {
+		body["using"] = using
+	}
+	if limit > 0 {
+		body["limit"] = limit
+	}
+	if err := addFilter(body, filterJSON); err != nil {
+		return nil, err
+	}
+	return json.Marshal(body)
+}
+
+// addFilter parses a JSON object string into body["filter"] when non-empty.
+func addFilter(body map[string]any, filterJSON string) error {
+	if filterJSON == "" {
+		return nil
+	}
+	var filter map[string]any
+	if err := json.Unmarshal([]byte(filterJSON), &filter); err != nil {
+		return fmt.Errorf("--filter must be a JSON object: %w", err)
+	}
+	body["filter"] = filter
+	return nil
+}

--- a/internal/inputs/collections_test.go
+++ b/internal/inputs/collections_test.go
@@ -1,0 +1,112 @@
+package inputs
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestParseVector(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    []float64
+		wantErr bool
+	}{
+		{"simple", "0.1,0.2,0.3", []float64{0.1, 0.2, 0.3}, false},
+		{"spaces", " 1 , 2 , 3 ", []float64{1, 2, 3}, false},
+		{"trailing-comma", "1,2,", []float64{1, 2}, false},
+		{"empty", "", nil, true},
+		{"non-numeric", "1,a,3", nil, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := ParseVector(c.in)
+			if c.wantErr != (err != nil) {
+				t.Fatalf("ParseVector(%q) err=%v, wantErr=%v", c.in, err, c.wantErr)
+			}
+			if !c.wantErr && !reflect.DeepEqual(got, c.want) {
+				t.Errorf("ParseVector(%q) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestBuildBulkDeleteBody(t *testing.T) {
+	cases := []struct {
+		name    string
+		ids     []string
+		filter  string
+		all     bool
+		wantErr bool
+		wantKey string // top-level key expected on success
+	}{
+		{"ids", []string{"a", "b"}, "", false, false, "ids"},
+		{"filter", nil, `{"lang":"en"}`, false, false, "filter"},
+		{"all", nil, "", true, false, "all"},
+		{"none", nil, "", false, true, ""},
+		{"two-selectors", []string{"a"}, "", true, true, ""},
+		{"bad-filter", nil, `{not json`, false, true, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			body, err := BuildBulkDeleteBody(c.ids, c.filter, c.all)
+			if c.wantErr != (err != nil) {
+				t.Fatalf("err=%v, wantErr=%v", err, c.wantErr)
+			}
+			if c.wantErr {
+				return
+			}
+			var m map[string]any
+			if uErr := json.Unmarshal(body, &m); uErr != nil {
+				t.Fatalf("unmarshal: %v", uErr)
+			}
+			if _, ok := m[c.wantKey]; !ok {
+				t.Errorf("body %s missing key %q", body, c.wantKey)
+			}
+		})
+	}
+}
+
+func TestBuildSearchBody(t *testing.T) {
+	cases := []struct {
+		name    string
+		query   string
+		vector  []float64
+		wantErr bool
+	}{
+		{"query-only", "hello", nil, false},
+		{"vector-only", "", []float64{0.1, 0.2}, false},
+		{"both", "hello", []float64{0.1}, true},
+		{"neither", "", nil, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := BuildSearchBody(c.query, c.vector, "", 0, "")
+			if c.wantErr != (err != nil) {
+				t.Errorf("err=%v, wantErr=%v", err, c.wantErr)
+			}
+		})
+	}
+}
+
+func TestBuildChunkCountBody(t *testing.T) {
+	if _, err := BuildChunkCountBody("", ""); err != nil {
+		t.Errorf("empty count body should not error: %v", err)
+	}
+	if _, err := BuildChunkCountBody(`{"lang":"en"}`, "doc-"); err != nil {
+		t.Errorf("valid count body should not error: %v", err)
+	}
+	if _, err := BuildChunkCountBody(`{bad`, ""); err == nil {
+		t.Errorf("bad filter should error")
+	}
+}
+
+func TestBuildAddSlotBody(t *testing.T) {
+	if _, err := BuildAddSlotBody("float32", 1536, "cosine"); err != nil {
+		t.Errorf("valid slot body should not error: %v", err)
+	}
+	if _, err := BuildAddSlotBody("float32", 0, ""); err == nil {
+		t.Errorf("dimension 0 should error")
+	}
+}

--- a/internal/output/collections.go
+++ b/internal/output/collections.go
@@ -1,0 +1,112 @@
+package output
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
+)
+
+// PrintCollectionList renders a collections list as a table.
+func PrintCollectionList(out io.Writer, collections []clients.CollectionSummary) error {
+	if len(collections) == 0 {
+		fmt.Fprintln(out, "No collections found.")
+		return nil
+	}
+
+	headers := []string{"NAME", "CREATED", "UPDATED"}
+	rows := make([][]string, len(collections))
+	for i, c := range collections {
+		rows[i] = []string{c.Name, LocalTime(c.CreatedAt), LocalTime(c.UpdatedAt)}
+	}
+	return PrintTable(out, headers, rows)
+}
+
+// PrintCollectionDescribe renders a collection's config: header fields plus a
+// per-slot table.
+func PrintCollectionDescribe(out io.Writer, c *clients.DescribeCollectionResponse) error {
+	fmt.Fprintf(out, "Name:       %s\n", c.Name)
+	fmt.Fprintf(out, "Created:    %s\n", LocalTime(c.CreatedAt))
+	fmt.Fprintf(out, "Updated:    %s\n", LocalTime(c.UpdatedAt))
+
+	ft := "disabled"
+	if c.Config.FullText != nil && c.Config.FullText.Enabled {
+		ft = fmt.Sprintf("enabled (%s)", c.Config.FullText.Language)
+	}
+	fmt.Fprintf(out, "Full-text:  %s\n\n", ft)
+
+	headers := []string{"SLOT", "TYPE", "DIMENSION", "DISTANCE", "EMBEDDING MODEL", "INDEX"}
+	rows := make([][]string, 0, len(c.Config.Vectors))
+	for _, name := range sortedSlotNames(c.Config.Vectors) {
+		slot := c.Config.Vectors[name]
+		rows = append(rows, []string{
+			name,
+			slot.Type,
+			fmt.Sprintf("%d", slot.Dimension),
+			slot.Distance,
+			embeddingModel(slot),
+			indexType(slot),
+		})
+	}
+	return PrintTable(out, headers, rows)
+}
+
+// PrintCollectionStats renders a collection's operational stats.
+func PrintCollectionStats(out io.Writer, s *clients.CollectionStats) error {
+	fmt.Fprintf(out, "Chunks:  %d\n", s.ChunkCount)
+	fmt.Fprintf(out, "Size:    %s\n", humanBytes(s.SizeBytes))
+
+	if len(s.IndexValid) == 0 {
+		return nil
+	}
+	fmt.Fprintln(out)
+	headers := []string{"SLOT", "INDEX VALID"}
+	rows := make([][]string, 0, len(s.IndexValid))
+	names := make([]string, 0, len(s.IndexValid))
+	for name := range s.IndexValid {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		rows = append(rows, []string{name, fmt.Sprintf("%t", s.IndexValid[name])})
+	}
+	return PrintTable(out, headers, rows)
+}
+
+func sortedSlotNames(slots map[string]clients.CollectionSlot) []string {
+	names := make([]string, 0, len(slots))
+	for name := range slots {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func embeddingModel(slot clients.CollectionSlot) string {
+	if slot.Embedding != nil && slot.Embedding.Model != "" {
+		return slot.Embedding.Model
+	}
+	return "-"
+}
+
+func indexType(slot clients.CollectionSlot) string {
+	if slot.Index != nil && slot.Index.Type != "" {
+		return slot.Index.Type
+	}
+	return "deferred"
+}
+
+// humanBytes renders a byte count in the largest unit that keeps it >= 1.
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for v := n / unit; v >= unit; v /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGTPE"[exp])
+}

--- a/internal/output/collections_chunks.go
+++ b/internal/output/collections_chunks.go
@@ -1,0 +1,89 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
+)
+
+// PrintChunkUpsertResult summarizes an upsert response: a per-status count plus
+// any per-chunk errors.
+func PrintChunkUpsertResult(out io.Writer, r *clients.ChunkUpsertResult) error {
+	byStatus := map[string]int{}
+	for _, res := range r.Results {
+		byStatus[res.Status]++
+	}
+	for status, n := range byStatus {
+		fmt.Fprintf(out, "%d %s\n", n, status)
+	}
+	if len(r.Errors) > 0 {
+		fmt.Fprintf(out, "\n%d error(s):\n", len(r.Errors))
+		for _, e := range r.Errors {
+			b, _ := json.Marshal(e)
+			fmt.Fprintf(out, "  %s\n", string(b))
+		}
+	}
+	return nil
+}
+
+// PrintChunkList renders a page of chunks as a table.
+func PrintChunkList(out io.Writer, list *clients.ChunkList) error {
+	if len(list.Chunks) == 0 {
+		fmt.Fprintln(out, "No chunks found.")
+		return nil
+	}
+
+	headers := []string{"ID", "DOCUMENT", "TEXT"}
+	rows := make([][]string, len(list.Chunks))
+	for i, c := range list.Chunks {
+		rows[i] = []string{c.ID, c.DocumentID, truncate(c.Text, 60)}
+	}
+	if err := PrintTable(out, headers, rows); err != nil {
+		return err
+	}
+
+	if list.HasMore && list.NextCursor != nil {
+		fmt.Fprintf(out, "\nMore results — next page: --cursor %s\n", *list.NextCursor)
+	}
+	return nil
+}
+
+// PrintChunk renders a single chunk's detail.
+func PrintChunk(out io.Writer, c *clients.Chunk) error {
+	fmt.Fprintf(out, "ID:        %s\n", c.ID)
+	fmt.Fprintf(out, "Document:  %s\n", c.DocumentID)
+	fmt.Fprintf(out, "Text:      %s\n", c.Text)
+
+	if len(c.Metadata) > 0 {
+		b, _ := json.MarshalIndent(c.Metadata, "           ", "  ")
+		fmt.Fprintf(out, "Metadata:  %s\n", string(b))
+	}
+
+	for slot, raw := range c.Vectors {
+		var v []float64
+		if err := json.Unmarshal(raw, &v); err == nil {
+			fmt.Fprintf(out, "Vector[%s]: %d dims\n", slot, len(v))
+		}
+	}
+	if len(c.Vector) > 0 {
+		fmt.Fprintf(out, "Vector:    %d dims\n", len(c.Vector))
+	}
+	return nil
+}
+
+// PrintBulkDeleteResult renders a bulk-delete response.
+func PrintBulkDeleteResult(out io.Writer, r *clients.BulkDeleteResult) error {
+	fmt.Fprintf(out, "Deleted %d chunk(s)\n", r.DeletedCount)
+	return nil
+}
+
+// truncate shortens s to n runes, appending an ellipsis when cut.
+func truncate(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n]) + "…"
+}

--- a/internal/output/collections_documents.go
+++ b/internal/output/collections_documents.go
@@ -1,0 +1,59 @@
+package output
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
+)
+
+// PrintDocumentList renders a documents list as a table.
+func PrintDocumentList(out io.Writer, list *clients.DocumentList) error {
+	if len(list.Documents) == 0 {
+		fmt.Fprintln(out, "No documents found.")
+		return nil
+	}
+
+	headers := []string{"DOCUMENT", "CHUNKS"}
+	rows := make([][]string, len(list.Documents))
+	for i, d := range list.Documents {
+		rows[i] = []string{d.DocumentID, fmt.Sprintf("%d", d.ChunkCount)}
+	}
+	if err := PrintTable(out, headers, rows); err != nil {
+		return err
+	}
+
+	if list.HasMore && list.NextCursor != nil {
+		fmt.Fprintf(out, "\nMore results — next page: --cursor %s\n", *list.NextCursor)
+	}
+	return nil
+}
+
+// PrintDocumentChunks renders one document's chunks: a header plus a chunk table.
+func PrintDocumentChunks(out io.Writer, doc *clients.DocumentChunks) error {
+	fmt.Fprintf(out, "Document:  %s\n\n", doc.DocumentID)
+	if len(doc.Chunks) == 0 {
+		fmt.Fprintln(out, "No chunks found.")
+		return nil
+	}
+
+	headers := []string{"ID", "TEXT"}
+	rows := make([][]string, len(doc.Chunks))
+	for i, c := range doc.Chunks {
+		rows[i] = []string{c.ID, truncate(c.Text, 70)}
+	}
+	if err := PrintTable(out, headers, rows); err != nil {
+		return err
+	}
+
+	if doc.HasMore && doc.NextCursor != nil {
+		fmt.Fprintf(out, "\nMore chunks — next page: --cursor %s\n", *doc.NextCursor)
+	}
+	return nil
+}
+
+// PrintDeleteDocumentResult renders a document-delete response.
+func PrintDeleteDocumentResult(out io.Writer, r *clients.DeleteDocumentResult) error {
+	fmt.Fprintf(out, "Deleted document %q (%d chunk(s))\n", r.DocumentID, r.DeletedCount)
+	return nil
+}

--- a/internal/output/collections_search.go
+++ b/internal/output/collections_search.go
@@ -1,0 +1,46 @@
+package output
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
+)
+
+// PrintSearchResults renders ranked search hits as a table.
+func PrintSearchResults(out io.Writer, r *clients.SearchResponse) error {
+	if len(r.Results) == 0 {
+		fmt.Fprintln(out, "No results.")
+		return nil
+	}
+	return searchHitsTable(out, r.Results)
+}
+
+// PrintBatchSearchResults renders one result block per sub-search.
+func PrintBatchSearchResults(out io.Writer, r *clients.BatchSearchResponse) error {
+	if len(r.Responses) == 0 {
+		fmt.Fprintln(out, "No results.")
+		return nil
+	}
+	for i, resp := range r.Responses {
+		fmt.Fprintf(out, "Query %d:\n", i+1)
+		if len(resp.Results) == 0 {
+			fmt.Fprintln(out, "  No results.")
+		} else if err := searchHitsTable(out, resp.Results); err != nil {
+			return err
+		}
+		if i < len(r.Responses)-1 {
+			fmt.Fprintln(out)
+		}
+	}
+	return nil
+}
+
+func searchHitsTable(out io.Writer, hits []clients.SearchHit) error {
+	headers := []string{"SCORE", "ID", "TEXT"}
+	rows := make([][]string, len(hits))
+	for i, h := range hits {
+		rows[i] = []string{fmt.Sprintf("%.4f", h.Score), h.ID, truncate(h.Text, 60)}
+	}
+	return PrintTable(out, headers, rows)
+}

--- a/internal/output/collections_slots.go
+++ b/internal/output/collections_slots.go
@@ -1,0 +1,36 @@
+package output
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
+)
+
+// PrintSlotAddResult renders the result of adding a slot.
+func PrintSlotAddResult(out io.Writer, r *clients.SlotAddResult) error {
+	fmt.Fprintf(out, "Slot:          %s\n", r.Slot)
+	fmt.Fprintf(out, "Type:          %s\n", r.Type)
+	fmt.Fprintf(out, "Dimension:     %d\n", r.Dimension)
+	fmt.Fprintf(out, "Distance:      %s\n", r.Distance)
+	fmt.Fprintf(out, "Index status:  %s\n", r.IndexStatus)
+	return nil
+}
+
+// PrintSlotIndexProgress renders a slot's index build progress.
+func PrintSlotIndexProgress(out io.Writer, p *clients.SlotIndexProgress) error {
+	fmt.Fprintf(out, "Slot:        %s\n", p.Slot)
+	fmt.Fprintf(out, "Index type:  %s\n", p.IndexType)
+	fmt.Fprintf(out, "Status:      %s\n", p.Status)
+	return nil
+}
+
+// PrintSlotOpResult renders a reindex/vacuum result (whichever status is set).
+func PrintSlotOpResult(out io.Writer, r *clients.SlotOpResult) error {
+	status := r.Status
+	if status == "" {
+		status = r.IndexStatus
+	}
+	fmt.Fprintf(out, "Slot %q: %s\n", r.Slot, status)
+	return nil
+}

--- a/internal/output/collections_test.go
+++ b/internal/output/collections_test.go
@@ -1,0 +1,25 @@
+package output
+
+import "testing"
+
+func TestHumanBytes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   int64
+		want string
+	}{
+		{"zero", 0, "0 B"},
+		{"bytes", 512, "512 B"},
+		{"exact-kib", 1024, "1.0 KiB"},
+		{"kib", 204800, "200.0 KiB"},
+		{"mib", 5 * 1024 * 1024, "5.0 MiB"},
+		{"gib", 3 * 1024 * 1024 * 1024, "3.0 GiB"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := humanBytes(c.in); got != c.want {
+				t.Errorf("humanBytes(%d) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds `iai collections` — CLI coverage for the knowledge-base / pgvector **collections** endpoints in the deployment-operator (paired with deployment-operator#186). A collection lives inside a database, so every command is scoped by a required `-d/--database` (mirroring how `dataset-items`/`replicas` name their parent), consistent with how each CLI resource is named after its API resource.

Naming decision: **`iai collections`** (1:1 with the API resource), chosen over `iai knowledgebase` / nesting under `databases` (see the design doc; validated with the team).

## Command surface

Built in five vertical slices, each its own commit:

- **lifecycle** — `list` / `create --file` / `describe` / `patch --file` / `delete` / `stats`
- **chunks** — `upsert --file` / `list` / `get [--include-vector]` / `count [--filter]` / `patch --file` / `delete` / `bulk-delete (--ids|--filter|--all)`
- **documents** — `list` / `get` / `delete`
- **search** — `search --query|--vector [--exact]` / `search batch --file` / `search by-id --id` / `search hybrid --file`
- **slots** — `slots add` / `reindex` / `vacuum` / `progress` / `delete`

Same 4-layer wiring as the other resources: `internal/clients` (DeploymentClient methods), `internal/inputs` (request bodies; YAML or JSON via `--file`), `internal/output` (table formatters + `--json`/`--yaml`), `cmd`. Regenerated CLI docs via `make docs`.

## Test plan

- `go build ./...`, `go test ./...`, golines/gofumpt/gci, `make docs` — all green (pre-commit clean).
- **Manual end-to-end against a live deployment-operator** (local `air`, dev pgvector DB): every command exercised — collection CRUD/stats; chunk upsert (text → embedded server-side via the caller's forwarded session, stored as a 1536-dim vector, confirmed with `get --include-vector`), list/count(+filter)/patch/delete/bulk-delete; documents list/get/delete; search dense/exact/by-id/batch/hybrid (RRF) all returning correct rankings; slot add → progress (hnsw/ready) → reindex → vacuum → delete.

Refs: DEV-822

🤖 Generated with [Claude Code](https://claude.com/claude-code)
