### PR TITLE
DEV-876: Add models list/get commands

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.37.5"
+current_version = "0.38.0"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/models.go
+++ b/cmd/models.go
@@ -1,0 +1,156 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/inputs"
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var (
+	modelsListPage    int
+	modelsListLimit   int
+	modelsListSearch  string
+	modelsListRegion  string
+	modelsListJSON    bool
+	modelsListYAML    bool
+	modelsListOrg     string
+	modelsListProject string
+
+	modelsGetJSON    bool
+	modelsGetYAML    bool
+	modelsGetOrg     string
+	modelsGetProject string
+)
+
+var modelsCmd = &cobra.Command{
+	Use:              "models",
+	Aliases:          []string{"model"},
+	Short:            "List and inspect models",
+	GroupID:          groupInfra,
+	Long:             `List and inspect router models available to a project.`,
+	PersistentPreRun: chainRootPersistentPreRun,
+}
+
+var modelsListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List router models",
+	Long:    `List router models for a project.`,
+	Example: `  iai models list
+  iai models list -o my-org -p my-project
+  iai models list --page 1 --limit 10
+  iai models list --search claude
+  iai models list --region eu
+  iai models list --json
+  iai models list --yaml`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+
+		opts := clients.RouterModelListOptions{
+			Page:   modelsListPage,
+			Limit:  modelsListLimit,
+			Search: modelsListSearch,
+			Region: modelsListRegion,
+		}
+
+		if err := inputs.ValidateRouterModelListOptions(opts); err != nil {
+			return err
+		}
+
+		pCtx, apiClient, _, err := resolveProject(cmd.Context(), modelsListOrg, modelsListProject)
+		if err != nil {
+			return err
+		}
+
+		models, meta, err := apiClient.ListRouterModels(
+			cmd.Context(),
+			pCtx.projectId,
+			opts,
+		)
+		if err != nil {
+			return err
+		}
+
+		if modelsListJSON {
+			return output.PrintStructuredJSON(out, models)
+		}
+		if modelsListYAML {
+			return output.PrintStructuredYAML(out, models)
+		}
+
+		return output.PrintRouterModelList(out, models, meta)
+	},
+}
+
+var modelsGetCmd = &cobra.Command{
+	Use:     "get <id>",
+	Aliases: []string{"describe", "desc"},
+	Short:   "Get a router model",
+	Long:    `Get detailed information about a router model by its ID.`,
+	Example: `  iai models get d34313ff-92ce-47ed-a1ae-fbb37f8a9411
+  iai models get d34313ff-92ce-47ed-a1ae-fbb37f8a9411 -o my-org -p my-project
+  iai models get d34313ff-92ce-47ed-a1ae-fbb37f8a9411 --json
+  iai models get d34313ff-92ce-47ed-a1ae-fbb37f8a9411 --yaml`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+
+		modelID := strings.TrimSpace(args[0])
+		if modelID == "" {
+			return fmt.Errorf("model id must not be empty")
+		}
+
+		pCtx, apiClient, _, err := resolveProject(cmd.Context(), modelsGetOrg, modelsGetProject)
+		if err != nil {
+			return err
+		}
+
+		model, err := apiClient.GetRouterModelByID(
+			cmd.Context(),
+			pCtx.projectId,
+			modelID,
+		)
+		if err != nil {
+			return err
+		}
+
+		if modelsGetJSON {
+			return output.PrintStructuredJSON(out, model)
+		}
+		if modelsGetYAML {
+			return output.PrintStructuredYAML(out, model)
+		}
+
+		return output.PrintRouterModelDetail(out, model)
+	},
+}
+
+func init() {
+	modelsListCmd.Flags().IntVar(&modelsListPage, "page", 0, "Page number (0-indexed)")
+	modelsListCmd.Flags().IntVar(&modelsListLimit, "limit", 50, "Items per page (max 100)")
+	modelsListCmd.Flags().StringVar(&modelsListSearch, "search", "", "Search filter")
+	modelsListCmd.Flags().StringVar(&modelsListRegion, "region", "", "Filter by region (us|eu)")
+	modelsListCmd.Flags().
+		BoolVar(&modelsListJSON, "json", false, "Output response as JSON")
+	modelsListCmd.Flags().
+		BoolVar(&modelsListYAML, "yaml", false, "Output response as YAML")
+	modelsListCmd.MarkFlagsMutuallyExclusive("json", "yaml")
+	modelsListCmd.Flags().
+		StringVarP(&modelsListOrg, "organization", "o", "", "Organization name that owns the project")
+	modelsListCmd.Flags().StringVarP(&modelsListProject, "project", "p", "", "Project name")
+
+	modelsGetCmd.Flags().BoolVar(&modelsGetJSON, "json", false, "Output response as JSON")
+	modelsGetCmd.Flags().BoolVar(&modelsGetYAML, "yaml", false, "Output response as YAML")
+	modelsGetCmd.MarkFlagsMutuallyExclusive("json", "yaml")
+	modelsGetCmd.Flags().
+		StringVarP(&modelsGetOrg, "organization", "o", "", "Organization name that owns the project")
+	modelsGetCmd.Flags().StringVarP(&modelsGetProject, "project", "p", "", "Project name")
+
+	modelsCmd.AddCommand(modelsListCmd, modelsGetCmd)
+	rootCmd.AddCommand(modelsCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version            = "0.37.5"
+	version            = "0.38.0"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second

--- a/docs/iai.md
+++ b/docs/iai.md
@@ -101,6 +101,7 @@ Prompt resources (`prompts`, `routines`, `policies`, `variables`, `glossaries`, 
 * [iai logout](iai_logout.md)	 - Clear local session
 * [iai macros](iai_macros.md)	 - Pre-approved response templates used in routines
 * [iai metrics](iai_metrics.md)	 - Query aggregated observability metrics
+* [iai models](iai_models.md)	 - List and inspect models
 * [iai observations](iai_observations.md)	 - Inspect spans within traces
 * [iai organizations](iai_organizations.md)	 - Switch or list organizations
 * [iai policies](iai_policies.md)	 - Single-step behavioral rules for agents

--- a/docs/iai_models.md
+++ b/docs/iai_models.md
@@ -1,0 +1,29 @@
+## iai models
+
+List and inspect models
+
+### Synopsis
+
+List and inspect router models available to a project.
+
+### Options
+
+```
+  -h, --help   help for models
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai](iai.md)	 - InteractiveAI's CLI
+* [iai models get](iai_models_get.md)	 - Get a router model
+* [iai models list](iai_models_list.md)	 - List router models
+

--- a/docs/iai_models_get.md
+++ b/docs/iai_models_get.md
@@ -1,0 +1,44 @@
+## iai models get
+
+Get a router model
+
+### Synopsis
+
+Get detailed information about a router model by its ID.
+
+```
+iai models get <id> [flags]
+```
+
+### Examples
+
+```
+  iai models get d34313ff-92ce-47ed-a1ae-fbb37f8a9411
+  iai models get d34313ff-92ce-47ed-a1ae-fbb37f8a9411 -o my-org -p my-project
+  iai models get d34313ff-92ce-47ed-a1ae-fbb37f8a9411 --json
+  iai models get d34313ff-92ce-47ed-a1ae-fbb37f8a9411 --yaml
+```
+
+### Options
+
+```
+  -h, --help                  help for get
+      --json                  Output response as JSON
+  -o, --organization string   Organization name that owns the project
+  -p, --project string        Project name
+      --yaml                  Output response as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai models](iai_models.md)	 - List and inspect models
+

--- a/docs/iai_models_list.md
+++ b/docs/iai_models_list.md
@@ -1,0 +1,51 @@
+## iai models list
+
+List router models
+
+### Synopsis
+
+List router models for a project.
+
+```
+iai models list [flags]
+```
+
+### Examples
+
+```
+  iai models list
+  iai models list -o my-org -p my-project
+  iai models list --page 1 --limit 10
+  iai models list --search claude
+  iai models list --region eu
+  iai models list --json
+  iai models list --yaml
+```
+
+### Options
+
+```
+  -h, --help                  help for list
+      --json                  Output response as JSON
+      --limit int             Items per page (max 100) (default 50)
+  -o, --organization string   Organization name that owns the project
+      --page int              Page number (0-indexed)
+  -p, --project string        Project name
+      --region string         Filter by region (us|eu)
+      --search string         Search filter
+      --yaml                  Output response as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai models](iai_models.md)	 - List and inspect models
+

--- a/internal/clients/router_models.go
+++ b/internal/clients/router_models.go
@@ -1,0 +1,117 @@
+package clients
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/google/go-querystring/query"
+)
+
+// RouterModel is a model exposed by the router-models endpoints. Unlike the
+// eval-scoped resources, these endpoints take projectId as a query parameter
+// and return the resource directly (no {success, data} envelope).
+type RouterModel struct {
+	ID              string             `json:"id"`
+	ProjectID       string             `json:"projectId,omitempty"`
+	ModelName       string             `json:"modelName"`
+	MarketingName   string             `json:"marketingName,omitempty"`
+	MatchPattern    string             `json:"matchPattern"`
+	Description     string             `json:"description,omitempty"`
+	ContextLength   *int               `json:"contextLength,omitempty"`
+	Capabilities    []string           `json:"capabilities"`
+	Prices          map[string]float64 `json:"prices"`
+	TokenizerID     string             `json:"tokenizerId,omitempty"`
+	TokenizerConfig json.RawMessage    `json:"tokenizerConfig,omitempty"`
+	CreatedAt       string             `json:"createdAt,omitempty"`
+	LastUsed        string             `json:"lastUsed,omitempty"`
+	Region          string             `json:"region"`
+	HasOtherRegion  bool               `json:"hasOtherRegion"`
+}
+
+type RouterModelListOptions struct {
+	// Page is 0-indexed; omitempty drops page=0 from the query, which the API
+	// treats as the default first page.
+	Page   int    `url:"page,omitempty"`
+	Limit  int    `url:"limit,omitempty"`
+	Search string `url:"search,omitempty"`
+	Region string `url:"region,omitempty"`
+}
+
+type routerModelListData struct {
+	Models     []RouterModel `json:"models"`
+	TotalCount int           `json:"totalCount"`
+}
+
+// ListRouterModels lists router models for a project. This endpoint is
+// 0-indexed and returns only a totalCount, so we synthesize a PageMeta (with a
+// 1-indexed Page) to match the shape of the eval-scoped list endpoints.
+func (c *APIClient) ListRouterModels(
+	ctx context.Context,
+	projectID string,
+	opts RouterModelListOptions,
+) ([]RouterModel, PageMeta, error) {
+	req, err := c.newRequest(ctx, http.MethodGet, "/api/v1/models/router-models")
+	if err != nil {
+		return nil, PageMeta{}, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	q, err := query.Values(opts)
+	if err != nil {
+		return nil, PageMeta{}, fmt.Errorf("failed to encode query parameters: %w", err)
+	}
+	q.Set("projectId", projectID)
+	req.URL.RawQuery = q.Encode()
+
+	body, err := c.doAndRead(req, "list router models")
+	if err != nil {
+		return nil, PageMeta{}, err
+	}
+
+	var data routerModelListData
+	if err := json.Unmarshal(body, &data); err != nil {
+		return nil, PageMeta{}, fmt.Errorf(
+			"failed to decode list router models response: %w",
+			err,
+		)
+	}
+
+	meta := PageMeta{
+		Page:       opts.Page + 1,
+		Limit:      opts.Limit,
+		TotalItems: data.TotalCount,
+	}
+	if opts.Limit > 0 {
+		meta.TotalPages = (data.TotalCount + opts.Limit - 1) / opts.Limit
+	}
+	return data.Models, meta, nil
+}
+
+// GetRouterModelByID retrieves a single router model by its local UUID.
+func (c *APIClient) GetRouterModelByID(
+	ctx context.Context,
+	projectID, modelID string,
+) (*RouterModel, error) {
+	path := "/api/v1/models/router-models/by-id/" + url.PathEscape(modelID)
+	req, err := c.newRequest(ctx, http.MethodGet, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	q := req.URL.Query()
+	q.Set("projectId", projectID)
+	req.URL.RawQuery = q.Encode()
+
+	body, err := c.doAndRead(req, "get router model")
+	if err != nil {
+		return nil, err
+	}
+
+	var model RouterModel
+	if err := json.Unmarshal(body, &model); err != nil {
+		return nil, fmt.Errorf("failed to decode router model response: %w", err)
+	}
+	return &model, nil
+}

--- a/internal/clients/router_models_test.go
+++ b/internal/clients/router_models_test.go
@@ -1,0 +1,110 @@
+package clients
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestAPIClientListRouterModels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/v1/models/router-models" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		query := r.URL.Query()
+		if query.Get("projectId") != "proj-1" {
+			t.Fatalf("projectId = %q", query.Get("projectId"))
+		}
+		if query.Get("page") != "2" {
+			t.Fatalf("page = %q", query.Get("page"))
+		}
+		if query.Get("limit") != "10" {
+			t.Fatalf("limit = %q", query.Get("limit"))
+		}
+		if query.Get("search") != "gpt" {
+			t.Fatalf("search = %q", query.Get("search"))
+		}
+		if query.Get("region") != "us" {
+			t.Fatalf("region = %q", query.Get("region"))
+		}
+		_, _ = io.WriteString(
+			w,
+			`{"models":[{"id":"m-1","modelName":"gpt-4o","endpointProvider":"openai","region":"us"}],"totalCount":1}`,
+		)
+	}))
+	defer server.Close()
+
+	client, err := NewAPIClient(
+		server.URL,
+		5*time.Second,
+		"",
+		"",
+		[]*http.Cookie{{Name: "session", Value: "abc"}},
+	)
+	if err != nil {
+		t.Fatalf("NewAPIClient() error = %v", err)
+	}
+
+	models, meta, err := client.ListRouterModels(
+		context.Background(),
+		"proj-1",
+		RouterModelListOptions{Page: 2, Limit: 10, Search: "gpt", Region: "us"},
+	)
+	if err != nil {
+		t.Fatalf("ListRouterModels() error = %v", err)
+	}
+	if len(models) != 1 || models[0].ID != "m-1" {
+		t.Fatalf("unexpected models: %#v", models)
+	}
+	// Page is 1-indexed (opts.Page 2 -> 3); TotalPages = ceil(1/10) = 1.
+	if meta.Page != 3 || meta.TotalItems != 1 || meta.TotalPages != 1 {
+		t.Fatalf("unexpected meta: %#v", meta)
+	}
+}
+
+func TestAPIClientGetRouterModelByID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/v1/models/router-models/by-id/m-1" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("projectId") != "proj-1" {
+			t.Fatalf("projectId = %q", r.URL.Query().Get("projectId"))
+		}
+		_, _ = io.WriteString(
+			w,
+			`{"id":"m-1","modelName":"gpt-4o","endpointProvider":"openai","region":"us","prices":{"input":0.01}}`,
+		)
+	}))
+	defer server.Close()
+
+	client, err := NewAPIClient(
+		server.URL,
+		5*time.Second,
+		"",
+		"",
+		[]*http.Cookie{{Name: "session", Value: "abc"}},
+	)
+	if err != nil {
+		t.Fatalf("NewAPIClient() error = %v", err)
+	}
+
+	model, err := client.GetRouterModelByID(context.Background(), "proj-1", "m-1")
+	if err != nil {
+		t.Fatalf("GetRouterModelByID() error = %v", err)
+	}
+	if model.ID != "m-1" || model.ModelName != "gpt-4o" {
+		t.Fatalf("unexpected model: %#v", model)
+	}
+	if model.Prices["input"] != 0.01 {
+		t.Fatalf("unexpected prices: %#v", model.Prices)
+	}
+}

--- a/internal/inputs/router_models.go
+++ b/internal/inputs/router_models.go
@@ -1,0 +1,26 @@
+package inputs
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
+)
+
+var validRouterModelRegions = []string{"us", "eu"}
+
+// ValidateRouterModelListOptions validates router model list options. This
+// endpoint is 0-indexed (page >= 0) with a max limit of 100, so it cannot reuse
+// ValidatePagination.
+func ValidateRouterModelListOptions(opts clients.RouterModelListOptions) error {
+	if opts.Page < 0 {
+		return fmt.Errorf("page must be >= 0, got %d", opts.Page)
+	}
+	if opts.Limit < 1 || opts.Limit > 100 {
+		return fmt.Errorf("limit must be between 1 and 100, got %d", opts.Limit)
+	}
+	if opts.Region != "" && !slices.Contains(validRouterModelRegions, opts.Region) {
+		return fmt.Errorf("invalid region %q: must be one of us, eu", opts.Region)
+	}
+	return nil
+}

--- a/internal/inputs/router_models_test.go
+++ b/internal/inputs/router_models_test.go
@@ -1,0 +1,31 @@
+package inputs
+
+import (
+	"testing"
+
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
+)
+
+func TestValidateRouterModelListOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    clients.RouterModelListOptions
+		wantErr bool
+	}{
+		{"valid defaults", clients.RouterModelListOptions{Page: 0, Limit: 50}, false},
+		{"valid region", clients.RouterModelListOptions{Limit: 100, Region: "eu"}, false},
+		{"negative page", clients.RouterModelListOptions{Page: -1, Limit: 50}, true},
+		{"limit zero", clients.RouterModelListOptions{Limit: 0}, true},
+		{"limit too high", clients.RouterModelListOptions{Limit: 101}, true},
+		{"invalid region", clients.RouterModelListOptions{Limit: 50, Region: "apac"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateRouterModelListOptions(tt.opts)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateRouterModelListOptions() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/output/models.go
+++ b/internal/output/models.go
@@ -1,0 +1,82 @@
+package output
+
+import (
+	"fmt"
+	"io"
+	"maps"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
+)
+
+func PrintRouterModelList(
+	out io.Writer,
+	models []clients.RouterModel,
+	meta clients.PageMeta,
+) error {
+	if len(models) == 0 {
+		fmt.Fprintln(out, "No models found.")
+		return nil
+	}
+
+	headers := []string{"NAME", "CONTEXT", "REGION", "ID"}
+	rows := make([][]string, len(models))
+	for i, m := range models {
+		rows[i] = []string{
+			m.ModelName,
+			formatInt(m.ContextLength),
+			m.Region,
+			m.ID,
+		}
+	}
+
+	if err := PrintTable(out, headers, rows); err != nil {
+		return err
+	}
+
+	PrintPageMeta(out, meta.Page, meta.TotalPages, meta.TotalItems)
+	return nil
+}
+
+func PrintRouterModelDetail(out io.Writer, m *clients.RouterModel) error {
+	w := NewDescribeWriter(out)
+	fmt.Fprintf(w, "ID:\t%s\n", m.ID)
+	fmt.Fprintf(w, "Model Name:\t%s\n", m.ModelName)
+	if m.MarketingName != "" {
+		fmt.Fprintf(w, "Marketing:\t%s\n", m.MarketingName)
+	}
+	fmt.Fprintf(w, "Match:\t%s\n", m.MatchPattern)
+	fmt.Fprintf(w, "Region:\t%s\n", m.Region)
+	otherRegion := "No"
+	if m.HasOtherRegion {
+		otherRegion = "Yes"
+	}
+	fmt.Fprintf(w, "Other Region:\t%s\n", otherRegion)
+	if m.Description != "" {
+		fmt.Fprintf(w, "Description:\t%s\n", m.Description)
+	}
+	if m.ContextLength != nil {
+		fmt.Fprintf(w, "Context:\t%s\n", formatInt(m.ContextLength))
+	}
+	if len(m.Capabilities) > 0 {
+		fmt.Fprintf(w, "Capabilities:\t%s\n", strings.Join(m.Capabilities, ", "))
+	}
+	if m.TokenizerID != "" {
+		fmt.Fprintf(w, "Tokenizer:\t%s\n", m.TokenizerID)
+	}
+	if m.CreatedAt != "" {
+		fmt.Fprintf(w, "Created At:\t%s\n", LocalTime(m.CreatedAt))
+	}
+	if m.LastUsed != "" {
+		fmt.Fprintf(w, "Last Used:\t%s\n", LocalTime(m.LastUsed))
+	}
+	if len(m.Prices) > 0 {
+		fmt.Fprintln(w, "Prices:")
+		for _, k := range slices.Sorted(maps.Keys(m.Prices)) {
+			fmt.Fprintf(w, "  %s:\t%s\n", k, strconv.FormatFloat(m.Prices[k], 'f', -1, 64))
+		}
+	}
+	return w.Flush()
+}

--- a/internal/output/models_test.go
+++ b/internal/output/models_test.go
@@ -1,0 +1,81 @@
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
+)
+
+func intPtr(i int) *int { return &i }
+
+func TestPrintRouterModelList(t *testing.T) {
+	tests := []struct {
+		name   string
+		models []clients.RouterModel
+		meta   clients.PageMeta
+		want   string
+	}{
+		{
+			name:   "empty list prints message",
+			models: nil,
+			want:   "No models found.\n",
+		},
+		{
+			name: "single model",
+			models: []clients.RouterModel{
+				{
+					ID:            "m-1",
+					ModelName:     "gpt-4o",
+					ContextLength: intPtr(128000),
+					Region:        "us",
+				},
+			},
+			meta: clients.PageMeta{Page: 1, TotalPages: 1, TotalItems: 1},
+			want: "NAME     CONTEXT   REGION   ID\n" +
+				"gpt-4o   128000    us       m-1\n" +
+				"\nPage 1 of 1 (1 total items)\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := PrintRouterModelList(&buf, tt.models, tt.meta); err != nil {
+				t.Fatalf("PrintRouterModelList() error = %v", err)
+			}
+			if got := buf.String(); got != tt.want {
+				t.Errorf("output mismatch\ngot:\n%q\nwant:\n%q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrintRouterModelDetail(t *testing.T) {
+	var buf bytes.Buffer
+	model := &clients.RouterModel{
+		ID:           "m-1",
+		ModelName:    "gpt-4o",
+		MatchPattern: "gpt-4o*",
+		Region:       "us",
+		Capabilities: []string{"text", "vision"},
+		Prices:       map[string]float64{"input": 0.01, "output": 0.03},
+	}
+	if err := PrintRouterModelDetail(&buf, model); err != nil {
+		t.Fatalf("PrintRouterModelDetail() error = %v", err)
+	}
+	got := buf.String()
+	for _, want := range []string{
+		"ID:             m-1",
+		"Model Name:     gpt-4o",
+		"Capabilities:   text, vision",
+		"Prices:",
+		"  input:    0.01",
+		"  output:   0.03",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q\ngot:\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Adds `models list` and `models get` commands for router models, with input validation and refined output.

- `models list`: table of router models with a 1-indexed pagination footer (endpoint is 0-indexed internally).
- `models get <id>`: aligned detail view; guards against an empty id.
- Validation (`internal/inputs/router_models.go`): page ≥ 0, limit 1–100, region ∈ {us, eu}. This endpoint's paging semantics differ from `ValidatePagination`, so it gets its own validator.

## Test plan
- `go build ./...`
- `go test ./internal/output/ ./internal/inputs/ ./cmd/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)