### PR TITLE
DEV-813: add key update commands

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.35.3"
+current_version = "0.35.4"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/api_keys.go
+++ b/cmd/api_keys.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/Interactive-AI-Labs/interactive-cli/internal/auth"
 	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
@@ -20,6 +19,7 @@ var (
 	apiKeysYAML         bool
 	apiKeysListColumns  []string
 	apiKeyNote          string
+	apiKeyUpdateNote    string
 
 	routerKeysProject      string
 	routerKeysOrganization string
@@ -30,6 +30,9 @@ var (
 	routerKeyLimit         float64
 	routerKeyLimitReset    string
 	routerKeyExpiresAt     string
+	routerKeyClearLimit    bool
+	routerKeyDisable       bool
+	routerKeyEnable        bool
 )
 
 func requireKeyManagementAuth() error {
@@ -148,6 +151,57 @@ Project API keys authenticate platform/API access for reading and writing projec
 		fmt.Fprintf(out, "Public key: %s\n", key.PublicKey)
 		fmt.Fprintf(out, "Secret key: %s\n", key.SecretKey)
 		fmt.Fprintln(out, "Save this secret now; it is only shown once.")
+		return nil
+	},
+}
+
+var apiKeysUpdateCmd = &cobra.Command{
+	Use:   "update <id>",
+	Short: "Update a project API key",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireKeyManagementAuth(); err != nil {
+			return err
+		}
+		if !cmd.Flags().Changed("note") {
+			return fmt.Errorf("at least one update flag is required")
+		}
+
+		out := cmd.OutOrStdout()
+		pCtx, apiClient, _, err := resolveProject(
+			cmd.Context(),
+			apiKeysOrganization,
+			apiKeysProject,
+		)
+		if err != nil {
+			return err
+		}
+
+		res, err := apiClient.UpdateProjectAPIKey(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			args[0],
+			clients.UpdateProjectAPIKeyBody{Note: apiKeyUpdateNote},
+		)
+		if err != nil {
+			return err
+		}
+		if !res.Success {
+			if res.Message != "" {
+				return fmt.Errorf("update failed: %s", res.Message)
+			}
+			return fmt.Errorf("update failed")
+		}
+
+		if apiKeysJSON {
+			return output.PrintStructuredJSON(out, res)
+		}
+		if apiKeysYAML {
+			return output.PrintStructuredYAML(out, res)
+		}
+
+		fmt.Fprintln(out, "Updated")
 		return nil
 	},
 }
@@ -271,24 +325,6 @@ Router keys authenticate inference requests to the InteractiveAI Router, for exa
 		if name == "" {
 			return fmt.Errorf("name is required")
 		}
-		if routerKeyLimit < 0 {
-			return fmt.Errorf("--limit must be greater than or equal to 0")
-		}
-		if routerKeyLimitReset != "" && routerKeyLimitReset != "daily" &&
-			routerKeyLimitReset != "weekly" &&
-			routerKeyLimitReset != "monthly" {
-			return fmt.Errorf("--limit-reset must be one of: daily, weekly, monthly")
-		}
-		if routerKeyLimitReset != "" && routerKeyLimit == 0 {
-			return fmt.Errorf("--limit-reset requires --limit")
-		}
-		if routerKeyExpiresAt != "" {
-			if _, err := time.Parse(time.RFC3339, routerKeyExpiresAt); err != nil {
-				return fmt.Errorf(
-					"--expires-at must be an RFC3339 timestamp, for example 2026-12-31T23:59:59Z",
-				)
-			}
-		}
 		out := cmd.OutOrStdout()
 		pCtx, apiClient, _, err := resolveProject(
 			cmd.Context(),
@@ -324,6 +360,72 @@ Router keys authenticate inference requests to the InteractiveAI Router, for exa
 		fmt.Fprintln(out)
 		fmt.Fprintf(out, "Router key: %s\n", res.Key)
 		fmt.Fprintln(out, "Save this secret now; it is only shown once.")
+		return nil
+	},
+}
+
+var routerKeysUpdateCmd = &cobra.Command{
+	Use:   "update <id>",
+	Short: "Update a router API key",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireKeyManagementAuth(); err != nil {
+			return err
+		}
+		if routerKeyClearLimit && cmd.Flags().Changed("limit") {
+			return fmt.Errorf("--clear-limit cannot be used with --limit")
+		}
+		if routerKeyDisable && routerKeyEnable {
+			return fmt.Errorf("--disable cannot be used with --enable")
+		}
+
+		patch := clients.UpdateRouterAPIKeyBody{}
+		if cmd.Flags().Changed("limit") {
+			patch["limit"] = routerKeyLimit
+		}
+		if routerKeyClearLimit {
+			patch["limit"] = nil
+		}
+		if cmd.Flags().Changed("limit-reset") {
+			if routerKeyLimitReset == "none" {
+				patch["limit_reset"] = nil
+			} else {
+				patch["limit_reset"] = routerKeyLimitReset
+			}
+		}
+		if routerKeyDisable {
+			patch["disabled"] = true
+		}
+		if routerKeyEnable {
+			patch["disabled"] = false
+		}
+		if len(patch) == 0 {
+			return fmt.Errorf("at least one update flag is required")
+		}
+
+		out := cmd.OutOrStdout()
+		pCtx, apiClient, _, err := resolveProject(
+			cmd.Context(),
+			routerKeysOrganization,
+			routerKeysProject,
+		)
+		if err != nil {
+			return err
+		}
+
+		key, err := apiClient.UpdateRouterAPIKey(cmd.Context(), pCtx.projectId, args[0], patch)
+		if err != nil {
+			return err
+		}
+
+		if routerKeysJSON {
+			return output.PrintStructuredJSON(out, key)
+		}
+		if routerKeysYAML {
+			return output.PrintStructuredYAML(out, key)
+		}
+
+		fmt.Fprintln(out, "Updated")
 		return nil
 	},
 }
@@ -378,7 +480,7 @@ var routerKeysDeleteCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(apiKeysCmd, routerKeysCmd)
 
-	for _, c := range []*cobra.Command{apiKeysListCmd, apiKeysCreateCmd, apiKeysDeleteCmd} {
+	for _, c := range []*cobra.Command{apiKeysListCmd, apiKeysCreateCmd, apiKeysUpdateCmd, apiKeysDeleteCmd} {
 		c.Flags().StringVarP(&apiKeysProject, "project", "p", "", "Project name")
 		c.Flags().StringVarP(&apiKeysOrganization, "organization", "o", "", "Organization name")
 		c.Flags().BoolVar(&apiKeysJSON, "json", false, "Output response as JSON")
@@ -389,9 +491,10 @@ func init() {
 		StringSliceVar(&apiKeysListColumns, "columns", nil, "Columns to display for table output only (comma-separated, default: id,public_key,secret,note,created_at). Cannot be used with --json or --yaml.\nAvailable: id,public_key,secret,note,status,expires_at,last_used_at,created_at")
 	apiKeysListCmd.MarkFlagsMutuallyExclusive("columns", "json", "yaml")
 	apiKeysCreateCmd.Flags().StringVar(&apiKeyNote, "note", "", "API key note")
-	apiKeysCmd.AddCommand(apiKeysListCmd, apiKeysCreateCmd, apiKeysDeleteCmd)
+	apiKeysUpdateCmd.Flags().StringVar(&apiKeyUpdateNote, "note", "", "API key note")
+	apiKeysCmd.AddCommand(apiKeysListCmd, apiKeysCreateCmd, apiKeysUpdateCmd, apiKeysDeleteCmd)
 
-	for _, c := range []*cobra.Command{routerKeysListCmd, routerKeysCreateCmd, routerKeysDeleteCmd} {
+	for _, c := range []*cobra.Command{routerKeysListCmd, routerKeysCreateCmd, routerKeysUpdateCmd, routerKeysDeleteCmd} {
 		c.Flags().StringVarP(&routerKeysProject, "project", "p", "", "Project name")
 		c.Flags().StringVarP(&routerKeysOrganization, "organization", "o", "", "Organization name")
 		c.Flags().BoolVar(&routerKeysJSON, "json", false, "Output response as JSON")
@@ -409,5 +512,20 @@ func init() {
 		StringVar(&routerKeyLimitReset, "limit-reset", "", "Limit reset period: daily, weekly, monthly. If omitted, defaults to monthly.")
 	routerKeysCreateCmd.Flags().
 		StringVar(&routerKeyExpiresAt, "expires-at", "", "Expiration timestamp (RFC3339). If omitted, keys do not expire by default.")
-	routerKeysCmd.AddCommand(routerKeysListCmd, routerKeysCreateCmd, routerKeysDeleteCmd)
+	routerKeysUpdateCmd.Flags().
+		Float64Var(&routerKeyLimit, "limit", 0, "Credit limit in USD")
+	routerKeysUpdateCmd.Flags().
+		BoolVar(&routerKeyClearLimit, "clear-limit", false, "Remove the credit limit")
+	routerKeysUpdateCmd.Flags().
+		StringVar(&routerKeyLimitReset, "limit-reset", "", "Limit reset period: none, daily, weekly, monthly")
+	routerKeysUpdateCmd.Flags().
+		BoolVar(&routerKeyDisable, "disable", false, "Disable this key")
+	routerKeysUpdateCmd.Flags().
+		BoolVar(&routerKeyEnable, "enable", false, "Enable this key")
+	routerKeysCmd.AddCommand(
+		routerKeysListCmd,
+		routerKeysCreateCmd,
+		routerKeysUpdateCmd,
+		routerKeysDeleteCmd,
+	)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version            = "0.35.3"
+	version            = "0.35.4"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second

--- a/docs/iai_api-keys.md
+++ b/docs/iai_api-keys.md
@@ -29,4 +29,5 @@ Project API keys authenticate platform/API access for reading and writing projec
 * [iai api-keys create](iai_api-keys_create.md)	 - Create a project API key
 * [iai api-keys delete](iai_api-keys_delete.md)	 - Delete a project API key
 * [iai api-keys list](iai_api-keys_list.md)	 - List project API keys
+* [iai api-keys update](iai_api-keys_update.md)	 - Update a project API key
 

--- a/docs/iai_api-keys_update.md
+++ b/docs/iai_api-keys_update.md
@@ -1,0 +1,32 @@
+## iai api-keys update
+
+Update a project API key
+
+```
+iai api-keys update <id> [flags]
+```
+
+### Options
+
+```
+  -h, --help                  help for update
+      --json                  Output response as JSON
+      --note string           API key note
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+      --yaml                  Output response as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai api-keys](iai_api-keys.md)	 - Project API keys
+

--- a/docs/iai_router-keys.md
+++ b/docs/iai_router-keys.md
@@ -29,4 +29,5 @@ Router keys authenticate inference requests to the InteractiveAI Router, for exa
 * [iai router-keys create](iai_router-keys_create.md)	 - Create a router API key
 * [iai router-keys delete](iai_router-keys_delete.md)	 - Delete a router API key
 * [iai router-keys list](iai_router-keys_list.md)	 - List router API keys
+* [iai router-keys update](iai_router-keys_update.md)	 - Update a router API key
 

--- a/docs/iai_router-keys_update.md
+++ b/docs/iai_router-keys_update.md
@@ -1,0 +1,36 @@
+## iai router-keys update
+
+Update a router API key
+
+```
+iai router-keys update <id> [flags]
+```
+
+### Options
+
+```
+      --clear-limit           Remove the credit limit
+      --disable               Disable this key
+      --enable                Enable this key
+  -h, --help                  help for update
+      --json                  Output response as JSON
+      --limit float           Credit limit in USD
+      --limit-reset string    Limit reset period: none, daily, weekly, monthly
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+      --yaml                  Output response as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai router-keys](iai_router-keys.md)	 - Router API keys
+

--- a/internal/clients/api_client_keys.go
+++ b/internal/clients/api_client_keys.go
@@ -25,6 +25,10 @@ type CreateProjectAPIKeyBody struct {
 	Note string `json:"note,omitempty"`
 }
 
+type UpdateProjectAPIKeyBody struct {
+	Note string `json:"note"`
+}
+
 type RouterAPIKey struct {
 	ID             string  `json:"id"`
 	Name           string  `json:"name"`
@@ -64,7 +68,9 @@ type CreateRouterAPIKeyResponse struct {
 	Warning string `json:"warning,omitempty"`
 }
 
-type DeleteAPIKeyResponse struct {
+type UpdateRouterAPIKeyBody map[string]any
+
+type APIKeySuccessResponse struct {
 	Success bool   `json:"success"`
 	Message string `json:"message"`
 }
@@ -144,24 +150,50 @@ func (c *APIClient) CreateProjectAPIKey(
 	return decodeSuccess[ProjectAPIKey](respBody, "create project API key")
 }
 
+func (c *APIClient) UpdateProjectAPIKey(
+	ctx context.Context,
+	orgID, projectID, keyID string,
+	body UpdateProjectAPIKeyBody,
+) (APIKeySuccessResponse, error) {
+	if err := c.requireKeyManagementAuth(); err != nil {
+		return APIKeySuccessResponse{}, err
+	}
+
+	req, err := c.newJSONRequest(
+		ctx,
+		http.MethodPatch,
+		projectAPIKeyPath(orgID, projectID, keyID),
+		body,
+	)
+	if err != nil {
+		return APIKeySuccessResponse{}, err
+	}
+
+	respBody, err := c.doAndRead(req, "update project API key")
+	if err != nil {
+		return APIKeySuccessResponse{}, err
+	}
+	return decodeSuccess[APIKeySuccessResponse](respBody, "update project API key")
+}
+
 func (c *APIClient) DeleteProjectAPIKey(
 	ctx context.Context,
 	orgID, projectID, keyID string,
-) (DeleteAPIKeyResponse, error) {
+) (APIKeySuccessResponse, error) {
 	if err := c.requireKeyManagementAuth(); err != nil {
-		return DeleteAPIKeyResponse{}, err
+		return APIKeySuccessResponse{}, err
 	}
 
 	req, err := c.newRequest(ctx, http.MethodDelete, projectAPIKeyPath(orgID, projectID, keyID))
 	if err != nil {
-		return DeleteAPIKeyResponse{}, err
+		return APIKeySuccessResponse{}, err
 	}
 
 	body, err := c.doAndRead(req, "delete project API key")
 	if err != nil {
-		return DeleteAPIKeyResponse{}, err
+		return APIKeySuccessResponse{}, err
 	}
-	return decodeSuccess[DeleteAPIKeyResponse](body, "delete project API key")
+	return decodeSuccess[APIKeySuccessResponse](body, "delete project API key")
 }
 
 func (c *APIClient) ListRouterAPIKeys(
@@ -213,30 +245,57 @@ func (c *APIClient) CreateRouterAPIKey(
 	return res, nil
 }
 
-func (c *APIClient) DeleteRouterAPIKey(
-	ctx context.Context,
-	projectID, keyID string,
-) (DeleteAPIKeyResponse, error) {
-	if err := c.requireKeyManagementAuth(); err != nil {
-		return DeleteAPIKeyResponse{}, err
-	}
-
-	path := fmt.Sprintf(
+func routerAPIKeyPath(projectID, keyID string) string {
+	return fmt.Sprintf(
 		"/api/v1/projects/%s/openrouter-keys/%s",
 		url.PathEscape(projectID),
 		url.PathEscape(keyID),
 	)
-	req, err := c.newRequest(ctx, http.MethodDelete, path)
+}
+
+func (c *APIClient) UpdateRouterAPIKey(
+	ctx context.Context,
+	projectID, keyID string,
+	body UpdateRouterAPIKeyBody,
+) (RouterAPIKey, error) {
+	if err := c.requireKeyManagementAuth(); err != nil {
+		return RouterAPIKey{}, err
+	}
+
+	req, err := c.newJSONRequest(ctx, http.MethodPatch, routerAPIKeyPath(projectID, keyID), body)
 	if err != nil {
-		return DeleteAPIKeyResponse{}, err
+		return RouterAPIKey{}, err
+	}
+	respBody, err := c.doAndRead(req, "update router key")
+	if err != nil {
+		return RouterAPIKey{}, err
+	}
+	var res RouterAPIKey
+	if err := json.Unmarshal(respBody, &res); err != nil {
+		return RouterAPIKey{}, fmt.Errorf("failed to decode router key: %w", err)
+	}
+	return res, nil
+}
+
+func (c *APIClient) DeleteRouterAPIKey(
+	ctx context.Context,
+	projectID, keyID string,
+) (APIKeySuccessResponse, error) {
+	if err := c.requireKeyManagementAuth(); err != nil {
+		return APIKeySuccessResponse{}, err
+	}
+
+	req, err := c.newRequest(ctx, http.MethodDelete, routerAPIKeyPath(projectID, keyID))
+	if err != nil {
+		return APIKeySuccessResponse{}, err
 	}
 	body, err := c.doAndRead(req, "delete router key")
 	if err != nil {
-		return DeleteAPIKeyResponse{}, err
+		return APIKeySuccessResponse{}, err
 	}
-	var res DeleteAPIKeyResponse
+	var res APIKeySuccessResponse
 	if err := json.Unmarshal(body, &res); err != nil {
-		return DeleteAPIKeyResponse{}, fmt.Errorf("failed to decode delete response: %w", err)
+		return APIKeySuccessResponse{}, fmt.Errorf("failed to decode delete response: %w", err)
 	}
 	return res, nil
 }

--- a/internal/clients/api_client_keys_test.go
+++ b/internal/clients/api_client_keys_test.go
@@ -68,6 +68,36 @@ func TestProjectAPIKeyPath(t *testing.T) {
 	}
 }
 
+func TestRouterAPIKeyPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		projectID string
+		keyID     string
+		want      string
+	}{
+		{
+			name:      "plain ids",
+			projectID: "project-1",
+			keyID:     "key-1",
+			want:      "/api/v1/projects/project-1/openrouter-keys/key-1",
+		},
+		{
+			name:      "escapes path segments",
+			projectID: "project 1",
+			keyID:     "key/1",
+			want:      "/api/v1/projects/project%201/openrouter-keys/key%2F1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := routerAPIKeyPath(tt.projectID, tt.keyID); got != tt.want {
+				t.Fatalf("routerAPIKeyPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRequireKeyManagementAuth(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary
- add `iai api-keys update <id> --note`
- add `iai router-keys update <id>` for limits, reset cadence, enable, and disable
- generate command docs

## Testing
- `go test ./internal/clients ./internal/inputs ./internal/output ./cmd`
- dev smoke: router key create/update/clear/enable/delete passed
- dev project API key update is blocked until the Platform PATCH bridge deploys: current dev returns Method Not Allowed
