### PR TITLE
Fix followed logs max connection handling

### DIFF
--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -2,10 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"os/signal"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
@@ -497,13 +494,6 @@ nested JSON values.`,
 		out := cmd.OutOrStdout()
 		agentName := strings.TrimSpace(args[0])
 
-		ctx := cmd.Context()
-		if agentLogsFollow {
-			var stop func()
-			ctx, stop = signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
-			defer stop()
-		}
-
 		timeout := 1 * time.Minute
 		if agentLogsFollow {
 			timeout = 0
@@ -525,9 +515,12 @@ nested JSON values.`,
 			Limit:     agentLogsLimit,
 		}
 
+		ctx, stop := logFollowContext(cmd.Context(), agentLogsFollow)
+		defer stop()
+
 		logsResp, err := deployClient.GetAgentLogs(ctx, pCtx.orgId, pCtx.projectId, agentName, opts)
 		if err != nil {
-			return err
+			return finishLogStream(cmd.ErrOrStderr(), agentLogsFollow, ctx, err)
 		}
 		defer logsResp.Body.Close()
 
@@ -546,10 +539,7 @@ nested JSON values.`,
 			Timestamps: agentLogsTimestamps,
 		}
 		err = output.PrintLogStream(out, logsResp.Body, true, meta, fmtOpts)
-		if agentLogsFollow && ctx.Err() != nil {
-			return nil
-		}
-		return err
+		return finishLogStream(cmd.ErrOrStderr(), agentLogsFollow, ctx, err)
 	},
 }
 

--- a/cmd/databases.go
+++ b/cmd/databases.go
@@ -2,10 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"os/signal"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
@@ -407,13 +404,6 @@ JSON strings into nested JSON values.`,
 			return fmt.Errorf("database name is required")
 		}
 
-		ctx := cmd.Context()
-		if dbLogsFollow {
-			var stop func()
-			ctx, stop = signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
-			defer stop()
-		}
-
 		timeout := 1 * time.Minute
 		if dbLogsFollow {
 			timeout = 0
@@ -435,6 +425,9 @@ JSON strings into nested JSON values.`,
 			Limit:     dbLogsLimit,
 		}
 
+		ctx, stop := logFollowContext(cmd.Context(), dbLogsFollow)
+		defer stop()
+
 		logsResp, err := deployClient.GetDatabaseLogs(
 			ctx,
 			pCtx.orgId,
@@ -443,7 +436,7 @@ JSON strings into nested JSON values.`,
 			opts,
 		)
 		if err != nil {
-			return err
+			return finishLogStream(cmd.ErrOrStderr(), dbLogsFollow, ctx, err)
 		}
 		defer logsResp.Body.Close()
 
@@ -463,10 +456,7 @@ JSON strings into nested JSON values.`,
 			Timestamps: dbLogsTimestamps,
 		}
 		err = output.PrintLogStream(out, logsResp.Body, true, meta, fmtOpts)
-		if dbLogsFollow && ctx.Err() != nil {
-			return nil
-		}
-		return err
+		return finishLogStream(cmd.ErrOrStderr(), dbLogsFollow, ctx, err)
 	},
 }
 

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+const logFollowMaxConnectionTime = 10 * time.Minute
+
+func logFollowContext(ctx context.Context, follow bool) (context.Context, func()) {
+	if !follow {
+		return ctx, func() {}
+	}
+
+	ctx, stopSignals := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	ctx, cancelTimeout := context.WithTimeout(ctx, logFollowMaxConnectionTime)
+	return ctx, func() {
+		cancelTimeout()
+		stopSignals()
+	}
+}
+
+func finishLogStream(errOut io.Writer, follow bool, ctx context.Context, err error) error {
+	if !follow {
+		return err
+	}
+
+	switch ctx.Err() {
+	case context.Canceled:
+		return nil
+	case context.DeadlineExceeded:
+		fmt.Fprintf(
+			errOut,
+			"Maximum connection time is %g minutes, closing connection.\n",
+			logFollowMaxConnectionTime.Minutes(),
+		)
+		return nil
+	default:
+		return err
+	}
+}

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFinishLogStream(t *testing.T) {
+	readErr := errors.New("stream closed")
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	deadlineCtx, cancelDeadline := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancelDeadline()
+	<-deadlineCtx.Done()
+
+	tests := []struct {
+		name    string
+		follow  bool
+		ctx     context.Context
+		err     error
+		wantOut string
+		wantErr string
+	}{
+		{
+			name:    "non-follow returns read error",
+			ctx:     context.Background(),
+			err:     readErr,
+			wantErr: "stream closed",
+		},
+		{
+			name:   "follow ignores user cancel",
+			follow: true,
+			ctx:    canceledCtx,
+			err:    readErr,
+		},
+		{
+			name:    "follow prints max connection message on deadline",
+			follow:  true,
+			ctx:     deadlineCtx,
+			err:     readErr,
+			wantOut: "Maximum connection time is 10 minutes, closing connection.\n",
+		},
+		{
+			name:    "follow returns other read error",
+			follow:  true,
+			ctx:     context.Background(),
+			err:     readErr,
+			wantErr: "stream closed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			err := finishLogStream(&out, tt.follow, tt.ctx, tt.err)
+			gotErr := ""
+			if err != nil {
+				gotErr = err.Error()
+			}
+			if diff := cmp.Diff(tt.wantErr, gotErr); diff != "" {
+				t.Fatalf("error mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tt.wantOut, out.String()); diff != "" {
+				t.Fatalf("output mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/cmd/replicas.go
+++ b/cmd/replicas.go
@@ -2,10 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"os/signal"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
@@ -167,13 +164,6 @@ nested JSON values.`,
 			return fmt.Errorf("replica name is required")
 		}
 
-		ctx := cmd.Context()
-		if replicaLogsFollow {
-			var stop func()
-			ctx, stop = signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
-			defer stop()
-		}
-
 		cfg, err := files.LoadStackConfig(cfgFilePath)
 		if err != nil {
 			return fmt.Errorf("failed to load config file: %w", err)
@@ -230,9 +220,12 @@ nested JSON values.`,
 			Limit:     replicaLogsLimit,
 		}
 
+		ctx, stop := logFollowContext(cmd.Context(), replicaLogsFollow)
+		defer stop()
+
 		logsResp, err := deployClient.GetReplicaLogs(ctx, orgId, projectId, replicaName, opts)
 		if err != nil {
-			return err
+			return finishLogStream(cmd.ErrOrStderr(), replicaLogsFollow, ctx, err)
 		}
 		defer logsResp.Body.Close()
 
@@ -251,10 +244,7 @@ nested JSON values.`,
 			Timestamps: replicaLogsTimestamps,
 		}
 		err = output.PrintLogStream(out, logsResp.Body, false, meta, fmtOpts)
-		if replicaLogsFollow && ctx.Err() != nil {
-			return nil
-		}
-		return err
+		return finishLogStream(cmd.ErrOrStderr(), replicaLogsFollow, ctx, err)
 	},
 }
 

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -2,10 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"os/signal"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
@@ -562,13 +559,6 @@ nested JSON values.`,
 			return fmt.Errorf("service name is required")
 		}
 
-		ctx := cmd.Context()
-		if servLogsFollow {
-			var stop func()
-			ctx, stop = signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
-			defer stop()
-		}
-
 		timeout := 1 * time.Minute
 		if servLogsFollow {
 			timeout = 0
@@ -590,6 +580,9 @@ nested JSON values.`,
 			Limit:     servLogsLimit,
 		}
 
+		ctx, stop := logFollowContext(cmd.Context(), servLogsFollow)
+		defer stop()
+
 		logsResp, err := deployClient.GetServiceLogs(
 			ctx,
 			pCtx.orgId,
@@ -598,7 +591,7 @@ nested JSON values.`,
 			opts,
 		)
 		if err != nil {
-			return err
+			return finishLogStream(cmd.ErrOrStderr(), servLogsFollow, ctx, err)
 		}
 		defer logsResp.Body.Close()
 
@@ -617,10 +610,7 @@ nested JSON values.`,
 			Timestamps: servLogsTimestamps,
 		}
 		err = output.PrintLogStream(out, logsResp.Body, true, meta, fmtOpts)
-		if servLogsFollow && ctx.Err() != nil {
-			return nil
-		}
-		return err
+		return finishLogStream(cmd.ErrOrStderr(), servLogsFollow, ctx, err)
 	},
 }
 


### PR DESCRIPTION
## Summary
- add a 10-minute deadline for followed log streams
- print a clean max-connection-time message instead of surfacing transport errors
- share the behavior across service, agent, database, and replica logs

## Validation
- `go test ./...`
- `go vet ./...`
- local dev test: `agents logs -f` on installed CLI reproduced `stream error: stream ID 1; INTERNAL_ERROR; received from peer`
- local fixed binary closed after 600s with `Maximum connection time is 10 minutes, closing connection.`
