### PR TITLE
Add activate and deactivate commands

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.36.0"
+current_version = "0.37.0"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -378,6 +378,86 @@ var agentRestartCmd = &cobra.Command{
 	},
 }
 
+var agentDeactivateCmd = &cobra.Command{
+	Use:     "deactivate <agent_name>",
+	Short:   "Deactivate an agent in a project",
+	Long:    `Deactivate an agent until it is activated again.`,
+	Example: `  iai agents deactivate my-agent`,
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+
+		agentName := strings.TrimSpace(args[0])
+
+		pCtx, _, deployClient, err := resolveProject(
+			cmd.Context(),
+			agentOrganization,
+			agentProject,
+		)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintln(out)
+
+		serverMessage, err := deployClient.DeactivateAgent(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			agentName,
+		)
+		if err != nil {
+			return err
+		}
+
+		if serverMessage != "" {
+			fmt.Fprintln(out, serverMessage)
+		}
+
+		return nil
+	},
+}
+
+var agentActivateCmd = &cobra.Command{
+	Use:     "activate <agent_name>",
+	Short:   "Activate a deactivated agent in a project",
+	Long:    `Activate a deactivated agent and restore its previous scale configuration.`,
+	Example: `  iai agents activate my-agent`,
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+
+		agentName := strings.TrimSpace(args[0])
+
+		pCtx, _, deployClient, err := resolveProject(
+			cmd.Context(),
+			agentOrganization,
+			agentProject,
+		)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintln(out)
+
+		serverMessage, err := deployClient.ActivateAgent(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			agentName,
+		)
+		if err != nil {
+			return err
+		}
+
+		if serverMessage != "" {
+			fmt.Fprintln(out, serverMessage)
+		}
+
+		return nil
+	},
+}
+
 var (
 	agentLogsFollow     bool
 	agentLogsSince      string
@@ -864,6 +944,18 @@ func init() {
 	agentRestartCmd.Flags().
 		StringVarP(&agentOrganization, "organization", "o", "", "Organization name")
 
+	// Flags for "agents deactivate"
+	agentDeactivateCmd.Flags().
+		StringVarP(&agentProject, "project", "p", "", "Project name")
+	agentDeactivateCmd.Flags().
+		StringVarP(&agentOrganization, "organization", "o", "", "Organization name")
+
+	// Flags for "agents activate"
+	agentActivateCmd.Flags().
+		StringVarP(&agentProject, "project", "p", "", "Project name")
+	agentActivateCmd.Flags().
+		StringVarP(&agentOrganization, "organization", "o", "", "Organization name")
+
 	// Flags for "agents logs"
 	agentLogsCmd.Flags().
 		StringVarP(&agentProject, "project", "p", "", "Project name")
@@ -947,6 +1039,8 @@ func init() {
 	agentsCmd.AddCommand(agentDescribeCmd)
 	agentsCmd.AddCommand(agentDeleteCmd)
 	agentsCmd.AddCommand(agentRestartCmd)
+	agentsCmd.AddCommand(agentDeactivateCmd)
+	agentsCmd.AddCommand(agentActivateCmd)
 	agentsCmd.AddCommand(agentLogsCmd)
 	agentsCmd.AddCommand(agentSchemaCmd)
 	agentsCmd.AddCommand(agentCatalogCmd)

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -379,9 +379,10 @@ var agentRestartCmd = &cobra.Command{
 }
 
 var agentDeactivateCmd = &cobra.Command{
-	Use:     "deactivate <agent_name>",
-	Short:   "Deactivate an agent in a project",
-	Long:    `Deactivate an agent until it is activated again.`,
+	Use:   "deactivate <agent_name>",
+	Short: "Deactivate an agent in a project",
+	Long: `Deactivate an agent, stopping all running instances. The current configuration
+is preserved and will be restored when the agent is activated again.`,
 	Example: `  iai agents deactivate my-agent`,
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -399,6 +400,7 @@ var agentDeactivateCmd = &cobra.Command{
 		}
 
 		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Submitting agent deactivate request...")
 
 		serverMessage, err := deployClient.DeactivateAgent(
 			cmd.Context(),
@@ -421,7 +423,7 @@ var agentDeactivateCmd = &cobra.Command{
 var agentActivateCmd = &cobra.Command{
 	Use:     "activate <agent_name>",
 	Short:   "Activate a deactivated agent in a project",
-	Long:    `Activate a deactivated agent and restore its previous scale configuration.`,
+	Long:    `Activate a deactivated agent, restoring it to its previous configuration.`,
 	Example: `  iai agents activate my-agent`,
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -439,6 +441,7 @@ var agentActivateCmd = &cobra.Command{
 		}
 
 		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Submitting agent activate request...")
 
 		serverMessage, err := deployClient.ActivateAgent(
 			cmd.Context(),

--- a/cmd/databases.go
+++ b/cmd/databases.go
@@ -303,6 +303,78 @@ var dbDeleteCmd = &cobra.Command{
 	},
 }
 
+var dbDeactivateCmd = &cobra.Command{
+	Use:   "deactivate <database_name>",
+	Short: "Deactivate a database in a project",
+	Long:  `Deactivate a database until it is activated again.`,
+	Example: `  iai databases deactivate my-db
+  iai databases deactivate my-db -p my-project`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		databaseName := strings.TrimSpace(args[0])
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), dbOrganization, dbProject)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintln(out)
+
+		serverMessage, err := deployClient.DeactivateDatabase(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			databaseName,
+		)
+		if err != nil {
+			return err
+		}
+
+		if serverMessage != "" {
+			fmt.Fprintln(out, serverMessage)
+		}
+
+		return nil
+	},
+}
+
+var dbActivateCmd = &cobra.Command{
+	Use:   "activate <database_name>",
+	Short: "Activate a deactivated database in a project",
+	Long:  `Activate a deactivated database.`,
+	Example: `  iai databases activate my-db
+  iai databases activate my-db -p my-project`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		databaseName := strings.TrimSpace(args[0])
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), dbOrganization, dbProject)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintln(out)
+
+		serverMessage, err := deployClient.ActivateDatabase(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			databaseName,
+		)
+		if err != nil {
+			return err
+		}
+
+		if serverMessage != "" {
+			fmt.Fprintln(out, serverMessage)
+		}
+
+		return nil
+	},
+}
+
 var dbLogsCmd = &cobra.Command{
 	Use:   "logs <database_name>",
 	Short: "Show logs for a database",
@@ -678,6 +750,18 @@ func init() {
 	dbDeleteCmd.Flags().
 		StringVarP(&dbOrganization, "organization", "o", "", "Organization name")
 
+	// databases deactivate
+	dbDeactivateCmd.Flags().
+		StringVarP(&dbProject, "project", "p", "", "Project name")
+	dbDeactivateCmd.Flags().
+		StringVarP(&dbOrganization, "organization", "o", "", "Organization name")
+
+	// databases activate
+	dbActivateCmd.Flags().
+		StringVarP(&dbProject, "project", "p", "", "Project name")
+	dbActivateCmd.Flags().
+		StringVarP(&dbOrganization, "organization", "o", "", "Organization name")
+
 	// databases logs
 	dbLogsCmd.Flags().
 		StringVarP(&dbProject, "project", "p", "", "Project name")
@@ -758,6 +842,7 @@ func init() {
 	// Wire up command hierarchy
 	databasesCmd.AddCommand(
 		dbListCmd, dbDescribeCmd, dbCreateCmd, dbUpdateCmd, dbDeleteCmd,
+		dbDeactivateCmd, dbActivateCmd,
 		dbLogsCmd, dbLogFieldsCmd, dbBackupsCmd, dbBackupCmd, dbRestoreCmd, dbPortForwardCmd,
 	)
 	rootCmd.AddCommand(databasesCmd)

--- a/cmd/databases.go
+++ b/cmd/databases.go
@@ -306,7 +306,8 @@ var dbDeleteCmd = &cobra.Command{
 var dbDeactivateCmd = &cobra.Command{
 	Use:   "deactivate <database_name>",
 	Short: "Deactivate a database in a project",
-	Long:  `Deactivate a database until it is activated again.`,
+	Long: `Deactivate a database by hibernating it. The database configuration is
+preserved and will be restored when the database is activated again.`,
 	Example: `  iai databases deactivate my-db
   iai databases deactivate my-db -p my-project`,
 	Args: cobra.ExactArgs(1),
@@ -320,6 +321,7 @@ var dbDeactivateCmd = &cobra.Command{
 		}
 
 		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Submitting database deactivate request...")
 
 		serverMessage, err := deployClient.DeactivateDatabase(
 			cmd.Context(),
@@ -342,7 +344,7 @@ var dbDeactivateCmd = &cobra.Command{
 var dbActivateCmd = &cobra.Command{
 	Use:   "activate <database_name>",
 	Short: "Activate a deactivated database in a project",
-	Long:  `Activate a deactivated database.`,
+	Long:  `Activate a deactivated database, restoring it from hibernation.`,
 	Example: `  iai databases activate my-db
   iai databases activate my-db -p my-project`,
 	Args: cobra.ExactArgs(1),
@@ -356,6 +358,7 @@ var dbActivateCmd = &cobra.Command{
 		}
 
 		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Submitting database activate request...")
 
 		serverMessage, err := deployClient.ActivateDatabase(
 			cmd.Context(),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version            = "0.36.0"
+	version            = "0.37.0"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -440,7 +440,8 @@ var servRestartCmd = &cobra.Command{
 var servDeactivateCmd = &cobra.Command{
 	Use:   "deactivate <service_name>",
 	Short: "Deactivate a service in a project",
-	Long:  `Deactivate a service until it is activated again.`,
+	Long: `Deactivate a service, stopping all running instances. The current configuration
+is preserved and will be restored when the service is activated again.`,
 	Example: `  iai services deactivate my-svc
   iai services deactivate my-svc --project my-project`,
 	Args: cobra.ExactArgs(1),
@@ -459,6 +460,7 @@ var servDeactivateCmd = &cobra.Command{
 		}
 
 		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Submitting service deactivate request...")
 
 		serverMessage, err := deployClient.DeactivateService(
 			cmd.Context(),
@@ -481,7 +483,7 @@ var servDeactivateCmd = &cobra.Command{
 var servActivateCmd = &cobra.Command{
 	Use:   "activate <service_name>",
 	Short: "Activate a deactivated service in a project",
-	Long:  `Activate a deactivated service and restore its previous scale configuration.`,
+	Long:  `Activate a deactivated service, restoring it to its previous configuration.`,
 	Example: `  iai services activate my-svc
   iai services activate my-svc --project my-project`,
 	Args: cobra.ExactArgs(1),
@@ -500,6 +502,7 @@ var servActivateCmd = &cobra.Command{
 		}
 
 		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Submitting service activate request...")
 
 		serverMessage, err := deployClient.ActivateService(
 			cmd.Context(),

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -437,6 +437,88 @@ var servRestartCmd = &cobra.Command{
 	},
 }
 
+var servDeactivateCmd = &cobra.Command{
+	Use:   "deactivate <service_name>",
+	Short: "Deactivate a service in a project",
+	Long:  `Deactivate a service until it is activated again.`,
+	Example: `  iai services deactivate my-svc
+  iai services deactivate my-svc --project my-project`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+
+		serviceName := strings.TrimSpace(args[0])
+
+		pCtx, _, deployClient, err := resolveProject(
+			cmd.Context(),
+			serviceOrganization,
+			serviceProject,
+		)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintln(out)
+
+		serverMessage, err := deployClient.DeactivateService(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			serviceName,
+		)
+		if err != nil {
+			return err
+		}
+
+		if serverMessage != "" {
+			fmt.Fprintln(out, serverMessage)
+		}
+
+		return nil
+	},
+}
+
+var servActivateCmd = &cobra.Command{
+	Use:   "activate <service_name>",
+	Short: "Activate a deactivated service in a project",
+	Long:  `Activate a deactivated service and restore its previous scale configuration.`,
+	Example: `  iai services activate my-svc
+  iai services activate my-svc --project my-project`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+
+		serviceName := strings.TrimSpace(args[0])
+
+		pCtx, _, deployClient, err := resolveProject(
+			cmd.Context(),
+			serviceOrganization,
+			serviceProject,
+		)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintln(out)
+
+		serverMessage, err := deployClient.ActivateService(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			serviceName,
+		)
+		if err != nil {
+			return err
+		}
+
+		if serverMessage != "" {
+			fmt.Fprintln(out, serverMessage)
+		}
+
+		return nil
+	},
+}
+
 var (
 	servLogsFollow     bool
 	servLogsSince      string
@@ -974,6 +1056,18 @@ func init() {
 	servRestartCmd.Flags().
 		StringVarP(&serviceOrganization, "organization", "o", "", "Organization name that owns the project")
 
+	// Flags for "services deactivate"
+	servDeactivateCmd.Flags().
+		StringVarP(&serviceProject, "project", "p", "", "Project name")
+	servDeactivateCmd.Flags().
+		StringVarP(&serviceOrganization, "organization", "o", "", "Organization name")
+
+	// Flags for "services activate"
+	servActivateCmd.Flags().
+		StringVarP(&serviceProject, "project", "p", "", "Project name")
+	servActivateCmd.Flags().
+		StringVarP(&serviceOrganization, "organization", "o", "", "Organization name")
+
 	// Flags for "services logs"
 	servLogsCmd.Flags().
 		StringVarP(&serviceProject, "project", "p", "", "Project name that owns the service")
@@ -1047,6 +1141,8 @@ func init() {
 	servicesCmd.AddCommand(servDescribeCmd)
 	servicesCmd.AddCommand(servDCmd)
 	servicesCmd.AddCommand(servRestartCmd)
+	servicesCmd.AddCommand(servDeactivateCmd)
+	servicesCmd.AddCommand(servActivateCmd)
 	servicesCmd.AddCommand(servLogsCmd)
 	servicesCmd.AddCommand(servRevisionsCmd)
 	servicesCmd.AddCommand(servDiffCmd)

--- a/docs/iai_agents.md
+++ b/docs/iai_agents.md
@@ -24,9 +24,11 @@ Manage deployment of agents to InteractiveAI projects.
 ### SEE ALSO
 
 * [iai](iai.md)	 - InteractiveAI's CLI
+* [iai agents activate](iai_agents_activate.md)	 - Activate a deactivated agent in a project
 * [iai agents catalog](iai_agents_catalog.md)	 - List available agent types and versions
 * [iai agents compatibility-matrix](iai_agents_compatibility-matrix.md)	 - Show agent version to schema version compatibility
 * [iai agents create](iai_agents_create.md)	 - Create an agent in a project
+* [iai agents deactivate](iai_agents_deactivate.md)	 - Deactivate an agent in a project
 * [iai agents delete](iai_agents_delete.md)	 - Delete an agent from a project
 * [iai agents describe](iai_agents_describe.md)	 - Describe an agent in detail
 * [iai agents diff](iai_agents_diff.md)	 - Compare two revisions of an agent

--- a/docs/iai_agents_activate.md
+++ b/docs/iai_agents_activate.md
@@ -4,7 +4,7 @@ Activate a deactivated agent in a project
 
 ### Synopsis
 
-Activate a deactivated agent and restore its previous scale configuration.
+Activate a deactivated agent, restoring it to its previous configuration.
 
 ```
 iai agents activate <agent_name> [flags]

--- a/docs/iai_agents_activate.md
+++ b/docs/iai_agents_activate.md
@@ -1,0 +1,39 @@
+## iai agents activate
+
+Activate a deactivated agent in a project
+
+### Synopsis
+
+Activate a deactivated agent and restore its previous scale configuration.
+
+```
+iai agents activate <agent_name> [flags]
+```
+
+### Examples
+
+```
+  iai agents activate my-agent
+```
+
+### Options
+
+```
+  -h, --help                  help for activate
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai agents](iai_agents.md)	 - Deploy AI agents with policies, routines, and tools
+

--- a/docs/iai_agents_deactivate.md
+++ b/docs/iai_agents_deactivate.md
@@ -4,7 +4,8 @@ Deactivate an agent in a project
 
 ### Synopsis
 
-Deactivate an agent until it is activated again.
+Deactivate an agent, stopping all running instances. The current configuration
+is preserved and will be restored when the agent is activated again.
 
 ```
 iai agents deactivate <agent_name> [flags]

--- a/docs/iai_agents_deactivate.md
+++ b/docs/iai_agents_deactivate.md
@@ -1,0 +1,39 @@
+## iai agents deactivate
+
+Deactivate an agent in a project
+
+### Synopsis
+
+Deactivate an agent until it is activated again.
+
+```
+iai agents deactivate <agent_name> [flags]
+```
+
+### Examples
+
+```
+  iai agents deactivate my-agent
+```
+
+### Options
+
+```
+  -h, --help                  help for deactivate
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai agents](iai_agents.md)	 - Deploy AI agents with policies, routines, and tools
+

--- a/docs/iai_databases.md
+++ b/docs/iai_databases.md
@@ -31,9 +31,11 @@ connection credentials (host, port, username, password, URI).
 ### SEE ALSO
 
 * [iai](iai.md)	 - InteractiveAI's CLI
+* [iai databases activate](iai_databases_activate.md)	 - Activate a deactivated database in a project
 * [iai databases backup](iai_databases_backup.md)	 - Trigger an on-demand backup
 * [iai databases backups](iai_databases_backups.md)	 - List backups for a database
 * [iai databases create](iai_databases_create.md)	 - Create a database in a project
+* [iai databases deactivate](iai_databases_deactivate.md)	 - Deactivate a database in a project
 * [iai databases delete](iai_databases_delete.md)	 - Delete a database from a project
 * [iai databases describe](iai_databases_describe.md)	 - Describe a database in detail
 * [iai databases list](iai_databases_list.md)	 - List databases in a project

--- a/docs/iai_databases_activate.md
+++ b/docs/iai_databases_activate.md
@@ -4,7 +4,7 @@ Activate a deactivated database in a project
 
 ### Synopsis
 
-Activate a deactivated database.
+Activate a deactivated database, restoring it from hibernation.
 
 ```
 iai databases activate <database_name> [flags]

--- a/docs/iai_databases_activate.md
+++ b/docs/iai_databases_activate.md
@@ -1,0 +1,40 @@
+## iai databases activate
+
+Activate a deactivated database in a project
+
+### Synopsis
+
+Activate a deactivated database.
+
+```
+iai databases activate <database_name> [flags]
+```
+
+### Examples
+
+```
+  iai databases activate my-db
+  iai databases activate my-db -p my-project
+```
+
+### Options
+
+```
+  -h, --help                  help for activate
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai databases](iai_databases.md)	 - PostgreSQL instances with extension support, including pgvector
+

--- a/docs/iai_databases_deactivate.md
+++ b/docs/iai_databases_deactivate.md
@@ -4,7 +4,8 @@ Deactivate a database in a project
 
 ### Synopsis
 
-Deactivate a database until it is activated again.
+Deactivate a database by hibernating it. The database configuration is
+preserved and will be restored when the database is activated again.
 
 ```
 iai databases deactivate <database_name> [flags]

--- a/docs/iai_databases_deactivate.md
+++ b/docs/iai_databases_deactivate.md
@@ -1,0 +1,40 @@
+## iai databases deactivate
+
+Deactivate a database in a project
+
+### Synopsis
+
+Deactivate a database until it is activated again.
+
+```
+iai databases deactivate <database_name> [flags]
+```
+
+### Examples
+
+```
+  iai databases deactivate my-db
+  iai databases deactivate my-db -p my-project
+```
+
+### Options
+
+```
+  -h, --help                  help for deactivate
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai databases](iai_databases.md)	 - PostgreSQL instances with extension support, including pgvector
+

--- a/docs/iai_services.md
+++ b/docs/iai_services.md
@@ -24,7 +24,9 @@ Manage deployment of services to InteractiveAI projects.
 ### SEE ALSO
 
 * [iai](iai.md)	 - InteractiveAI's CLI
+* [iai services activate](iai_services_activate.md)	 - Activate a deactivated service in a project
 * [iai services create](iai_services_create.md)	 - Create a service in a project
+* [iai services deactivate](iai_services_deactivate.md)	 - Deactivate a service in a project
 * [iai services delete](iai_services_delete.md)	 - Delete a service from a project
 * [iai services describe](iai_services_describe.md)	 - Describe a service in detail
 * [iai services diff](iai_services_diff.md)	 - Compare two revisions of a service

--- a/docs/iai_services_activate.md
+++ b/docs/iai_services_activate.md
@@ -4,7 +4,7 @@ Activate a deactivated service in a project
 
 ### Synopsis
 
-Activate a deactivated service and restore its previous scale configuration.
+Activate a deactivated service, restoring it to its previous configuration.
 
 ```
 iai services activate <service_name> [flags]

--- a/docs/iai_services_activate.md
+++ b/docs/iai_services_activate.md
@@ -1,0 +1,40 @@
+## iai services activate
+
+Activate a deactivated service in a project
+
+### Synopsis
+
+Activate a deactivated service and restore its previous scale configuration.
+
+```
+iai services activate <service_name> [flags]
+```
+
+### Examples
+
+```
+  iai services activate my-svc
+  iai services activate my-svc --project my-project
+```
+
+### Options
+
+```
+  -h, --help                  help for activate
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai services](iai_services.md)	 - Deploy and manage HTTP services
+

--- a/docs/iai_services_deactivate.md
+++ b/docs/iai_services_deactivate.md
@@ -1,0 +1,40 @@
+## iai services deactivate
+
+Deactivate a service in a project
+
+### Synopsis
+
+Deactivate a service until it is activated again.
+
+```
+iai services deactivate <service_name> [flags]
+```
+
+### Examples
+
+```
+  iai services deactivate my-svc
+  iai services deactivate my-svc --project my-project
+```
+
+### Options
+
+```
+  -h, --help                  help for deactivate
+  -o, --organization string   Organization name
+  -p, --project string        Project name
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai services](iai_services.md)	 - Deploy and manage HTTP services
+

--- a/docs/iai_services_deactivate.md
+++ b/docs/iai_services_deactivate.md
@@ -4,7 +4,8 @@ Deactivate a service in a project
 
 ### Synopsis
 
-Deactivate a service until it is activated again.
+Deactivate a service, stopping all running instances. The current configuration
+is preserved and will be restored when the service is activated again.
 
 ```
 iai services deactivate <service_name> [flags]

--- a/internal/clients/deployment_client.go
+++ b/internal/clients/deployment_client.go
@@ -424,6 +424,86 @@ func (c *DeploymentClient) RestartService(
 	return "", fmt.Errorf("service restart failed with status %s", resp.Status)
 }
 
+func (c *DeploymentClient) DeactivateService(
+	ctx context.Context,
+	orgId,
+	projectId string,
+	serviceName string,
+) (string, error) {
+	path := fmt.Sprintf(
+		"/v1/organizations/%s/projects/%s/services/%s/deactivate",
+		url.PathEscape(orgId),
+		url.PathEscape(projectId),
+		url.PathEscape(serviceName),
+	)
+	reqHTTP, err := c.newRequest(ctx, http.MethodPost, path)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.do(reqHTTP)
+	if err != nil {
+		return "", fmt.Errorf("service deactivate request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	serverMessage := ExtractServerMessage(respBody)
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return serverMessage, nil
+	}
+
+	if serverMessage != "" {
+		return "", fmt.Errorf("%s", serverMessage)
+	}
+	return "", fmt.Errorf("service deactivate failed with status %s", resp.Status)
+}
+
+func (c *DeploymentClient) ActivateService(
+	ctx context.Context,
+	orgId,
+	projectId string,
+	serviceName string,
+) (string, error) {
+	path := fmt.Sprintf(
+		"/v1/organizations/%s/projects/%s/services/%s/activate",
+		url.PathEscape(orgId),
+		url.PathEscape(projectId),
+		url.PathEscape(serviceName),
+	)
+	reqHTTP, err := c.newRequest(ctx, http.MethodPost, path)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.do(reqHTTP)
+	if err != nil {
+		return "", fmt.Errorf("service activate request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	serverMessage := ExtractServerMessage(respBody)
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return serverMessage, nil
+	}
+
+	if serverMessage != "" {
+		return "", fmt.Errorf("%s", serverMessage)
+	}
+	return "", fmt.Errorf("service activate failed with status %s", resp.Status)
+}
+
 func (c *DeploymentClient) ListServices(
 	ctx context.Context,
 	orgId,
@@ -1595,6 +1675,86 @@ func (c *DeploymentClient) RestartAgent(
 	return "", fmt.Errorf("agent restart failed with status %s", resp.Status)
 }
 
+func (c *DeploymentClient) DeactivateAgent(
+	ctx context.Context,
+	orgId,
+	projectId string,
+	agentName string,
+) (string, error) {
+	path := fmt.Sprintf(
+		"/v1/organizations/%s/projects/%s/agents/%s/deactivate",
+		url.PathEscape(orgId),
+		url.PathEscape(projectId),
+		url.PathEscape(agentName),
+	)
+	reqHTTP, err := c.newRequest(ctx, http.MethodPost, path)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.do(reqHTTP)
+	if err != nil {
+		return "", fmt.Errorf("agent deactivate request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	serverMessage := ExtractServerMessage(respBody)
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return serverMessage, nil
+	}
+
+	if serverMessage != "" {
+		return "", fmt.Errorf("%s", serverMessage)
+	}
+	return "", fmt.Errorf("agent deactivate failed with status %s", resp.Status)
+}
+
+func (c *DeploymentClient) ActivateAgent(
+	ctx context.Context,
+	orgId,
+	projectId string,
+	agentName string,
+) (string, error) {
+	path := fmt.Sprintf(
+		"/v1/organizations/%s/projects/%s/agents/%s/activate",
+		url.PathEscape(orgId),
+		url.PathEscape(projectId),
+		url.PathEscape(agentName),
+	)
+	reqHTTP, err := c.newRequest(ctx, http.MethodPost, path)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.do(reqHTTP)
+	if err != nil {
+		return "", fmt.Errorf("agent activate request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	serverMessage := ExtractServerMessage(respBody)
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return serverMessage, nil
+	}
+
+	if serverMessage != "" {
+		return "", fmt.Errorf("%s", serverMessage)
+	}
+	return "", fmt.Errorf("agent activate failed with status %s", resp.Status)
+}
+
 func (c *DeploymentClient) GetAgentLogs(
 	ctx context.Context,
 	orgId,
@@ -2065,6 +2225,86 @@ func (c *DeploymentClient) DeleteDatabase(
 	}
 
 	return serverMessage, nil
+}
+
+func (c *DeploymentClient) DeactivateDatabase(
+	ctx context.Context,
+	orgId,
+	projectId string,
+	databaseName string,
+) (string, error) {
+	path := fmt.Sprintf(
+		"/v1/organizations/%s/projects/%s/databases/%s/deactivate",
+		url.PathEscape(orgId),
+		url.PathEscape(projectId),
+		url.PathEscape(databaseName),
+	)
+	reqHTTP, err := c.newRequest(ctx, http.MethodPost, path)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.do(reqHTTP)
+	if err != nil {
+		return "", fmt.Errorf("database deactivate request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	serverMessage := ExtractServerMessage(respBody)
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return serverMessage, nil
+	}
+
+	if serverMessage != "" {
+		return "", fmt.Errorf("%s", serverMessage)
+	}
+	return "", fmt.Errorf("database deactivate failed with status %s", resp.Status)
+}
+
+func (c *DeploymentClient) ActivateDatabase(
+	ctx context.Context,
+	orgId,
+	projectId string,
+	databaseName string,
+) (string, error) {
+	path := fmt.Sprintf(
+		"/v1/organizations/%s/projects/%s/databases/%s/activate",
+		url.PathEscape(orgId),
+		url.PathEscape(projectId),
+		url.PathEscape(databaseName),
+	)
+	reqHTTP, err := c.newRequest(ctx, http.MethodPost, path)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.do(reqHTTP)
+	if err != nil {
+		return "", fmt.Errorf("database activate request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	serverMessage := ExtractServerMessage(respBody)
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return serverMessage, nil
+	}
+
+	if serverMessage != "" {
+		return "", fmt.Errorf("%s", serverMessage)
+	}
+	return "", fmt.Errorf("database activate failed with status %s", resp.Status)
 }
 
 func (c *DeploymentClient) ListDatabases(


### PR DESCRIPTION
## Summary
- Add `iai services activate/deactivate <name>` commands
- Add `iai agents activate/deactivate <name>` commands
- Add `iai databases activate/deactivate <name>` commands

Companion to [deployment-operator#214](https://github.com/Interactive-AI-Labs/deployment-operator/pull/214) which added the API endpoints.

## Test plan
- [x] Verified end-to-end against dev: created a service, deactivated it (status shows `Deactivated`), activated it (replicas restored), deleted it

🤖 Generated with [Claude Code](https://claude.com/claude-code)