### PR TITLE
fix(collections): address PR #186 review feedback (CLI)

### DIFF
--- a/cmd/collections.go
+++ b/cmd/collections.go
@@ -280,6 +280,123 @@ func init() {
 
 	collectionsCmd.AddCommand(
 		collListCmd, collDescribeCmd, collStatsCmd, collCreateCmd, collPatchCmd, collDeleteCmd,
+		collSchemaCmd,
 	)
+	collSchemaCmd.Flags().BoolVar(&collJSON, "json", false, "Output the schemas as JSON")
+	collSchemaCmd.Flags().BoolVar(&collYAML, "yaml", false, "Output the schemas as YAML")
 	rootCmd.AddCommand(collectionsCmd)
+}
+
+var collSchemaCmd = &cobra.Command{
+	Use:   "schema",
+	Short: "Show the file schemas for the --file-based collection commands",
+	Long: `Print the expected shape of every --file body: collection create/patch,
+chunks upsert/patch, slots add/reindex, and search batch/hybrid. Use --json or
+--yaml for structured output.`,
+	Example: `  iai collections schema
+  iai collections schema --json`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		if collJSON {
+			return output.PrintStructuredJSON(out, collectionSchemas())
+		}
+		if collYAML {
+			return output.PrintStructuredYAML(out, collectionSchemas())
+		}
+		fmt.Fprint(out, collectionSchemaText)
+		return nil
+	},
+}
+
+const collectionSchemaText = `Collection file schemas (bodies for --file). All fields camelCase.
+
+create (--file):
+  {
+    "vectors": {
+      "<slot>": { "type": "float32", "dimension": 768, "distance": "cosine" },
+      "<slot>": { "embedding": { "model": "<model-id>" }, "dimension": 768 }
+    },
+    "full_text": { "enabled": true, "language": "english" }
+  }
+  NOTE: slot type, dimension, distance, and embedding model are IMMUTABLE.
+  Provide either a raw slot (type+dimension) or an embedding slot (embedding+dimension).
+
+patch (--file):
+  { "full_text": { "enabled": false },
+    "vectors": { "<slot>": { "index": { "ef_search_default": 200 } } } }
+
+chunks upsert (--file):
+  { "chunks": [
+      { "id": "c1", "documentId": "doc1", "text": "content", "metadata": {"k":"v"} }
+  ] }
+  Fields: id, documentId, text, metadata, vector/vectors. Use documentId (NOT document_id).
+
+chunks patch (--file):
+  { "text": "new content", "metadata": {"k":"v"} }
+
+slots add / reindex (--file):
+  { "type": "float32", "dimension": 768, "distance": "cosine",
+    "index": { "type": "hnsw", "m": 16, "ef_construct": 200 } }
+
+search batch (--file):
+  { "searches": [ {"query":"text","using":"default","limit":10} ] }
+
+search hybrid (--file):
+  { "queries": [
+      {"query":"text","using":"default","candidate_limit":50},
+      {"full_text":"keywords","candidate_limit":30}
+    ],
+    "fusion": {"method":"rrf","k":60}, "limit": 10 }
+  NOTE: "using" selects a vector slot; use "full_text" for the keyword lane.
+`
+
+// collectionSchemas mirrors collectionSchemaText as a structured map for --json/--yaml.
+func collectionSchemas() map[string]any {
+	return map[string]any{
+		"create": map[string]any{
+			"vectors": map[string]any{
+				"<slot>": map[string]any{
+					"type": "float32", "dimension": 768, "distance": "cosine",
+					"embedding": map[string]string{"model": "<model-id>"},
+				},
+			},
+			"full_text": map[string]any{"enabled": true, "language": "english"},
+			"immutable": []string{"type", "dimension", "distance", "embedding.model"},
+		},
+		"patch": map[string]any{
+			"full_text": map[string]any{"enabled": false},
+			"vectors": map[string]any{
+				"<slot>": map[string]any{"index": map[string]int{"ef_search_default": 200}},
+			},
+		},
+		"chunks_upsert": map[string]any{
+			"chunks": []map[string]any{
+				{
+					"id":         "c1",
+					"documentId": "doc1",
+					"text":       "content",
+					"metadata":   map[string]string{"k": "v"},
+				},
+			},
+		},
+		"chunks_patch": map[string]any{
+			"text":     "new content",
+			"metadata": map[string]string{"k": "v"},
+		},
+		"slots_add": map[string]any{
+			"type": "float32", "dimension": 768, "distance": "cosine",
+			"index": map[string]any{"type": "hnsw", "m": 16, "ef_construct": 200},
+		},
+		"search_batch": map[string]any{
+			"searches": []map[string]any{{"query": "text", "using": "default", "limit": 10}},
+		},
+		"search_hybrid": map[string]any{
+			"queries": []map[string]any{
+				{"query": "text", "using": "default", "candidate_limit": 50},
+				{"full_text": "keywords", "candidate_limit": 30},
+			},
+			"fusion": map[string]any{"method": "rrf", "k": 60}, "limit": 10,
+		},
+	}
 }

--- a/cmd/collections.go
+++ b/cmd/collections.go
@@ -28,7 +28,9 @@ var collectionsCmd = &cobra.Command{
 
 A collection is a vector store (knowledge base) that lives inside an existing
 pgvector database, so every command requires --database. Use 'iai databases
-create' first to provision the database.`,
+create' first to provision the database.
+
+Run 'iai collections schema' to see the body format for every --file command.`,
 }
 
 var collListCmd = &cobra.Command{
@@ -146,7 +148,12 @@ var collCreateCmd = &cobra.Command{
 
 The config declares the vector slot(s) — either an embedding-backed slot
 ("embedding": {model, dimension}) or a raw vector slot ({type, dimension,
-distance}) — and optional full-text search.`,
+distance}) — and optional full-text search.
+
+Slot type, dimension, distance, and the embedding model are IMMUTABLE after
+creation; fixing a wrong value means deleting and recreating the collection.
+
+Run 'iai collections schema' for the config file format.`,
 	Example: `  iai collections create docs -d my-db --file collection.yaml`,
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/collections.go
+++ b/cmd/collections.go
@@ -16,6 +16,7 @@ var (
 	collFile         string
 	collJSON         bool
 	collYAML         bool
+	collDryRun       bool
 )
 
 var collectionsCmd = &cobra.Command{
@@ -169,6 +170,7 @@ distance}) — and optional full-text search.`,
 			collDatabase,
 			name,
 			body,
+			collDryRun,
 		)
 		if err != nil {
 			return err
@@ -270,6 +272,8 @@ func init() {
 	}
 
 	collCreateCmd.Flags().StringVar(&collFile, "file", "", "Path to a YAML/JSON collection config")
+	collCreateCmd.Flags().
+		BoolVar(&collDryRun, "dry-run", false, "Validate the config without creating the collection")
 	_ = collCreateCmd.MarkFlagRequired("file")
 	collPatchCmd.Flags().StringVar(&collFile, "file", "", "Path to a YAML/JSON patch config")
 	_ = collPatchCmd.MarkFlagRequired("file")

--- a/cmd/collections_chunks.go
+++ b/cmd/collections_chunks.go
@@ -98,7 +98,12 @@ var chunksListCmd = &cobra.Command{
 			pCtx.projectId,
 			collDatabase,
 			collection,
-			clients.ListChunksOpts{Limit: chunkLimit, Cursor: chunkCursor, Prefix: chunkPrefix},
+			clients.ListChunksOpts{
+				Limit:  chunkLimit,
+				Cursor: chunkCursor,
+				Prefix: chunkPrefix,
+				Filter: chunkFilter,
+			},
 		)
 		if err != nil {
 			return err
@@ -351,6 +356,8 @@ func init() {
 		StringVar(&chunkCursor, "cursor", "", "Opaque cursor from a previous page")
 	chunksListCmd.Flags().
 		StringVar(&chunkPrefix, "prefix", "", "Only chunks whose id has this prefix")
+	chunksListCmd.Flags().
+		StringVar(&chunkFilter, "filter", "", "Metadata filter as a JSON object")
 
 	chunksGetCmd.Flags().
 		BoolVar(&chunkIncludeVector, "include-vector", false, "Include the stored vector(s)")

--- a/cmd/collections_chunks.go
+++ b/cmd/collections_chunks.go
@@ -61,6 +61,7 @@ defer_embedding=true with client-supplied vectors to skip embedding).`,
 			collDatabase,
 			collection,
 			body,
+			collDryRun,
 		)
 		if err != nil {
 			return err
@@ -349,6 +350,8 @@ func init() {
 	}
 
 	chunksUpsertCmd.Flags().StringVar(&chunkFile, "file", "", "Path to a YAML/JSON chunks file")
+	chunksUpsertCmd.Flags().
+		BoolVar(&collDryRun, "dry-run", false, "Validate the batch without embedding or storing")
 	_ = chunksUpsertCmd.MarkFlagRequired("file")
 
 	chunksListCmd.Flags().IntVar(&chunkLimit, "limit", 0, "Page size (1-1000, default 100)")

--- a/cmd/collections_documents.go
+++ b/cmd/collections_documents.go
@@ -10,6 +10,7 @@ import (
 var (
 	docLimit         int
 	docCursor        string
+	docFilter        string
 	docIncludeVector bool
 )
 
@@ -43,6 +44,7 @@ var documentsListCmd = &cobra.Command{
 			collection,
 			docLimit,
 			docCursor,
+			docFilter,
 		)
 		if err != nil {
 			return err
@@ -144,6 +146,8 @@ func init() {
 		c.Flags().BoolVar(&collYAML, "yaml", false, "Output raw API response as YAML")
 		c.Flags().IntVar(&docLimit, "limit", 0, "Page size (1-1000, default 100)")
 		c.Flags().StringVar(&docCursor, "cursor", "", "Opaque cursor from a previous page")
+		c.Flags().
+			StringVar(&docFilter, "filter", "", "Metadata filter as a JSON object (list only)")
 	}
 
 	documentsGetCmd.Flags().

--- a/cmd/collections_search.go
+++ b/cmd/collections_search.go
@@ -157,8 +157,25 @@ var searchByIDCmd = &cobra.Command{
 var searchHybridCmd = &cobra.Command{
 	Use:   "hybrid <collection>",
 	Short: "Run a multi-lane hybrid search (RRF) from a file",
-	Long: `Run a hybrid search from a YAML/JSON file whose body holds a "queries" array
-(dense and/or full_text lanes) and an optional "fusion" config.`,
+	Long: `Run a hybrid search from a YAML/JSON file. The command dispatches to the
+hybrid path automatically (it sets "mode":"hybrid" for you).
+
+The body holds a "queries" array and an optional "fusion" config. Each lane
+supplies exactly one of: query (dense, embedded server-side), vector
+(pre-computed dense), sparse_vector, or full_text (keyword search; requires
+full-text enabled on the collection). Note: "using" selects the vector slot —
+it does NOT select the full-text lane; set "full_text" for that. Lanes are
+fused with RRF.
+
+Schema:
+  {
+    "queries": [
+      {"query": "text", "using": "default", "candidate_limit": 50},
+      {"full_text": "keyword query", "candidate_limit": 30}
+    ],
+    "fusion": {"method": "rrf", "k": 60},
+    "limit": 10
+  }`,
 	Example: `  iai collections search hybrid docs -d my-db --file hybrid.json`,
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/iai_collections.md
+++ b/docs/iai_collections.md
@@ -10,6 +10,8 @@ A collection is a vector store (knowledge base) that lives inside an existing
 pgvector database, so every command requires --database. Use 'iai databases
 create' first to provision the database.
 
+Run 'iai collections schema' to see the body format for every --file command.
+
 ### Options
 
 ```

--- a/docs/iai_collections.md
+++ b/docs/iai_collections.md
@@ -35,6 +35,7 @@ create' first to provision the database.
 * [iai collections documents](iai_collections_documents.md)	 - Inspect documents (chunks grouped by documentId)
 * [iai collections list](iai_collections_list.md)	 - List collections in a database
 * [iai collections patch](iai_collections_patch.md)	 - Update a collection's mutable config from a file
+* [iai collections schema](iai_collections_schema.md)	 - Show the file schemas for the --file-based collection commands
 * [iai collections search](iai_collections_search.md)	 - Search a collection (single-lane vector search)
 * [iai collections slots](iai_collections_slots.md)	 - Manage a collection's vector slots and their indexes
 * [iai collections stats](iai_collections_stats.md)	 - Show a collection's chunk count, size, and index status

--- a/docs/iai_collections_chunks_list.md
+++ b/docs/iai_collections_chunks_list.md
@@ -18,6 +18,7 @@ iai collections chunks list <collection> [flags]
 ```
       --cursor string         Opaque cursor from a previous page
   -d, --database string       Database that holds the collection (required)
+      --filter string         Metadata filter as a JSON object
   -h, --help                  help for list
       --json                  Output raw API response as JSON
       --limit int             Page size (1-1000, default 100)

--- a/docs/iai_collections_chunks_upsert.md
+++ b/docs/iai_collections_chunks_upsert.md
@@ -23,6 +23,7 @@ iai collections chunks upsert <collection> [flags]
 
 ```
   -d, --database string       Database that holds the collection (required)
+      --dry-run               Validate the batch without embedding or storing
       --file string           Path to a YAML/JSON chunks file
   -h, --help                  help for upsert
       --json                  Output raw API response as JSON

--- a/docs/iai_collections_create.md
+++ b/docs/iai_collections_create.md
@@ -24,6 +24,7 @@ iai collections create <collection> [flags]
 
 ```
   -d, --database string       Database that holds the collection (required)
+      --dry-run               Validate the config without creating the collection
       --file string           Path to a YAML/JSON collection config
   -h, --help                  help for create
   -o, --organization string   Organization name

--- a/docs/iai_collections_create.md
+++ b/docs/iai_collections_create.md
@@ -10,6 +10,11 @@ The config declares the vector slot(s) — either an embedding-backed slot
 ("embedding": {model, dimension}) or a raw vector slot ({type, dimension,
 distance}) — and optional full-text search.
 
+Slot type, dimension, distance, and the embedding model are IMMUTABLE after
+creation; fixing a wrong value means deleting and recreating the collection.
+
+Run 'iai collections schema' for the config file format.
+
 ```
 iai collections create <collection> [flags]
 ```

--- a/docs/iai_collections_documents_get.md
+++ b/docs/iai_collections_documents_get.md
@@ -17,6 +17,7 @@ iai collections documents get <collection> <documentId> [flags]
 ```
       --cursor string         Opaque cursor from a previous page
   -d, --database string       Database that holds the collection (required)
+      --filter string         Metadata filter as a JSON object (list only)
   -h, --help                  help for get
       --include-vector        Include the stored vector(s)
       --json                  Output raw API response as JSON

--- a/docs/iai_collections_documents_list.md
+++ b/docs/iai_collections_documents_list.md
@@ -17,6 +17,7 @@ iai collections documents list <collection> [flags]
 ```
       --cursor string         Opaque cursor from a previous page
   -d, --database string       Database that holds the collection (required)
+      --filter string         Metadata filter as a JSON object (list only)
   -h, --help                  help for list
       --json                  Output raw API response as JSON
       --limit int             Page size (1-1000, default 100)

--- a/docs/iai_collections_schema.md
+++ b/docs/iai_collections_schema.md
@@ -1,0 +1,42 @@
+## iai collections schema
+
+Show the file schemas for the --file-based collection commands
+
+### Synopsis
+
+Print the expected shape of every --file body: collection create/patch,
+chunks upsert/patch, slots add/reindex, and search batch/hybrid. Use --json or
+--yaml for structured output.
+
+```
+iai collections schema [flags]
+```
+
+### Examples
+
+```
+  iai collections schema
+  iai collections schema --json
+```
+
+### Options
+
+```
+  -h, --help   help for schema
+      --json   Output the schemas as JSON
+      --yaml   Output the schemas as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai collections](iai_collections.md)	 - Vector collections (knowledge bases) inside a pgvector database
+

--- a/docs/iai_collections_search_hybrid.md
+++ b/docs/iai_collections_search_hybrid.md
@@ -4,8 +4,25 @@ Run a multi-lane hybrid search (RRF) from a file
 
 ### Synopsis
 
-Run a hybrid search from a YAML/JSON file whose body holds a "queries" array
-(dense and/or full_text lanes) and an optional "fusion" config.
+Run a hybrid search from a YAML/JSON file. The command dispatches to the
+hybrid path automatically (it sets "mode":"hybrid" for you).
+
+The body holds a "queries" array and an optional "fusion" config. Each lane
+supplies exactly one of: query (dense, embedded server-side), vector
+(pre-computed dense), sparse_vector, or full_text (keyword search; requires
+full-text enabled on the collection). Note: "using" selects the vector slot —
+it does NOT select the full-text lane; set "full_text" for that. Lanes are
+fused with RRF.
+
+Schema:
+  {
+    "queries": [
+      {"query": "text", "using": "default", "candidate_limit": 50},
+      {"full_text": "keyword query", "candidate_limit": 30}
+    ],
+    "fusion": {"method": "rrf", "k": 60},
+    "limit": 10
+  }
 
 ```
 iai collections search hybrid <collection> [flags]

--- a/internal/clients/collections.go
+++ b/internal/clients/collections.go
@@ -178,9 +178,14 @@ func (c *DeploymentClient) CreateCollection(
 	ctx context.Context,
 	orgId, projectId, database, name string,
 	body []byte,
+	dryRun bool,
 ) (string, error) {
 	path := collectionsPath(orgId, projectId, database) + "/" + url.PathEscape(name)
-	return c.sendCollectionBody(ctx, http.MethodPost, path, body, "create collection")
+	rawQuery := ""
+	if dryRun {
+		rawQuery = "dry_run=true"
+	}
+	return c.sendCollectionBody(ctx, http.MethodPost, path, body, "create collection", rawQuery)
 }
 
 // PatchCollection updates a collection's mutable config from a raw JSON body.
@@ -190,7 +195,7 @@ func (c *DeploymentClient) PatchCollection(
 	body []byte,
 ) (string, error) {
 	path := collectionsPath(orgId, projectId, database) + "/" + url.PathEscape(name)
-	return c.sendCollectionBody(ctx, http.MethodPatch, path, body, "update collection")
+	return c.sendCollectionBody(ctx, http.MethodPatch, path, body, "update collection", "")
 }
 
 // DeleteCollection deletes a collection and its data.
@@ -227,11 +232,13 @@ func (c *DeploymentClient) sendCollectionBody(
 	method, path string,
 	body []byte,
 	action string,
+	rawQuery string,
 ) (string, error) {
 	req, err := c.newRequest(ctx, method, path)
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)
 	}
+	req.URL.RawQuery = rawQuery
 	req.Header.Set("Content-Type", "application/json")
 	req.Body = io.NopCloser(bytes.NewReader(body))
 

--- a/internal/clients/collections_chunks.go
+++ b/internal/clients/collections_chunks.go
@@ -53,6 +53,7 @@ type ListChunksOpts struct {
 	Limit  int
 	Cursor string
 	Prefix string
+	Filter string
 }
 
 func chunksPath(orgId, projectId, database, collection string) string {
@@ -115,6 +116,9 @@ func (c *DeploymentClient) ListChunks(
 	}
 	if opts.Prefix != "" {
 		q.Set("prefix", opts.Prefix)
+	}
+	if opts.Filter != "" {
+		q.Set("filter", opts.Filter)
 	}
 	req.URL.RawQuery = q.Encode()
 

--- a/internal/clients/collections_chunks.go
+++ b/internal/clients/collections_chunks.go
@@ -66,11 +66,15 @@ func (c *DeploymentClient) UpsertChunks(
 	ctx context.Context,
 	orgId, projectId, database, collection string,
 	body []byte,
+	dryRun bool,
 ) (*ChunkUpsertResult, error) {
 	path := chunksPath(orgId, projectId, database, collection)
 	req, err := c.newRequest(ctx, http.MethodPut, path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	if dryRun {
+		req.URL.RawQuery = "dry_run=true"
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Body = io.NopCloser(bytes.NewReader(body))

--- a/internal/clients/collections_documents.go
+++ b/internal/clients/collections_documents.go
@@ -47,6 +47,7 @@ func (c *DeploymentClient) ListDocuments(
 	orgId, projectId, database, collection string,
 	limit int,
 	cursor string,
+	filter string,
 ) (*DocumentList, error) {
 	req, err := c.newRequest(
 		ctx,
@@ -63,6 +64,9 @@ func (c *DeploymentClient) ListDocuments(
 	}
 	if cursor != "" {
 		q.Set("cursor", cursor)
+	}
+	if filter != "" {
+		q.Set("filter", filter)
 	}
 	req.URL.RawQuery = q.Encode()
 

--- a/internal/clients/collections_search.go
+++ b/internal/clients/collections_search.go
@@ -91,17 +91,33 @@ func (c *DeploymentClient) Search(
 	return c.postSearch(ctx, path, body, "search")
 }
 
-// HybridSearch runs a multi-lane (RRF-fused) search. Note it POSTs to the same
-// /search endpoint as Search — the server dispatches to single-lane vs hybrid
-// based on the request body (a top-level "queries" array selects hybrid), so the
-// `search` and `search hybrid` sub-commands hit the same URL with different bodies.
+// HybridSearch runs a multi-lane (RRF-fused) search. It POSTs to the same
+// /search endpoint as Search; the server picks the hybrid path off the
+// "mode":"hybrid" discriminator, which this method sets so the caller's file
+// never has to include it.
 func (c *DeploymentClient) HybridSearch(
 	ctx context.Context,
 	orgId, projectId, database, collection string,
 	body []byte,
 ) (*SearchResponse, error) {
+	body, err := withHybridMode(body)
+	if err != nil {
+		return nil, err
+	}
 	path := searchBase(orgId, projectId, database, collection) + "/search"
 	return c.postSearch(ctx, path, body, "hybrid search")
+}
+
+// withHybridMode forces "mode":"hybrid" onto a search body. The server keys the
+// hybrid path off this discriminator, not the body shape, so a file that omits
+// it would otherwise be parsed as a single search and rejected.
+func withHybridMode(body []byte) ([]byte, error) {
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		return nil, fmt.Errorf("hybrid search body must be a JSON object: %w", err)
+	}
+	m["mode"] = "hybrid"
+	return json.Marshal(m)
 }
 
 // QueryByID finds neighbors of an existing chunk by its stored vector.

--- a/internal/clients/collections_search_test.go
+++ b/internal/clients/collections_search_test.go
@@ -1,0 +1,36 @@
+package clients
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestWithHybridMode(t *testing.T) {
+	// Injects mode when absent and preserves the rest of the body.
+	out, err := withHybridMode([]byte(`{"queries":[{"query":"x"}],"limit":5}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatal(err)
+	}
+	if m["mode"] != "hybrid" {
+		t.Errorf("mode not set to hybrid: %v", m["mode"])
+	}
+	if _, ok := m["queries"]; !ok {
+		t.Error("queries lane dropped")
+	}
+
+	// Overrides an existing mode too (the subcommand always means hybrid).
+	out, _ = withHybridMode([]byte(`{"mode":"single","queries":[]}`))
+	_ = json.Unmarshal(out, &m)
+	if m["mode"] != "hybrid" {
+		t.Errorf("mode not forced to hybrid, got %v", m["mode"])
+	}
+
+	// A non-object body is a clear error, not a silent pass-through.
+	if _, err := withHybridMode([]byte(`[1,2,3]`)); err == nil {
+		t.Error("expected error for non-object body")
+	}
+}


### PR DESCRIPTION
CLI-side fixes for Bernardo's hands-on feedback on the collections work.

**Stacked on #154** — base is `DEV-818/cli-collections-commands` so the diff is just these fixes. Merge after #154 (GitHub will retarget this to `main` when #154 merges).

## Fixes
- **`search hybrid` now dispatches correctly** — it POSTed the file body verbatim, but the server keys hybrid off `mode:"hybrid"`; the subcommand now sets it, and the help documents the working shape (incl. `full_text` lane vs `using` slot).
- **`--filter` on `chunks list`** — count/bulk-delete had it, list didn't (operator already supported the query param).
- **`--filter` on `documents list`** — paired with the operator change.
- **`--dry-run` on `create` + `chunks upsert`** — validate a `--file` without applying it.
- **`iai collections schema`** — prints the `--file` body shape for every file-based command (parity with `iai agents schema`).
- **`create --help`** notes immutable fields; group + create help point at `collections schema`.

## Testing
Local operator (air) + this binary: e2e **smoke 39/39, negatives 38/38**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)