### PR TITLE
Bump: 0.35.4 → 0.36.0

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.35.4"
+current_version = "0.36.0"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version            = "0.35.4"
+	version            = "0.36.0"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second


### PR DESCRIPTION
Release the collections CLI feature (#154) as stable 0.36.0.

Minor bump: the `iai collections` command tree is a whole new module, not an incremental change. Merging touches .bumpversion.toml, triggering auto-tag to create v0.36.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)