### PR TITLE
feat: add router command and nest model commands

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.38.1"
+current_version = "0.38.2"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/models.go
+++ b/cmd/models.go
@@ -30,7 +30,6 @@ var modelsCmd = &cobra.Command{
 	Use:              "models",
 	Aliases:          []string{"model"},
 	Short:            "List and inspect models",
-	GroupID:          groupInfra,
 	Long:             `List and inspect router models available to a project.`,
 	PersistentPreRun: chainRootPersistentPreRun,
 }
@@ -40,13 +39,13 @@ var modelsListCmd = &cobra.Command{
 	Aliases: []string{"ls"},
 	Short:   "List router models",
 	Long:    `List router models for a project.`,
-	Example: `  iai models list
-  iai models list -o my-org -p my-project
-  iai models list --page 1 --limit 10
-  iai models list --search claude
-  iai models list --region eu
-  iai models list --json
-  iai models list --yaml`,
+	Example: `  iai router models list
+  iai router models list -o my-org -p my-project
+  iai router models list --page 1 --limit 10
+  iai router models list --search claude
+  iai router models list --region eu
+  iai router models list --json
+  iai router models list --yaml`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
@@ -92,10 +91,10 @@ var modelsGetCmd = &cobra.Command{
 	Aliases: []string{"describe", "desc"},
 	Short:   "Get a router model",
 	Long:    `Get detailed information about a router model by its ID.`,
-	Example: `  iai models get d34313ff-92ce-47ed-a1ae-fbb37f8a9411
-  iai models get d34313ff-92ce-47ed-a1ae-fbb37f8a9411 -o my-org -p my-project
-  iai models get d34313ff-92ce-47ed-a1ae-fbb37f8a9411 --json
-  iai models get d34313ff-92ce-47ed-a1ae-fbb37f8a9411 --yaml`,
+	Example: `  iai router models get d34313ff-92ce-47ed-a1ae-fbb37f8a9411
+  iai router models get d34313ff-92ce-47ed-a1ae-fbb37f8a9411 -o my-org -p my-project
+  iai router models get d34313ff-92ce-47ed-a1ae-fbb37f8a9411 --json
+  iai router models get d34313ff-92ce-47ed-a1ae-fbb37f8a9411 --yaml`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
@@ -152,5 +151,5 @@ func init() {
 	modelsGetCmd.Flags().StringVarP(&modelsGetProject, "project", "p", "", "Project name")
 
 	modelsCmd.AddCommand(modelsListCmd, modelsGetCmd)
-	rootCmd.AddCommand(modelsCmd)
+	routerCmd.AddCommand(modelsCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version            = "0.38.1"
+	version            = "0.38.2"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second

--- a/cmd/router.go
+++ b/cmd/router.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var (
+	routerInfoJSON bool
+	routerInfoYAML bool
+)
+
+var routerCmd = &cobra.Command{
+	Use:     "router",
+	Short:   "Inspect the inference router and its models",
+	GroupID: groupInfra,
+	Long: `Inspect the InteractiveAI inference router and its available models.
+
+Use "iai router info" to display inference endpoint URLs.`,
+}
+
+var routerInfoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Display router endpoint information",
+	Long:  `Display the inference router base URL, endpoints, and documentation URL.`,
+	Example: `  iai router info
+  iai router info --json
+  iai router info --yaml
+  iai router info --hostname https://dev.interactive.ai`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		info, err := output.NewRouterInfo(hostname)
+		if err != nil {
+			return err
+		}
+
+		out := cmd.OutOrStdout()
+		if routerInfoJSON {
+			return output.PrintStructuredJSON(out, info)
+		}
+		if routerInfoYAML {
+			return output.PrintStructuredYAML(out, info)
+		}
+		return output.PrintRouterInfo(out, info)
+	},
+}
+
+func init() {
+	routerInfoCmd.Flags().
+		BoolVar(&routerInfoJSON, "json", false, "Output router information as JSON")
+	routerInfoCmd.Flags().
+		BoolVar(&routerInfoYAML, "yaml", false, "Output router information as YAML")
+	routerInfoCmd.MarkFlagsMutuallyExclusive("json", "yaml")
+
+	routerCmd.AddCommand(routerInfoCmd)
+	rootCmd.AddCommand(routerCmd)
+}

--- a/cmd/router_test.go
+++ b/cmd/router_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRouterCommandPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "router", got: routerCmd.CommandPath(), want: "iai router"},
+		{name: "router info", got: routerInfoCmd.CommandPath(), want: "iai router info"},
+		{name: "models", got: modelsCmd.CommandPath(), want: "iai router models"},
+		{name: "models list", got: modelsListCmd.CommandPath(), want: "iai router models list"},
+		{name: "models get", got: modelsGetCmd.CommandPath(), want: "iai router models get"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := cmp.Diff(tt.want, tt.got); diff != "" {
+				t.Errorf("command path mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRouterUsesDefaultParentHelp(t *testing.T) {
+	got := struct {
+		Runnable       bool
+		HasSubcommands bool
+	}{
+		Runnable:       routerCmd.Runnable(),
+		HasSubcommands: routerCmd.HasSubCommands(),
+	}
+	want := struct {
+		Runnable       bool
+		HasSubcommands bool
+	}{HasSubcommands: true}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("parent behavior mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/docs/iai.md
+++ b/docs/iai.md
@@ -101,7 +101,6 @@ Prompt resources (`prompts`, `routines`, `policies`, `variables`, `glossaries`, 
 * [iai macros](iai_macros.md)	 - Pre-approved response templates used in routines
 * [iai mcps](iai_mcps.md)	 - Deploy and manage MCP servers
 * [iai metrics](iai_metrics.md)	 - Query aggregated observability metrics
-* [iai models](iai_models.md)	 - List and inspect models
 * [iai observations](iai_observations.md)	 - Inspect spans within traces
 * [iai organizations](iai_organizations.md)	 - Switch or list organizations
 * [iai policies](iai_policies.md)	 - Single-step behavioral rules for agents
@@ -110,6 +109,7 @@ Prompt resources (`prompts`, `routines`, `policies`, `variables`, `glossaries`, 
 * [iai queue-items](iai_queue-items.md)	 - Manage items in annotation queues
 * [iai queues](iai_queues.md)	 - Annotation queues for human review workflows
 * [iai replicas](iai_replicas.md)	 - Inspect service replicas
+* [iai router](iai_router.md)	 - Inspect the inference router and its models
 * [iai router-keys](iai_router-keys.md)	 - Router API keys
 * [iai routines](iai_routines.md)	 - Multi-step behavioral processes for agents
 * [iai run-items](iai_run-items.md)	 - Inspect results of evaluation runs

--- a/docs/iai_router.md
+++ b/docs/iai_router.md
@@ -1,15 +1,17 @@
-## iai models
+## iai router
 
-List and inspect models
+Inspect the inference router and its models
 
 ### Synopsis
 
-List and inspect router models available to a project.
+Inspect the InteractiveAI inference router and its available models.
+
+Use "iai router info" to display inference endpoint URLs.
 
 ### Options
 
 ```
-  -h, --help   help for models
+  -h, --help   help for router
 ```
 
 ### Options inherited from parent commands
@@ -24,6 +26,6 @@ List and inspect router models available to a project.
 ### SEE ALSO
 
 * [iai](iai.md)	 - InteractiveAI's CLI
-* [iai models get](iai_models_get.md)	 - Get a router model
-* [iai models list](iai_models_list.md)	 - List router models
+* [iai router info](iai_router_info.md)	 - Display router endpoint information
+* [iai router models](iai_router_models.md)	 - List and inspect models
 

--- a/docs/iai_router_info.md
+++ b/docs/iai_router_info.md
@@ -1,0 +1,42 @@
+## iai router info
+
+Display router endpoint information
+
+### Synopsis
+
+Display the inference router base URL, endpoints, and documentation URL.
+
+```
+iai router info [flags]
+```
+
+### Examples
+
+```
+  iai router info
+  iai router info --json
+  iai router info --yaml
+  iai router info --hostname https://dev.interactive.ai
+```
+
+### Options
+
+```
+  -h, --help   help for info
+      --json   Output router information as JSON
+      --yaml   Output router information as YAML
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai router](iai_router.md)	 - Inspect the inference router and its models
+

--- a/docs/iai_router_models.md
+++ b/docs/iai_router_models.md
@@ -1,0 +1,29 @@
+## iai router models
+
+List and inspect models
+
+### Synopsis
+
+List and inspect router models available to a project.
+
+### Options
+
+```
+  -h, --help   help for models
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai router](iai_router.md)	 - Inspect the inference router and its models
+* [iai router models get](iai_router_models_get.md)	 - Get a router model
+* [iai router models list](iai_router_models_list.md)	 - List router models
+

--- a/docs/iai_router_models_get.md
+++ b/docs/iai_router_models_get.md
@@ -1,4 +1,4 @@
-## iai models get
+## iai router models get
 
 Get a router model
 
@@ -7,16 +7,16 @@ Get a router model
 Get detailed information about a router model by its ID.
 
 ```
-iai models get <id> [flags]
+iai router models get <id> [flags]
 ```
 
 ### Examples
 
 ```
-  iai models get d34313ff-92ce-47ed-a1ae-fbb37f8a9411
-  iai models get d34313ff-92ce-47ed-a1ae-fbb37f8a9411 -o my-org -p my-project
-  iai models get d34313ff-92ce-47ed-a1ae-fbb37f8a9411 --json
-  iai models get d34313ff-92ce-47ed-a1ae-fbb37f8a9411 --yaml
+  iai router models get d34313ff-92ce-47ed-a1ae-fbb37f8a9411
+  iai router models get d34313ff-92ce-47ed-a1ae-fbb37f8a9411 -o my-org -p my-project
+  iai router models get d34313ff-92ce-47ed-a1ae-fbb37f8a9411 --json
+  iai router models get d34313ff-92ce-47ed-a1ae-fbb37f8a9411 --yaml
 ```
 
 ### Options
@@ -40,5 +40,5 @@ iai models get <id> [flags]
 
 ### SEE ALSO
 
-* [iai models](iai_models.md)	 - List and inspect models
+* [iai router models](iai_router_models.md)	 - List and inspect models
 

--- a/docs/iai_router_models_list.md
+++ b/docs/iai_router_models_list.md
@@ -1,4 +1,4 @@
-## iai models list
+## iai router models list
 
 List router models
 
@@ -7,19 +7,19 @@ List router models
 List router models for a project.
 
 ```
-iai models list [flags]
+iai router models list [flags]
 ```
 
 ### Examples
 
 ```
-  iai models list
-  iai models list -o my-org -p my-project
-  iai models list --page 1 --limit 10
-  iai models list --search claude
-  iai models list --region eu
-  iai models list --json
-  iai models list --yaml
+  iai router models list
+  iai router models list -o my-org -p my-project
+  iai router models list --page 1 --limit 10
+  iai router models list --search claude
+  iai router models list --region eu
+  iai router models list --json
+  iai router models list --yaml
 ```
 
 ### Options
@@ -47,5 +47,5 @@ iai models list [flags]
 
 ### SEE ALSO
 
-* [iai models](iai_models.md)	 - List and inspect models
+* [iai router models](iai_router_models.md)	 - List and inspect models
 

--- a/internal/output/router.go
+++ b/internal/output/router.go
@@ -1,0 +1,118 @@
+package output
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+)
+
+const routerDocumentationURL = "https://docs.interactive.ai/llm-router"
+
+type RouterEndpoint struct {
+	Method      string `json:"method"`
+	URL         string `json:"url"`
+	Description string `json:"description"`
+}
+
+type RouterEndpoints struct {
+	ChatCompletions RouterEndpoint `json:"chatCompletions"`
+	Responses       RouterEndpoint `json:"responses"`
+	Embeddings      RouterEndpoint `json:"embeddings"`
+	Rerank          RouterEndpoint `json:"rerank"`
+	Models          RouterEndpoint `json:"models"`
+	Health          RouterEndpoint `json:"health"`
+}
+
+type RouterInfo struct {
+	BaseURL          string          `json:"baseUrl"`
+	Endpoints        RouterEndpoints `json:"endpoints"`
+	DocumentationURL string          `json:"documentationUrl"`
+}
+
+func NewRouterInfo(hostname string) (RouterInfo, error) {
+	u, err := url.Parse(hostname)
+	if err != nil {
+		return RouterInfo{}, fmt.Errorf("failed to parse API hostname %q: %w", hostname, err)
+	}
+	if (u.Scheme != "http" && u.Scheme != "https") ||
+		u.Host == "" ||
+		u.User != nil ||
+		(u.Path != "" && u.Path != "/") ||
+		u.RawQuery != "" ||
+		u.Fragment != "" {
+		return RouterInfo{}, fmt.Errorf("invalid API hostname %q", hostname)
+	}
+
+	u.Path = ""
+	baseURL := u.JoinPath("api", "v1").String()
+	endpoint := func(method, path, description string) RouterEndpoint {
+		return RouterEndpoint{
+			Method:      method,
+			URL:         baseURL + path,
+			Description: description,
+		}
+	}
+
+	return RouterInfo{
+		BaseURL: baseURL,
+		Endpoints: RouterEndpoints{
+			ChatCompletions: endpoint(
+				"POST",
+				"/chat/completions",
+				"Generate chat responses, optionally returning them as they are created.",
+			),
+			Responses: endpoint(
+				"POST",
+				"/responses",
+				"Generate model responses from text, messages, or tool results.",
+			),
+			Embeddings: endpoint(
+				"POST",
+				"/embeddings",
+				"Convert text into numbers that can be compared by meaning.",
+			),
+			Rerank: endpoint(
+				"POST",
+				"/rerank",
+				"Sort candidate documents by their relevance to a query.",
+			),
+			Models: endpoint(
+				"GET",
+				"/models",
+				"List models available for the request region.",
+			),
+			Health: endpoint(
+				"GET",
+				"/health/openrouter",
+				"Check whether the inference router is healthy.",
+			),
+		},
+		DocumentationURL: routerDocumentationURL,
+	}, nil
+}
+
+func PrintRouterInfo(out io.Writer, info RouterInfo) error {
+	w := NewDescribeWriter(out)
+	fmt.Fprintf(w, "Base URL:\t%s\n", info.BaseURL)
+	fmt.Fprintf(w, "Documentation:\t%s\n", info.DocumentationURL)
+	fmt.Fprintln(w, "Endpoints:")
+
+	endpoints := []struct {
+		name     string
+		endpoint RouterEndpoint
+	}{
+		{"Chat Completions", info.Endpoints.ChatCompletions},
+		{"Responses", info.Endpoints.Responses},
+		{"Embeddings", info.Endpoints.Embeddings},
+		{"Rerank", info.Endpoints.Rerank},
+		{"Models", info.Endpoints.Models},
+		{"Health", info.Endpoints.Health},
+	}
+	for _, item := range endpoints {
+		fmt.Fprintf(w, "  %s:\n", item.name)
+		fmt.Fprintf(w, "    Method:\t%s\n", item.endpoint.Method)
+		fmt.Fprintf(w, "    URL:\t%s\n", item.endpoint.URL)
+		fmt.Fprintf(w, "    Description:\t%s\n", item.endpoint.Description)
+	}
+	return w.Flush()
+}

--- a/internal/output/router_test.go
+++ b/internal/output/router_test.go
@@ -1,0 +1,142 @@
+package output
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNewRouterInfo(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "production",
+			input: "https://app.interactive.ai",
+			want:  "https://app.interactive.ai/api/v1",
+		},
+		{
+			name:  "trailing slash",
+			input: "https://dev.interactive.ai/",
+			want:  "https://dev.interactive.ai/api/v1",
+		},
+		{name: "missing scheme", input: "app.interactive.ai", wantErr: true},
+		{name: "path", input: "https://app.interactive.ai/root", wantErr: true},
+		{name: "query string", input: "https://app.interactive.ai?region=eu", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewRouterInfo(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NewRouterInfo() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if diff := cmp.Diff(tt.want, got.BaseURL); diff != "" {
+				t.Errorf("base URL mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPrintRouterInfo(t *testing.T) {
+	info, err := NewRouterInfo("https://app.interactive.ai")
+	if err != nil {
+		t.Fatalf("NewRouterInfo() error = %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		print func(*bytes.Buffer) error
+		want  string
+	}{
+		{
+			name:  "human readable",
+			print: func(out *bytes.Buffer) error { return PrintRouterInfo(out, info) },
+			want: `Base URL:        https://app.interactive.ai/api/v1
+Documentation:   https://docs.interactive.ai/llm-router
+Endpoints:
+  Chat Completions:
+    Method:        POST
+    URL:           https://app.interactive.ai/api/v1/chat/completions
+    Description:   Generate chat responses, optionally returning them as they are created.
+  Responses:
+    Method:        POST
+    URL:           https://app.interactive.ai/api/v1/responses
+    Description:   Generate model responses from text, messages, or tool results.
+  Embeddings:
+    Method:        POST
+    URL:           https://app.interactive.ai/api/v1/embeddings
+    Description:   Convert text into numbers that can be compared by meaning.
+  Rerank:
+    Method:        POST
+    URL:           https://app.interactive.ai/api/v1/rerank
+    Description:   Sort candidate documents by their relevance to a query.
+  Models:
+    Method:        GET
+    URL:           https://app.interactive.ai/api/v1/models
+    Description:   List models available for the request region.
+  Health:
+    Method:        GET
+    URL:           https://app.interactive.ai/api/v1/health/openrouter
+    Description:   Check whether the inference router is healthy.
+`,
+		},
+		{
+			name:  "JSON",
+			print: func(out *bytes.Buffer) error { return PrintStructuredJSON(out, info) },
+			want: `{
+  "baseUrl": "https://app.interactive.ai/api/v1",
+  "endpoints": {
+    "chatCompletions": {
+      "method": "POST",
+      "url": "https://app.interactive.ai/api/v1/chat/completions",
+      "description": "Generate chat responses, optionally returning them as they are created."
+    },
+    "responses": {
+      "method": "POST",
+      "url": "https://app.interactive.ai/api/v1/responses",
+      "description": "Generate model responses from text, messages, or tool results."
+    },
+    "embeddings": {
+      "method": "POST",
+      "url": "https://app.interactive.ai/api/v1/embeddings",
+      "description": "Convert text into numbers that can be compared by meaning."
+    },
+    "rerank": {
+      "method": "POST",
+      "url": "https://app.interactive.ai/api/v1/rerank",
+      "description": "Sort candidate documents by their relevance to a query."
+    },
+    "models": {
+      "method": "GET",
+      "url": "https://app.interactive.ai/api/v1/models",
+      "description": "List models available for the request region."
+    },
+    "health": {
+      "method": "GET",
+      "url": "https://app.interactive.ai/api/v1/health/openrouter",
+      "description": "Check whether the inference router is healthy."
+    }
+  },
+  "documentationUrl": "https://docs.interactive.ai/llm-router"
+}
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			if err := tt.print(&out); err != nil {
+				t.Fatalf("print() error = %v", err)
+			}
+			if diff := cmp.Diff(tt.want, out.String()); diff != "" {
+				t.Errorf("output mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add `iai router` as the parent for router discovery and model commands
- add `iai router info` with human, `--json`, and `--yaml` endpoint output derived from `--hostname`
- move `iai models list/get` to `iai router models list/get`
- regenerate CLI documentation for the new command paths

## Commands

```bash
iai router                          # parent help
iai router info                     # human-readable endpoint details
iai router info --json              # machine-readable endpoint details
iai router info --yaml
iai router models list
iai router models get <id>
```

## UX decision

`iai router` keeps Cobra's default parent behavior and prints help. `iai router info` provides endpoint URLs in human- and machine-readable formats.

## Breaking change

The top-level `iai models` path is removed. Its replacement is `iai router models`.

## Version

Rebased onto `main` at `v0.38.1` and bumped to `v0.38.2` after approval. The tag will be created automatically after merge.

## Verification

- `pre-commit run --from-ref origin/main --to-ref HEAD`
- `go test ./...`
- `make docs`
- `go run . router`
- `go run . router info --hostname https://dev.interactive.ai --json`
- `go run . router models list --hostname https://dev.interactive.ai --deployment-hostname https://deployment.dev.interactive.ai -o platform-development -p dgallego --limit 1 --json`
