### PR TITLE
fix(databases): consume replicas/highAvailability from operator (DEV-873)

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.37.3"
+current_version = "0.37.4"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version            = "0.37.3"
+	version            = "0.37.4"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second

--- a/internal/clients/deployment_client.go
+++ b/internal/clients/deployment_client.go
@@ -2042,6 +2042,11 @@ type DatabaseBackupConfig struct {
 	RetentionPolicy string `json:"retentionPolicy"`
 }
 
+type DatabaseBackupStatus struct {
+	Enabled bool `json:"enabled"`
+	DatabaseBackupConfig
+}
+
 type CreateDatabaseBody struct {
 	Instances       int                   `json:"instances"`
 	PostgresVersion string                `json:"postgresVersion,omitempty"`
@@ -2062,12 +2067,13 @@ type DescribeDatabaseResponse struct {
 	Name              string                `json:"name"`
 	Revision          int                   `json:"revision"`
 	Updated           string                `json:"updated,omitempty"`
-	Instances         int                   `json:"instances"`
+	Replicas          int                   `json:"replicas"`
+	HighAvailability  bool                  `json:"highAvailability"`
 	PostgresVersion   string                `json:"postgresVersion"`
 	Resources         Resources             `json:"resources"`
 	Storage           DatabaseStorageConfig `json:"storage"`
 	Extensions        []string              `json:"extensions,omitempty"`
-	Backup            *DatabaseBackupConfig `json:"backup,omitempty"`
+	Backup            DatabaseBackupStatus  `json:"backup"`
 	StackId           string                `json:"stackId,omitempty"`
 	CredentialsSecret string                `json:"credentialsSecret"`
 	Status            string                `json:"status"`

--- a/internal/output/databases.go
+++ b/internal/output/databases.go
@@ -43,9 +43,9 @@ func PrintDatabaseDescribe(out io.Writer, db *clients.DescribeDatabaseResponse) 
 		fmt.Fprintf(w, "Updated:\t%s\n", LocalTime(db.Updated))
 	}
 	fmt.Fprintf(w, "PostgreSQL Version:\t%s\n", db.PostgresVersion)
-	fmt.Fprintf(w, "Replicas:\t%d\n", db.Instances)
+	fmt.Fprintf(w, "Replicas:\t%d\n", db.Replicas)
 	highAvailability := "No"
-	if db.Instances >= 2 {
+	if db.HighAvailability {
 		highAvailability = "Yes"
 	}
 	fmt.Fprintf(w, "High Availability:\t%s\n", highAvailability)
@@ -62,7 +62,7 @@ func PrintDatabaseDescribe(out io.Writer, db *clients.DescribeDatabaseResponse) 
 	}
 
 	fmt.Fprintln(w)
-	if db.Backup == nil {
+	if !db.Backup.Enabled {
 		fmt.Fprintln(w, "Backup:\tnot configured")
 	} else {
 		fmt.Fprintln(w, "Backup:")

--- a/internal/output/databases_test.go
+++ b/internal/output/databases_test.go
@@ -82,19 +82,23 @@ func TestPrintDatabaseDescribe(t *testing.T) {
 		{
 			name: "full describe output",
 			db: &clients.DescribeDatabaseResponse{
-				Name:            "my-db",
-				Revision:        2,
-				Status:          "Healthy",
-				Message:         "All instances running",
-				Updated:         "2025-01-15T10:30:00Z",
-				PostgresVersion: "17",
-				Instances:       2,
-				Resources:       clients.Resources{CPU: "1", Memory: "2G"},
-				Storage:         clients.DatabaseStorageConfig{Size: "20G"},
-				Extensions:      []string{"vector", "pg_trgm"},
-				Backup: &clients.DatabaseBackupConfig{
-					Schedule:        "0 0 2 * * *",
-					RetentionPolicy: "30d",
+				Name:             "my-db",
+				Revision:         2,
+				Status:           "Healthy",
+				Message:          "All instances running",
+				Updated:          "2025-01-15T10:30:00Z",
+				PostgresVersion:  "17",
+				Replicas:         2,
+				HighAvailability: true,
+				Resources:        clients.Resources{CPU: "1", Memory: "2G"},
+				Storage:          clients.DatabaseStorageConfig{Size: "20G"},
+				Extensions:       []string{"vector", "pg_trgm"},
+				Backup: clients.DatabaseBackupStatus{
+					Enabled: true,
+					DatabaseBackupConfig: clients.DatabaseBackupConfig{
+						Schedule:        "0 0 2 * * *",
+						RetentionPolicy: "30d",
+					},
 				},
 				StackId:           "my-stack",
 				CredentialsSecret: "my-db-app",
@@ -121,13 +125,41 @@ func TestPrintDatabaseDescribe(t *testing.T) {
 				"Credentials Secret:   my-db-app\n",
 		},
 		{
+			name: "HA independent of replica count",
+			db: &clients.DescribeDatabaseResponse{
+				Name:              "flexible-db",
+				Revision:          1,
+				Status:            "Healthy",
+				PostgresVersion:   "17",
+				Replicas:          2,
+				HighAvailability:  false,
+				Resources:         clients.Resources{CPU: "0.5", Memory: "1G"},
+				Storage:           clients.DatabaseStorageConfig{Size: "10G"},
+				CredentialsSecret: "flexible-db-app",
+			},
+			want: "Name:                 flexible-db\n" +
+				"Revision:             1\n" +
+				"Status:               Healthy\n" +
+				"PostgreSQL Version:   17\n" +
+				"Replicas:             2\n" +
+				"High Availability:    No\n" +
+				"Resources:\n" +
+				"  CPU:      0.5\n" +
+				"  Memory:   1G\n" +
+				"Storage:\n" +
+				"  Size:   10G\n" +
+				"\n" +
+				"Backup:               not configured\n" +
+				"Credentials Secret:   flexible-db-app\n",
+		},
+		{
 			name: "without backup configuration",
 			db: &clients.DescribeDatabaseResponse{
 				Name:              "basic-db",
 				Revision:          1,
 				Status:            "Provisioning",
 				PostgresVersion:   "17",
-				Instances:         1,
+				Replicas:          1,
 				Resources:         clients.Resources{CPU: "0.5", Memory: "1G"},
 				Storage:           clients.DatabaseStorageConfig{Size: "10G"},
 				CredentialsSecret: "basic-db-app",


### PR DESCRIPTION
## Summary
- Follow-up to #165. HA and the instances→replicas rename were done client-side; the operator ([deployment-operator#226](https://github.com/Interactive-AI-Labs/deployment-operator/pull/226)) now owns both as part of its describe response, plus an explicit backup status object (raised by @ajaen-ai on the operator PR).
- `DescribeDatabaseResponse.Instances` → `Replicas` (matches operator's renamed `replicas` field) + new `HighAvailability` bool.
- New `DatabaseBackupStatus` (`Configured`/`Schedule`/`RetentionPolicy`) replaces the `*DatabaseBackupConfig` pointer — `Backup` is now always present, never nil.
- `PrintDatabaseDescribe` prints `db.HighAvailability` and branches on `db.Backup.Configured` directly instead of deriving either from replica count / a nil check.
- `CreateDatabaseBody.Instances` and `DatabaseBackupConfig` (used for create/patch bodies) untouched — this only affects the describe response shape.

Depends on deployment-operator#226 being deployed first (or a local operator with that branch) for the new fields to exist in the response — otherwise `Replicas`/`HighAvailability` decode as zero-value and `Backup.Configured` as false.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] Manually ran `iai databases describe` against a local operator on branch DEV-873/describe-replicas-ha (through the backup-nesting refactor too): `iai-bkp-103703` (1 replica, backup configured) showed `Replicas: 1` / `High Availability: No` / backup schedule+retention; disposable no-backup databases showed `Backup: not configured`. Cleaned up afterward.

Linear: https://linear.app/interactive-ai/issue/DEV-873/small-fix-iai-databases-describe