### PR TITLE
fix(databases): clarify describe replicas, HA, and backups (DEV-873)

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.37.2"
+current_version = "0.37.3"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version            = "0.37.2"
+	version            = "0.37.3"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second

--- a/internal/output/databases.go
+++ b/internal/output/databases.go
@@ -43,7 +43,12 @@ func PrintDatabaseDescribe(out io.Writer, db *clients.DescribeDatabaseResponse) 
 		fmt.Fprintf(w, "Updated:\t%s\n", LocalTime(db.Updated))
 	}
 	fmt.Fprintf(w, "PostgreSQL Version:\t%s\n", db.PostgresVersion)
-	fmt.Fprintf(w, "Instances:\t%d\n", db.Instances)
+	fmt.Fprintf(w, "Replicas:\t%d\n", db.Instances)
+	highAvailability := "No"
+	if db.Instances >= 2 {
+		highAvailability = "Yes"
+	}
+	fmt.Fprintf(w, "High Availability:\t%s\n", highAvailability)
 
 	fmt.Fprintln(w, "Resources:")
 	fmt.Fprintf(w, "  CPU:\t%s\n", db.Resources.CPU)
@@ -56,8 +61,10 @@ func PrintDatabaseDescribe(out io.Writer, db *clients.DescribeDatabaseResponse) 
 		fmt.Fprintf(w, "Extensions:\t%s\n", strings.Join(db.Extensions, ", "))
 	}
 
-	if db.Backup != nil {
-		fmt.Fprintln(w)
+	fmt.Fprintln(w)
+	if db.Backup == nil {
+		fmt.Fprintln(w, "Backup:\tnot configured")
+	} else {
 		fmt.Fprintln(w, "Backup:")
 		fmt.Fprintf(w, "  Schedule:\t%s\n", db.Backup.Schedule)
 		fmt.Fprintf(w, "  Retention:\t%s\n", db.Backup.RetentionPolicy)

--- a/internal/output/databases_test.go
+++ b/internal/output/databases_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestPrintDatabaseList(t *testing.T) {
@@ -105,7 +106,8 @@ func TestPrintDatabaseDescribe(t *testing.T) {
 				"Message:              All instances running\n" +
 				"Updated:              2025-01-15 11:30:00 CET\n" +
 				"PostgreSQL Version:   17\n" +
-				"Instances:            2\n" +
+				"Replicas:             2\n" +
+				"High Availability:    Yes\n" +
 				"Resources:\n" +
 				"  CPU:      1\n" +
 				"  Memory:   2G\n" +
@@ -119,26 +121,31 @@ func TestPrintDatabaseDescribe(t *testing.T) {
 				"Credentials Secret:   my-db-app\n",
 		},
 		{
-			name: "minimal without optional fields",
+			name: "without backup configuration",
 			db: &clients.DescribeDatabaseResponse{
-				Name:            "basic-db",
-				Revision:        1,
-				Status:          "Provisioning",
-				PostgresVersion: "17",
-				Instances:       1,
-				Resources:       clients.Resources{CPU: "0.5", Memory: "1G"},
-				Storage:         clients.DatabaseStorageConfig{Size: "10G"},
+				Name:              "basic-db",
+				Revision:          1,
+				Status:            "Provisioning",
+				PostgresVersion:   "17",
+				Instances:         1,
+				Resources:         clients.Resources{CPU: "0.5", Memory: "1G"},
+				Storage:           clients.DatabaseStorageConfig{Size: "10G"},
+				CredentialsSecret: "basic-db-app",
 			},
 			want: "Name:                 basic-db\n" +
 				"Revision:             1\n" +
 				"Status:               Provisioning\n" +
 				"PostgreSQL Version:   17\n" +
-				"Instances:            1\n" +
+				"Replicas:             1\n" +
+				"High Availability:    No\n" +
 				"Resources:\n" +
 				"  CPU:      0.5\n" +
 				"  Memory:   1G\n" +
 				"Storage:\n" +
-				"  Size:   10G\n",
+				"  Size:   10G\n" +
+				"\n" +
+				"Backup:               not configured\n" +
+				"Credentials Secret:   basic-db-app\n",
 		},
 	}
 
@@ -149,8 +156,8 @@ func TestPrintDatabaseDescribe(t *testing.T) {
 			if err != nil {
 				t.Fatalf("PrintDatabaseDescribe() error = %v", err)
 			}
-			if got := buf.String(); got != tt.want {
-				t.Errorf("output mismatch\ngot:\n%q\nwant:\n%q", got, tt.want)
+			if diff := cmp.Diff(tt.want, buf.String()); diff != "" {
+				t.Errorf("output mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- rename the human-readable database count from `Instances` to `Replicas`
- show whether high availability is enabled (`Yes` when replicas are 2 or greater)
- show `Backup: not configured` when the API returns no backup configuration
- cover configured backups, missing backups, and high availability in describe output tests

Linear: [DEV-873](https://linear.app/interactive-ai/issue/DEV-873/small-fix-iai-databases-describe)

## Local verification

Built this branch as `/tmp/iai-dev-873` and tested it against the dev project `platform-development/dgallego`.

### Database with backup configured

```text
Name:                 iai-bkp-103703
Revision:             1
Status:               Healthy
Message:              All instances running
Updated:              2026-07-15 10:37:06 CEST
PostgreSQL Version:   18
Replicas:             1
High Availability:    No
Resources:
  CPU:      0.5
  Memory:   1G
Storage:
  Size:       10G
Extensions:   vector

Backup:
  Schedule:           0 0 2 * * *
  Retention:          7d
Credentials Secret:   iai-bkp-103703-app
```

### Database without backup configured

Created a temporary database without backup flags, described it with the local binary, then deleted it.

```text
Name:                 no-bkp-111613
Revision:             1
Status:               Provisioning
Message:              Setting up primary instance
Updated:              2026-07-15 11:16:16 CEST
PostgreSQL Version:   18
Replicas:             1
High Availability:    No
Resources:
  CPU:      0.5
  Memory:   1G
Storage:
  Size:       10G
Extensions:   vector

Backup:               not configured
Credentials Secret:   no-bkp-111613-app
```

The `Message` values above are returned by the server and are not generated by the CLI.

## Checks

- `go test ./...`
- `go vet ./...`
- `go build ./...`
- pre-commit hooks
