### PR TITLE
fix(DEV-857): use the active label in skills help and docs

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.37.4"
+current_version = "0.37.5"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/glossaries.go
+++ b/cmd/glossaries.go
@@ -40,12 +40,11 @@ Example (glossary.json):
 
   Add as many entries under 'terms' as you need — each key must be unique.
 
-The server automatically assigns the "latest" label to new versions. To make a
-version retrievable via the default 'get' (which resolves "production"), assign
-the "production" label with --labels production.`,
+The server automatically assigns the "latest" label to new versions. Use
+--labels to assign additional labels (e.g. --labels staging).`,
 		CreateExample: `  iai glossaries create finance-terms --file glossary.json
   iai glossaries create finance-terms --file glossary.json --schema-version 2.1.0
-  iai glossaries create finance-terms --file glossary.json --labels production
+  iai glossaries create finance-terms --file glossary.json --labels staging
   iai glossaries create finance-terms --file glossary.json --tags domain`,
 		ListLong: `List glossary definitions in a specific project.
 
@@ -58,8 +57,9 @@ can be browsed into with --folder.`,
   iai glossaries list --page 2 --limit 10`,
 		GetLong: `Show detailed information about a specific glossary definition, including its full content.
 
-By default returns the version labeled "production". Use --version to retrieve a
-specific version number, or --label to resolve a different label.`,
+Without flags, returns the version the server resolves by default. Use
+--version to retrieve a specific version number, or --label to resolve a
+specific label.`,
 		GetExample: `  iai glossaries get finance-terms
   iai glossaries get finance-terms --version 3
   iai glossaries get finance-terms --label staging`,
@@ -94,7 +94,7 @@ Example (glossary.json):
   Add as many entries under 'terms' as you need — each key must be unique.`,
 		UpdateExample: `  iai glossaries update finance-terms --file glossary.json
   iai glossaries update finance-terms --file glossary.json --schema-version 2.1.0
-  iai glossaries update finance-terms --file glossary.json --labels production,staging`,
+  iai glossaries update finance-terms --file glossary.json --labels staging,qa`,
 		DeleteLong: `Delete a glossary definition and all its versions, or delete specific versions.
 
 Without flags, deletes the glossary entry and all its versions (requires

--- a/cmd/macros.go
+++ b/cmd/macros.go
@@ -19,11 +19,10 @@ No schema validation is applied — any text content is accepted.
 Example (disclaimer.md):
   **Disclaimer:** This is not financial advice. Consult a professional.
 
-The server automatically assigns the "latest" label to new versions. To make a
-version retrievable via the default 'get' (which resolves "production"), assign
-the "production" label with --labels production.`,
+The server automatically assigns the "latest" label to new versions. Use
+--labels to assign additional labels (e.g. --labels staging).`,
 		CreateExample: `  iai macros create disclaimer --file disclaimer.md
-  iai macros create disclaimer --file disclaimer.md --labels production
+  iai macros create disclaimer --file disclaimer.md --labels staging
   iai macros create disclaimer --file disclaimer.md --tags legal`,
 		ListLong: `List macros in a specific project.
 
@@ -36,8 +35,9 @@ can be browsed into with --folder.`,
   iai macros list --page 2 --limit 10`,
 		GetLong: `Show detailed information about a specific macro, including its full content.
 
-By default returns the version labeled "production". Use --version to retrieve a
-specific version number, or --label to resolve a different label.`,
+Without flags, returns the version the server resolves by default. Use
+--version to retrieve a specific version number, or --label to resolve a
+specific label.`,
 		GetExample: `  iai macros get disclaimer
   iai macros get disclaimer --version 3
   iai macros get disclaimer --label staging`,
@@ -51,7 +51,7 @@ No schema validation is applied — any text content is accepted.
 Example (disclaimer.md):
   **Disclaimer:** This is not financial advice. Consult a professional.`,
 		UpdateExample: `  iai macros update disclaimer --file disclaimer.md
-  iai macros update disclaimer --file disclaimer.md --labels production,staging`,
+  iai macros update disclaimer --file disclaimer.md --labels staging,qa`,
 		DeleteLong: `Delete a macro and all its versions, or delete specific versions.
 
 Without flags, deletes the macro and all its versions (requires confirmation).

--- a/cmd/policies.go
+++ b/cmd/policies.go
@@ -30,12 +30,11 @@ Example (policy.yaml):
   action: Transfer to human
   criticality: HIGH
 
-The server automatically assigns the "latest" label to new versions. To make a
-version retrievable via the default 'get' (which resolves "production"), assign
-the "production" label with --labels production.`,
+The server automatically assigns the "latest" label to new versions. Use
+--labels to assign additional labels (e.g. --labels staging).`,
 		CreateExample: `  iai policies create safety-rules --file policy.yaml
   iai policies create safety-rules --file policy.yaml --schema-version 2.1.0
-  iai policies create safety-rules --file policy.yaml --labels production
+  iai policies create safety-rules --file policy.yaml --labels staging
   iai policies create safety-rules --file policy.yaml --tags compliance`,
 		ListLong: `List policies in a specific project.
 
@@ -48,8 +47,9 @@ can be browsed into with --folder.`,
   iai policies list --page 2 --limit 10`,
 		GetLong: `Show detailed information about a specific policy, including its full content.
 
-By default returns the version labeled "production". Use --version to retrieve a
-specific version number, or --label to resolve a different label.`,
+Without flags, returns the version the server resolves by default. Use
+--version to retrieve a specific version number, or --label to resolve a
+specific label.`,
 		GetExample: `  iai policies get safety-rules
   iai policies get safety-rules --version 3
   iai policies get safety-rules --label staging`,
@@ -74,7 +74,7 @@ Example (policy.yaml):
   criticality: HIGH`,
 		UpdateExample: `  iai policies update safety-rules --file policy.yaml
   iai policies update safety-rules --file policy.yaml --schema-version 2.1.0
-  iai policies update safety-rules --file policy.yaml --labels production,staging`,
+  iai policies update safety-rules --file policy.yaml --labels staging,qa`,
 		DeleteLong: `Delete a policy and all its versions, or delete specific versions.
 
 Without flags, deletes the policy and all its versions (requires confirmation).

--- a/cmd/prompt_types.go
+++ b/cmd/prompt_types.go
@@ -325,8 +325,7 @@ func makeGetCmd(ptCfg PromptTypeConfig) *cobra.Command {
 	}
 
 	cmd.Flags().IntVar(&version, "version", 0, "Retrieve a specific version number")
-	cmd.Flags().
-		StringVar(&label, "label", "", "Retrieve the version with this label (default: server resolves 'production')")
+	cmd.Flags().StringVar(&label, "label", "", "Retrieve the version with this label")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Output response as JSON")
 	cmd.Flags().BoolVar(&asYAML, "yaml", false, "Output response as YAML")
 	cmd.MarkFlagsMutuallyExclusive("json", "yaml")

--- a/cmd/prompts.go
+++ b/cmd/prompts.go
@@ -62,13 +62,12 @@ Exactly one of --file or --content must be specified.
 
 The --type flag selects the prompt type: "text" (default) or "chat".
 
-The server automatically assigns the "latest" label to new versions. To make a
-version retrievable via the default 'get' (which resolves "production"), assign
-the "production" label with --labels production.`,
+The server automatically assigns the "latest" label to new versions. Use
+--labels to assign additional labels (e.g. --labels staging).`,
 		Example: `  iai prompts create greeting --content "Hello, how can I help you?"
   iai prompts create greeting --file greeting.txt
   iai prompts create greeting --file greeting.txt --type chat
-  iai prompts create greeting --content "Hi!" --labels production
+  iai prompts create greeting --content "Hi!" --labels staging
   iai prompts create greeting --file greeting.txt --tags support`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -232,8 +231,9 @@ func makeGenericGetCmd() *cobra.Command {
 		Short:   "Describe a prompt in detail",
 		Long: `Show detailed information about a specific prompt, including its full content.
 
-By default returns the version labeled "production". Use --version to retrieve a
-specific version number, or --label to resolve a different label.`,
+Without flags, returns the version the server resolves by default. Use
+--version to retrieve a specific version number, or --label to resolve a
+specific label.`,
 		Example: `  iai prompts get greeting
   iai prompts get greeting --version 3
   iai prompts get greeting --label staging`,
@@ -271,10 +271,7 @@ specific version number, or --label to resolve a different label.`,
 	}
 
 	cmd.Flags().IntVar(&version, "version", 0, "Retrieve a specific version number")
-	cmd.Flags().StringVar(
-		&label, "label", "",
-		`Retrieve the version with this label (default: server resolves "production")`,
-	)
+	cmd.Flags().StringVar(&label, "label", "", "Retrieve the version with this label")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Output response as JSON")
 	cmd.Flags().BoolVar(&asYAML, "yaml", false, "Output response as YAML")
 	cmd.MarkFlagsMutuallyExclusive("json", "yaml")
@@ -308,7 +305,7 @@ by version number.
 Exactly one of --file or --content must be specified.`,
 		Example: `  iai prompts update greeting --content "Hello! How may I assist you today?"
   iai prompts update greeting --file greeting.txt
-  iai prompts update greeting --file greeting.txt --labels production,staging`,
+  iai prompts update greeting --file greeting.txt --labels staging,qa`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out := cmd.OutOrStdout()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version            = "0.37.4"
+	version            = "0.37.5"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second

--- a/cmd/routines.go
+++ b/cmd/routines.go
@@ -35,12 +35,11 @@ Example (routine.yaml):
       tools: crm:get_user
       tool_instruction: Fetch user data
 
-The server automatically assigns the "latest" label to new versions. To make a
-version retrievable via the default 'get' (which resolves "production"), assign
-the "production" label with --labels production.`,
+The server automatically assigns the "latest" label to new versions. Use
+--labels to assign additional labels (e.g. --labels staging).`,
 		CreateExample: `  iai routines create onboarding-flow --file routine.yaml
   iai routines create onboarding-flow --file routine.yaml --schema-version 2.1.0
-  iai routines create onboarding-flow --file routine.yaml --labels production
+  iai routines create onboarding-flow --file routine.yaml --labels staging
   iai routines create onboarding-flow --file routine.yaml --tags v2,experimental`,
 		ListLong: `List routines in a specific project.
 
@@ -53,8 +52,9 @@ can be browsed into with --folder.`,
   iai routines list --page 2 --limit 10`,
 		GetLong: `Show detailed information about a specific routine, including its full content.
 
-By default returns the version labeled "production". Use --version to retrieve a
-specific version number, or --label to resolve a different label.`,
+Without flags, returns the version the server resolves by default. Use
+--version to retrieve a specific version number, or --label to resolve a
+specific label.`,
 		GetExample: `  iai routines get onboarding-flow
   iai routines get onboarding-flow --version 3
   iai routines get onboarding-flow --label staging`,
@@ -84,7 +84,7 @@ Example (routine.yaml):
       tool_instruction: Fetch user data`,
 		UpdateExample: `  iai routines update onboarding-flow --file routine.yaml
   iai routines update onboarding-flow --file routine.yaml --schema-version 2.1.0
-  iai routines update onboarding-flow --file routine.yaml --labels production,staging`,
+  iai routines update onboarding-flow --file routine.yaml --labels staging,qa`,
 		DeleteLong: `Delete a routine and all its versions, or delete specific versions.
 
 Without flags, deletes the routine and all its versions (requires confirmation).

--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -36,13 +36,13 @@ Example (skill.md):
   Given a Langfuse trace ID, fetch the trace and summarize key steps,
   latencies, and any errors.
 
-The server automatically assigns the "latest" label to new versions. To make
-a version retrievable via the default 'get' (which resolves "production"),
-assign the "production" label with --labels production.`,
+The server automatically assigns the "latest" label to new versions. Copilot
+loads the version labeled "active", so assign it with --labels active to make
+a skill the one Copilot uses.`,
 		CreateExample: `  iai skills create summarize-trace --file ./skill.md \
     --description "Summarize a Langfuse trace" \
     --intents "summarize trace" --intents "explain trace"
-  iai skills create summarize-trace --file ./skill.md --labels production`,
+  iai skills create summarize-trace --file ./skill.md --labels active`,
 		ListLong: `List Copilot skills in a project.
 
 Returns all Copilot skills with their name, labels, tags, and last update time.
@@ -53,11 +53,14 @@ can be browsed into with --folder.`,
   iai skills list --page 2 --limit 10`,
 		GetLong: `Show a Copilot skill in detail, including its config and full content.
 
-By default returns the version labeled "production". Use --version to retrieve a
-specific version number, or --label to resolve a different label.`,
+A label-less get returns whatever the server resolves by default: the version
+labeled "production" if one exists, otherwise the highest version number.
+Copilot loads the "active" version, so use --label active to fetch the version
+Copilot uses. Use --version to retrieve a specific version number, or --label
+to resolve any other label.`,
 		GetExample: `  iai skills get summarize-trace
   iai skills get summarize-trace --version 3
-  iai skills get summarize-trace --label staging`,
+  iai skills get summarize-trace --label active`,
 		UpdateLong: `Update a Copilot skill by creating a new version with updated content.
 
 Each update creates a brand-new version with exactly the content and config
@@ -71,7 +74,7 @@ Pass --intents once per intent (the flag is repeatable).`,
 		UpdateExample: `  iai skills update summarize-trace --file ./skill.md \
     --description "Summarize a Langfuse trace" \
     --intents "summarize trace" --intents "explain trace"
-  iai skills update summarize-trace --file ./skill.md --labels production,staging`,
+  iai skills update summarize-trace --file ./skill.md --labels active`,
 		DeleteLong: `Delete a Copilot skill and all its versions, or delete specific versions.
 
 Without flags, deletes the skill and all its versions (requires confirmation).

--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -53,11 +53,10 @@ can be browsed into with --folder.`,
   iai skills list --page 2 --limit 10`,
 		GetLong: `Show a Copilot skill in detail, including its config and full content.
 
-A label-less get returns whatever the server resolves by default: the version
-labeled "production" if one exists, otherwise the highest version number.
-Copilot loads the "active" version, so use --label active to fetch the version
-Copilot uses. Use --version to retrieve a specific version number, or --label
-to resolve any other label.`,
+Without flags, returns the version the server resolves by default. Copilot
+loads the "active" version, so use --label active to fetch the version Copilot
+uses. Use --version to retrieve a specific version number, or --label to
+resolve any other label.`,
 		GetExample: `  iai skills get summarize-trace
   iai skills get summarize-trace --version 3
   iai skills get summarize-trace --label active`,

--- a/cmd/variables.go
+++ b/cmd/variables.go
@@ -38,12 +38,11 @@ Example (variables.json):
 
   Add as many entries under 'variables' as you need — each key must be unique.
 
-The server automatically assigns the "latest" label to new versions. To make a
-version retrievable via the default 'get' (which resolves "production"), assign
-the "production" label with --labels production.`,
+The server automatically assigns the "latest" label to new versions. Use
+--labels to assign additional labels (e.g. --labels staging).`,
 		CreateExample: `  iai variables create session-vars --file variables.json
   iai variables create session-vars --file variables.json --schema-version 2.1.0
-  iai variables create session-vars --file variables.json --labels production
+  iai variables create session-vars --file variables.json --labels staging
   iai variables create session-vars --file variables.json --tags core`,
 		ListLong: `List variables in a specific project.
 
@@ -56,8 +55,9 @@ can be browsed into with --folder.`,
   iai variables list --page 2 --limit 10`,
 		GetLong: `Show detailed information about a specific variable definition, including its full content.
 
-By default returns the version labeled "production". Use --version to retrieve a
-specific version number, or --label to resolve a different label.`,
+Without flags, returns the version the server resolves by default. Use
+--version to retrieve a specific version number, or --label to resolve a
+specific label.`,
 		GetExample: `  iai variables get session-vars
   iai variables get session-vars --version 3
   iai variables get session-vars --label staging`,
@@ -90,7 +90,7 @@ Example (variables.json):
   Add as many entries under 'variables' as you need — each key must be unique.`,
 		UpdateExample: `  iai variables update session-vars --file variables.json
   iai variables update session-vars --file variables.json --schema-version 2.1.0
-  iai variables update session-vars --file variables.json --labels production,staging`,
+  iai variables update session-vars --file variables.json --labels staging,qa`,
 		DeleteLong: `Delete a variable definition and all its versions, or delete specific versions.
 
 Without flags, deletes the variable and all its versions (requires confirmation).

--- a/docs/iai_glossaries_create.md
+++ b/docs/iai_glossaries_create.md
@@ -37,7 +37,7 @@ glossary accepts any number of entries.
 ```
   iai glossaries create finance-terms --file glossary.json
   iai glossaries create finance-terms --file glossary.json --schema-version 2.1.0
-  iai glossaries create finance-terms --file glossary.json --labels production
+  iai glossaries create finance-terms --file glossary.json --labels staging
   iai glossaries create finance-terms --file glossary.json --tags domain
 ```
 

--- a/docs/iai_glossaries_get.md
+++ b/docs/iai_glossaries_get.md
@@ -6,8 +6,9 @@ Describe a glossary in detail
 
 Show detailed information about a specific glossary definition, including its full content.
 
-By default returns the version labeled "production". Use --version to retrieve a
-specific version number, or --label to resolve a different label.
+Without flags, returns the version the server resolves by default. Use
+--version to retrieve a specific version number, or --label to resolve a
+specific label.
 
 ```
 iai glossaries get <name> [flags]
@@ -26,7 +27,7 @@ iai glossaries get <name> [flags]
 ```
   -h, --help                  help for get
       --json                  Output response as JSON
-      --label string          Retrieve the version with this label (default: server resolves 'production')
+      --label string          Retrieve the version with this label
   -o, --organization string   Organization name that owns the project
   -p, --project string        Project name that owns the prompts
       --version int           Retrieve a specific version number

--- a/docs/iai_glossaries_update.md
+++ b/docs/iai_glossaries_update.md
@@ -39,7 +39,7 @@ glossary accepts any number of entries.
 ```
   iai glossaries update finance-terms --file glossary.json
   iai glossaries update finance-terms --file glossary.json --schema-version 2.1.0
-  iai glossaries update finance-terms --file glossary.json --labels production,staging
+  iai glossaries update finance-terms --file glossary.json --labels staging,qa
 ```
 
 ### Options

--- a/docs/iai_macros_create.md
+++ b/docs/iai_macros_create.md
@@ -20,7 +20,7 @@ No schema validation is applied — any text content is accepted.
 
 ```
   iai macros create disclaimer --file disclaimer.md
-  iai macros create disclaimer --file disclaimer.md --labels production
+  iai macros create disclaimer --file disclaimer.md --labels staging
   iai macros create disclaimer --file disclaimer.md --tags legal
 ```
 

--- a/docs/iai_macros_get.md
+++ b/docs/iai_macros_get.md
@@ -6,8 +6,9 @@ Describe a macro in detail
 
 Show detailed information about a specific macro, including its full content.
 
-By default returns the version labeled "production". Use --version to retrieve a
-specific version number, or --label to resolve a different label.
+Without flags, returns the version the server resolves by default. Use
+--version to retrieve a specific version number, or --label to resolve a
+specific label.
 
 ```
 iai macros get <name> [flags]
@@ -26,7 +27,7 @@ iai macros get <name> [flags]
 ```
   -h, --help                  help for get
       --json                  Output response as JSON
-      --label string          Retrieve the version with this label (default: server resolves 'production')
+      --label string          Retrieve the version with this label
   -o, --organization string   Organization name that owns the project
   -p, --project string        Project name that owns the prompts
       --version int           Retrieve a specific version number

--- a/docs/iai_macros_update.md
+++ b/docs/iai_macros_update.md
@@ -22,7 +22,7 @@ No schema validation is applied — any text content is accepted.
 
 ```
   iai macros update disclaimer --file disclaimer.md
-  iai macros update disclaimer --file disclaimer.md --labels production,staging
+  iai macros update disclaimer --file disclaimer.md --labels staging,qa
 ```
 
 ### Options

--- a/docs/iai_policies_create.md
+++ b/docs/iai_policies_create.md
@@ -27,7 +27,7 @@ criticality: HIGH
 ```
   iai policies create safety-rules --file policy.yaml
   iai policies create safety-rules --file policy.yaml --schema-version 2.1.0
-  iai policies create safety-rules --file policy.yaml --labels production
+  iai policies create safety-rules --file policy.yaml --labels staging
   iai policies create safety-rules --file policy.yaml --tags compliance
 ```
 

--- a/docs/iai_policies_get.md
+++ b/docs/iai_policies_get.md
@@ -6,8 +6,9 @@ Describe a policy in detail
 
 Show detailed information about a specific policy, including its full content.
 
-By default returns the version labeled "production". Use --version to retrieve a
-specific version number, or --label to resolve a different label.
+Without flags, returns the version the server resolves by default. Use
+--version to retrieve a specific version number, or --label to resolve a
+specific label.
 
 ```
 iai policies get <name> [flags]
@@ -26,7 +27,7 @@ iai policies get <name> [flags]
 ```
   -h, --help                  help for get
       --json                  Output response as JSON
-      --label string          Retrieve the version with this label (default: server resolves 'production')
+      --label string          Retrieve the version with this label
   -o, --organization string   Organization name that owns the project
   -p, --project string        Project name that owns the prompts
       --version int           Retrieve a specific version number

--- a/docs/iai_policies_update.md
+++ b/docs/iai_policies_update.md
@@ -29,7 +29,7 @@ criticality: HIGH
 ```
   iai policies update safety-rules --file policy.yaml
   iai policies update safety-rules --file policy.yaml --schema-version 2.1.0
-  iai policies update safety-rules --file policy.yaml --labels production,staging
+  iai policies update safety-rules --file policy.yaml --labels staging,qa
 ```
 
 ### Options

--- a/docs/iai_prompts_create.md
+++ b/docs/iai_prompts_create.md
@@ -11,9 +11,8 @@ Exactly one of --file or --content must be specified.
 
 The --type flag selects the prompt type: "text" (default) or "chat".
 
-The server automatically assigns the "latest" label to new versions. To make a
-version retrievable via the default 'get' (which resolves "production"), assign
-the "production" label with --labels production.
+The server automatically assigns the "latest" label to new versions. Use
+--labels to assign additional labels (e.g. --labels staging).
 
 ```
 iai prompts create <name> [flags]
@@ -25,7 +24,7 @@ iai prompts create <name> [flags]
   iai prompts create greeting --content "Hello, how can I help you?"
   iai prompts create greeting --file greeting.txt
   iai prompts create greeting --file greeting.txt --type chat
-  iai prompts create greeting --content "Hi!" --labels production
+  iai prompts create greeting --content "Hi!" --labels staging
   iai prompts create greeting --file greeting.txt --tags support
 ```
 

--- a/docs/iai_prompts_get.md
+++ b/docs/iai_prompts_get.md
@@ -6,8 +6,9 @@ Describe a prompt in detail
 
 Show detailed information about a specific prompt, including its full content.
 
-By default returns the version labeled "production". Use --version to retrieve a
-specific version number, or --label to resolve a different label.
+Without flags, returns the version the server resolves by default. Use
+--version to retrieve a specific version number, or --label to resolve a
+specific label.
 
 ```
 iai prompts get <name> [flags]
@@ -26,7 +27,7 @@ iai prompts get <name> [flags]
 ```
   -h, --help                  help for get
       --json                  Output response as JSON
-      --label string          Retrieve the version with this label (default: server resolves "production")
+      --label string          Retrieve the version with this label
   -o, --organization string   Organization name that owns the project
   -p, --project string        Project name that owns the prompts
       --version int           Retrieve a specific version number

--- a/docs/iai_prompts_update.md
+++ b/docs/iai_prompts_update.md
@@ -21,7 +21,7 @@ iai prompts update <name> [flags]
 ```
   iai prompts update greeting --content "Hello! How may I assist you today?"
   iai prompts update greeting --file greeting.txt
-  iai prompts update greeting --file greeting.txt --labels production,staging
+  iai prompts update greeting --file greeting.txt --labels staging,qa
 ```
 
 ### Options

--- a/docs/iai_routines_create.md
+++ b/docs/iai_routines_create.md
@@ -32,7 +32,7 @@ steps:
 ```
   iai routines create onboarding-flow --file routine.yaml
   iai routines create onboarding-flow --file routine.yaml --schema-version 2.1.0
-  iai routines create onboarding-flow --file routine.yaml --labels production
+  iai routines create onboarding-flow --file routine.yaml --labels staging
   iai routines create onboarding-flow --file routine.yaml --tags v2,experimental
 ```
 

--- a/docs/iai_routines_get.md
+++ b/docs/iai_routines_get.md
@@ -6,8 +6,9 @@ Describe a routine in detail
 
 Show detailed information about a specific routine, including its full content.
 
-By default returns the version labeled "production". Use --version to retrieve a
-specific version number, or --label to resolve a different label.
+Without flags, returns the version the server resolves by default. Use
+--version to retrieve a specific version number, or --label to resolve a
+specific label.
 
 ```
 iai routines get <name> [flags]
@@ -26,7 +27,7 @@ iai routines get <name> [flags]
 ```
   -h, --help                  help for get
       --json                  Output response as JSON
-      --label string          Retrieve the version with this label (default: server resolves 'production')
+      --label string          Retrieve the version with this label
   -o, --organization string   Organization name that owns the project
   -p, --project string        Project name that owns the prompts
       --version int           Retrieve a specific version number

--- a/docs/iai_routines_update.md
+++ b/docs/iai_routines_update.md
@@ -34,7 +34,7 @@ steps:
 ```
   iai routines update onboarding-flow --file routine.yaml
   iai routines update onboarding-flow --file routine.yaml --schema-version 2.1.0
-  iai routines update onboarding-flow --file routine.yaml --labels production,staging
+  iai routines update onboarding-flow --file routine.yaml --labels staging,qa
 ```
 
 ### Options

--- a/docs/iai_skills_create.md
+++ b/docs/iai_skills_create.md
@@ -19,9 +19,9 @@ Example (skill.md):
   Given a Langfuse trace ID, fetch the trace and summarize key steps,
   latencies, and any errors.
 
-The server automatically assigns the "latest" label to new versions. To make
-a version retrievable via the default 'get' (which resolves "production"),
-assign the "production" label with --labels production.
+The server automatically assigns the "latest" label to new versions. Copilot
+loads the version labeled "active", so assign it with --labels active to make
+a skill the one Copilot uses.
 
 ```
 iai skills create <name> [flags]
@@ -33,7 +33,7 @@ iai skills create <name> [flags]
   iai skills create summarize-trace --file ./skill.md \
     --description "Summarize a Langfuse trace" \
     --intents "summarize trace" --intents "explain trace"
-  iai skills create summarize-trace --file ./skill.md --labels production
+  iai skills create summarize-trace --file ./skill.md --labels active
 ```
 
 ### Options

--- a/docs/iai_skills_get.md
+++ b/docs/iai_skills_get.md
@@ -6,11 +6,10 @@ Describe a skill in detail
 
 Show a Copilot skill in detail, including its config and full content.
 
-A label-less get returns whatever the server resolves by default: the version
-labeled "production" if one exists, otherwise the highest version number.
-Copilot loads the "active" version, so use --label active to fetch the version
-Copilot uses. Use --version to retrieve a specific version number, or --label
-to resolve any other label.
+Without flags, returns the version the server resolves by default. Copilot
+loads the "active" version, so use --label active to fetch the version Copilot
+uses. Use --version to retrieve a specific version number, or --label to
+resolve any other label.
 
 ```
 iai skills get <name> [flags]
@@ -29,7 +28,7 @@ iai skills get <name> [flags]
 ```
   -h, --help                  help for get
       --json                  Output response as JSON
-      --label string          Retrieve the version with this label (default: server resolves 'production')
+      --label string          Retrieve the version with this label
   -o, --organization string   Organization name that owns the project
   -p, --project string        Project name that owns the prompts
       --version int           Retrieve a specific version number

--- a/docs/iai_skills_get.md
+++ b/docs/iai_skills_get.md
@@ -6,8 +6,11 @@ Describe a skill in detail
 
 Show a Copilot skill in detail, including its config and full content.
 
-By default returns the version labeled "production". Use --version to retrieve a
-specific version number, or --label to resolve a different label.
+A label-less get returns whatever the server resolves by default: the version
+labeled "production" if one exists, otherwise the highest version number.
+Copilot loads the "active" version, so use --label active to fetch the version
+Copilot uses. Use --version to retrieve a specific version number, or --label
+to resolve any other label.
 
 ```
 iai skills get <name> [flags]
@@ -18,7 +21,7 @@ iai skills get <name> [flags]
 ```
   iai skills get summarize-trace
   iai skills get summarize-trace --version 3
-  iai skills get summarize-trace --label staging
+  iai skills get summarize-trace --label active
 ```
 
 ### Options

--- a/docs/iai_skills_update.md
+++ b/docs/iai_skills_update.md
@@ -25,7 +25,7 @@ iai skills update <name> [flags]
   iai skills update summarize-trace --file ./skill.md \
     --description "Summarize a Langfuse trace" \
     --intents "summarize trace" --intents "explain trace"
-  iai skills update summarize-trace --file ./skill.md --labels production,staging
+  iai skills update summarize-trace --file ./skill.md --labels active
 ```
 
 ### Options

--- a/docs/iai_variables_create.md
+++ b/docs/iai_variables_create.md
@@ -35,7 +35,7 @@ the set accepts any number of variables.
 ```
   iai variables create session-vars --file variables.json
   iai variables create session-vars --file variables.json --schema-version 2.1.0
-  iai variables create session-vars --file variables.json --labels production
+  iai variables create session-vars --file variables.json --labels staging
   iai variables create session-vars --file variables.json --tags core
 ```
 

--- a/docs/iai_variables_get.md
+++ b/docs/iai_variables_get.md
@@ -6,8 +6,9 @@ Describe a variable in detail
 
 Show detailed information about a specific variable definition, including its full content.
 
-By default returns the version labeled "production". Use --version to retrieve a
-specific version number, or --label to resolve a different label.
+Without flags, returns the version the server resolves by default. Use
+--version to retrieve a specific version number, or --label to resolve a
+specific label.
 
 ```
 iai variables get <name> [flags]
@@ -26,7 +27,7 @@ iai variables get <name> [flags]
 ```
   -h, --help                  help for get
       --json                  Output response as JSON
-      --label string          Retrieve the version with this label (default: server resolves 'production')
+      --label string          Retrieve the version with this label
   -o, --organization string   Organization name that owns the project
   -p, --project string        Project name that owns the prompts
       --version int           Retrieve a specific version number

--- a/docs/iai_variables_update.md
+++ b/docs/iai_variables_update.md
@@ -37,7 +37,7 @@ the set accepts any number of variables.
 ```
   iai variables update session-vars --file variables.json
   iai variables update session-vars --file variables.json --schema-version 2.1.0
-  iai variables update session-vars --file variables.json --labels production,staging
+  iai variables update session-vars --file variables.json --labels staging,qa
 ```
 
 ### Options


### PR DESCRIPTION
## What

Update the `iai skills` command help text, examples, and generated docs to reference the `active` label instead of `production`.

- `skills create` / `skills update`: examples now use `--labels active`.
- `skills create` long help: the `active` label marks the version Copilot loads; drop the guidance to label skills `production`.
- `skills get` long help: `--label active` fetches the version Copilot uses. The bare `get` default description stays accurate — the server resolves the `production` label if present, otherwise the highest version.
- `skills get` example: `--label staging` → `--label active`.
- Regenerated `docs/iai_skills_*.md` via `make docs`.

## Why

Platform (DEV-857) retired the built-in Langfuse `production` prompt label for Copilot skills. Copilot now resolves skills via `label=active`, loading the `active` version of each skill (platform PR #1245, copilot PR #123). The `production` label still exists as an ordinary user label for other prompt types, and the server's default label-less resolution is unchanged — so only the skills help text and examples needed updating. No hardcoded label logic exists in the CLI.

Skills-only; other command help (prompts, routines, policies, macros, variables) is untouched.