### PR TITLE
fix(schema): name discriminated unions in agents schema TYPE column

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.35.2"
+current_version = "0.35.3"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version            = "0.35.2"
+	version            = "0.35.3"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second

--- a/internal/output/schema.go
+++ b/internal/output/schema.go
@@ -18,6 +18,7 @@ type jsonSchema struct {
 	Ref         string                `json:"$ref"`
 	Items       *jsonSchema           `json:"items"`
 	AnyOf       []jsonSchema          `json:"anyOf"`
+	OneOf       []jsonSchema          `json:"oneOf"`
 	Enum        []any                 `json:"enum"`
 	Default     any                   `json:"default"`
 	Const       any                   `json:"const"`
@@ -113,9 +114,10 @@ func resolveTypeName(s jsonSchema, defs map[string]jsonSchema) string {
 		return refName(s.Ref)
 	}
 
-	if len(s.AnyOf) > 0 {
-		parts := make([]string, 0, len(s.AnyOf))
-		for _, alt := range s.AnyOf {
+	// Discriminated unions nest a oneOf inside an anyOf; union both alike.
+	if alts := append(append([]jsonSchema{}, s.AnyOf...), s.OneOf...); len(alts) > 0 {
+		parts := make([]string, 0, len(alts))
+		for _, alt := range alts {
 			parts = append(parts, resolveTypeName(alt, defs))
 		}
 		return strings.Join(parts, " | ")

--- a/internal/output/schema_test.go
+++ b/internal/output/schema_test.go
@@ -28,6 +28,26 @@ func TestPrintSchemaPretty(t *testing.T) {
 			"mcps": {
 				"items": {"$ref": "#/$defs/McpConfig"},
 				"type": "array"
+			},
+			"search": {
+				"anyOf": [
+					{
+						"oneOf": [
+							{"$ref": "#/$defs/KnowledgeBase"},
+							{"$ref": "#/$defs/ExternalSearch"}
+						],
+						"discriminator": {
+							"propertyName": "type",
+							"mapping": {
+								"knowledge_base": "#/$defs/KnowledgeBase",
+								"external_search": "#/$defs/ExternalSearch"
+							}
+						}
+					},
+					{"type": "null"}
+				],
+				"default": null,
+				"description": "Retrieval-grounding source."
 			}
 		},
 		"$defs": {
@@ -110,6 +130,7 @@ func TestPrintSchemaPretty(t *testing.T) {
 		"no",
 		"list[McpConfig]",
 		"string | null",
+		"KnowledgeBase | ExternalSearch | null",
 		"McpConfig",
 		"PromptRef",
 		"FIELD",


### PR DESCRIPTION
## Problem

`iai agents schema` renders the `search` row's TYPE column as `any | null` instead of `KnowledgeBase | ExternalSearch | null`. Display-only bug — the fetched JSON schema is correct; the Go renderer just can't name the type.

## Root cause

The type-namer (`resolveTypeName` in `internal/output/schema.go`) walked `anyOf` members but had **no `oneOf` case**. Pydantic emits a discriminated union as a `oneOf` nested inside an `anyOf`:

```json
"anyOf": [
  { "oneOf": [ {"$ref": "KnowledgeBase"}, {"$ref": "ExternalSearch"} ],
    "discriminator": { "propertyName": "type", "mapping": {...} } },
  { "type": "null" }
]
```

The namer stripped the null branch, then hit the `oneOf` wrapper — no `type`, no top-level `$ref` — and fell through to its `any` default.

## Fix

Add `OneOf` to the schema struct and resolve `oneOf` members the same way as `anyOf`: recurse each to its `$ref` title and join with `" | "`. General fix — corrects **every** discriminated union, not just `search`.

Same class of bug as the recently-fixed `gen_docs.py` issue, but in the CLI's Go renderer.

## Test

Extended `TestPrintSchemaPretty` with a `search`-shaped discriminated-union field; asserts `KnowledgeBase | ExternalSearch | null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
