### PR TITLE
refactor: move router keys under router command

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.38.2"
+current_version = "0.38.3"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/api_keys.go
+++ b/cmd/api_keys.go
@@ -255,10 +255,9 @@ var apiKeysDeleteCmd = &cobra.Command{
 }
 
 var routerKeysCmd = &cobra.Command{
-	Use:     "router-keys",
-	Aliases: []string{"router-key"},
+	Use:     "keys",
+	Aliases: []string{"key"},
 	Short:   "Router API keys",
-	GroupID: groupAuth,
 	Long: `Manage InteractiveAI Router API keys. Requires iai login or JWT authentication. API key authentication is not supported.
 
 Router keys authenticate inference requests to the InteractiveAI Router, for example chat completions and model calls. They are used as bearer tokens for runtime inference, not for managing project context or infrastructure.`,
@@ -478,7 +477,7 @@ var routerKeysDeleteCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(apiKeysCmd, routerKeysCmd)
+	rootCmd.AddCommand(apiKeysCmd)
 
 	for _, c := range []*cobra.Command{apiKeysListCmd, apiKeysCreateCmd, apiKeysUpdateCmd, apiKeysDeleteCmd} {
 		c.Flags().StringVarP(&apiKeysProject, "project", "p", "", "Project name")
@@ -528,4 +527,5 @@ func init() {
 		routerKeysUpdateCmd,
 		routerKeysDeleteCmd,
 	)
+	routerCmd.AddCommand(routerKeysCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version            = "0.38.2"
+	version            = "0.38.3"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second

--- a/cmd/router.go
+++ b/cmd/router.go
@@ -12,9 +12,9 @@ var (
 
 var routerCmd = &cobra.Command{
 	Use:     "router",
-	Short:   "Inspect the inference router and its models",
+	Short:   "Inspect the inference router, keys, and models",
 	GroupID: groupInfra,
-	Long: `Inspect the InteractiveAI inference router and its available models.
+	Long: `Inspect the InteractiveAI inference router, manage its API keys, and browse available models.
 
 Use "iai router info" to display inference endpoint URLs.`,
 }

--- a/cmd/router_test.go
+++ b/cmd/router_test.go
@@ -14,6 +14,23 @@ func TestRouterCommandPaths(t *testing.T) {
 	}{
 		{name: "router", got: routerCmd.CommandPath(), want: "iai router"},
 		{name: "router info", got: routerInfoCmd.CommandPath(), want: "iai router info"},
+		{name: "keys", got: routerKeysCmd.CommandPath(), want: "iai router keys"},
+		{name: "keys list", got: routerKeysListCmd.CommandPath(), want: "iai router keys list"},
+		{
+			name: "keys create",
+			got:  routerKeysCreateCmd.CommandPath(),
+			want: "iai router keys create",
+		},
+		{
+			name: "keys update",
+			got:  routerKeysUpdateCmd.CommandPath(),
+			want: "iai router keys update",
+		},
+		{
+			name: "keys delete",
+			got:  routerKeysDeleteCmd.CommandPath(),
+			want: "iai router keys delete",
+		},
 		{name: "models", got: modelsCmd.CommandPath(), want: "iai router models"},
 		{name: "models list", got: modelsListCmd.CommandPath(), want: "iai router models list"},
 		{name: "models get", got: modelsGetCmd.CommandPath(), want: "iai router models get"},
@@ -28,7 +45,7 @@ func TestRouterCommandPaths(t *testing.T) {
 	}
 }
 
-func TestRouterUsesDefaultParentHelp(t *testing.T) {
+func TestRouterCmdIsNonRunnableParent(t *testing.T) {
 	got := struct {
 		Runnable       bool
 		HasSubcommands bool

--- a/docs/iai.md
+++ b/docs/iai.md
@@ -109,8 +109,7 @@ Prompt resources (`prompts`, `routines`, `policies`, `variables`, `glossaries`, 
 * [iai queue-items](iai_queue-items.md)	 - Manage items in annotation queues
 * [iai queues](iai_queues.md)	 - Annotation queues for human review workflows
 * [iai replicas](iai_replicas.md)	 - Inspect service replicas
-* [iai router](iai_router.md)	 - Inspect the inference router and its models
-* [iai router-keys](iai_router-keys.md)	 - Router API keys
+* [iai router](iai_router.md)	 - Inspect the inference router, keys, and models
 * [iai routines](iai_routines.md)	 - Multi-step behavioral processes for agents
 * [iai run-items](iai_run-items.md)	 - Inspect results of evaluation runs
 * [iai score-configs](iai_score-configs.md)	 - Define scoring schemas for evaluation

--- a/docs/iai_router.md
+++ b/docs/iai_router.md
@@ -1,10 +1,10 @@
 ## iai router
 
-Inspect the inference router and its models
+Inspect the inference router, keys, and models
 
 ### Synopsis
 
-Inspect the InteractiveAI inference router and its available models.
+Inspect the InteractiveAI inference router, manage its API keys, and browse available models.
 
 Use "iai router info" to display inference endpoint URLs.
 
@@ -27,5 +27,6 @@ Use "iai router info" to display inference endpoint URLs.
 
 * [iai](iai.md)	 - InteractiveAI's CLI
 * [iai router info](iai_router_info.md)	 - Display router endpoint information
+* [iai router keys](iai_router_keys.md)	 - Router API keys
 * [iai router models](iai_router_models.md)	 - List and inspect models
 

--- a/docs/iai_router_info.md
+++ b/docs/iai_router_info.md
@@ -38,5 +38,5 @@ iai router info [flags]
 
 ### SEE ALSO
 
-* [iai router](iai_router.md)	 - Inspect the inference router and its models
+* [iai router](iai_router.md)	 - Inspect the inference router, keys, and models
 

--- a/docs/iai_router_keys.md
+++ b/docs/iai_router_keys.md
@@ -1,4 +1,4 @@
-## iai router-keys
+## iai router keys
 
 Router API keys
 
@@ -11,7 +11,7 @@ Router keys authenticate inference requests to the InteractiveAI Router, for exa
 ### Options
 
 ```
-  -h, --help   help for router-keys
+  -h, --help   help for keys
 ```
 
 ### Options inherited from parent commands
@@ -25,9 +25,9 @@ Router keys authenticate inference requests to the InteractiveAI Router, for exa
 
 ### SEE ALSO
 
-* [iai](iai.md)	 - InteractiveAI's CLI
-* [iai router-keys create](iai_router-keys_create.md)	 - Create a router API key
-* [iai router-keys delete](iai_router-keys_delete.md)	 - Delete a router API key
-* [iai router-keys list](iai_router-keys_list.md)	 - List router API keys
-* [iai router-keys update](iai_router-keys_update.md)	 - Update a router API key
+* [iai router](iai_router.md)	 - Inspect the inference router, keys, and models
+* [iai router keys create](iai_router_keys_create.md)	 - Create a router API key
+* [iai router keys delete](iai_router_keys_delete.md)	 - Delete a router API key
+* [iai router keys list](iai_router_keys_list.md)	 - List router API keys
+* [iai router keys update](iai_router_keys_update.md)	 - Update a router API key
 

--- a/docs/iai_router_keys_create.md
+++ b/docs/iai_router_keys_create.md
@@ -1,4 +1,4 @@
-## iai router-keys create
+## iai router keys create
 
 Create a router API key
 
@@ -9,7 +9,7 @@ Create a router API key.
 Router keys authenticate inference requests to the InteractiveAI Router, for example chat completions and model calls. They are used as bearer tokens for runtime inference, not for managing project context or infrastructure.
 
 ```
-iai router-keys create <name> [flags]
+iai router keys create <name> [flags]
 ```
 
 ### Options
@@ -37,5 +37,5 @@ iai router-keys create <name> [flags]
 
 ### SEE ALSO
 
-* [iai router-keys](iai_router-keys.md)	 - Router API keys
+* [iai router keys](iai_router_keys.md)	 - Router API keys
 

--- a/docs/iai_router_keys_delete.md
+++ b/docs/iai_router_keys_delete.md
@@ -1,21 +1,16 @@
-## iai router-keys update
+## iai router keys delete
 
-Update a router API key
+Delete a router API key
 
 ```
-iai router-keys update <id> [flags]
+iai router keys delete <id> [flags]
 ```
 
 ### Options
 
 ```
-      --clear-limit           Remove the credit limit
-      --disable               Disable this key
-      --enable                Enable this key
-  -h, --help                  help for update
+  -h, --help                  help for delete
       --json                  Output response as JSON
-      --limit float           Credit limit in USD
-      --limit-reset string    Limit reset period: none, daily, weekly, monthly
   -o, --organization string   Organization name
   -p, --project string        Project name
       --yaml                  Output response as YAML
@@ -32,5 +27,5 @@ iai router-keys update <id> [flags]
 
 ### SEE ALSO
 
-* [iai router-keys](iai_router-keys.md)	 - Router API keys
+* [iai router keys](iai_router_keys.md)	 - Router API keys
 

--- a/docs/iai_router_keys_list.md
+++ b/docs/iai_router_keys_list.md
@@ -1,15 +1,17 @@
-## iai router-keys delete
+## iai router keys list
 
-Delete a router API key
+List router API keys
 
 ```
-iai router-keys delete <id> [flags]
+iai router keys list [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help                  help for delete
+      --columns strings       Columns to display for table output only (comma-separated, default: id,name,key,limit,created_at). Cannot be used with --json or --yaml.
+                              Available: id,name,description,status,key,disabled,limit,remaining,limit_reset,expires_at,last_used_at,created_at,updated_at,project_id,user_id
+  -h, --help                  help for list
       --json                  Output response as JSON
   -o, --organization string   Organization name
   -p, --project string        Project name
@@ -27,5 +29,5 @@ iai router-keys delete <id> [flags]
 
 ### SEE ALSO
 
-* [iai router-keys](iai_router-keys.md)	 - Router API keys
+* [iai router keys](iai_router_keys.md)	 - Router API keys
 

--- a/docs/iai_router_keys_update.md
+++ b/docs/iai_router_keys_update.md
@@ -1,18 +1,21 @@
-## iai router-keys list
+## iai router keys update
 
-List router API keys
+Update a router API key
 
 ```
-iai router-keys list [flags]
+iai router keys update <id> [flags]
 ```
 
 ### Options
 
 ```
-      --columns strings       Columns to display for table output only (comma-separated, default: id,name,key,limit,created_at). Cannot be used with --json or --yaml.
-                              Available: id,name,description,status,key,disabled,limit,remaining,limit_reset,expires_at,last_used_at,created_at,updated_at,project_id,user_id
-  -h, --help                  help for list
+      --clear-limit           Remove the credit limit
+      --disable               Disable this key
+      --enable                Enable this key
+  -h, --help                  help for update
       --json                  Output response as JSON
+      --limit float           Credit limit in USD
+      --limit-reset string    Limit reset period: none, daily, weekly, monthly
   -o, --organization string   Organization name
   -p, --project string        Project name
       --yaml                  Output response as YAML
@@ -29,5 +32,5 @@ iai router-keys list [flags]
 
 ### SEE ALSO
 
-* [iai router-keys](iai_router-keys.md)	 - Router API keys
+* [iai router keys](iai_router_keys.md)	 - Router API keys
 

--- a/docs/iai_router_models.md
+++ b/docs/iai_router_models.md
@@ -23,7 +23,7 @@ List and inspect router models available to a project.
 
 ### SEE ALSO
 
-* [iai router](iai_router.md)	 - Inspect the inference router and its models
+* [iai router](iai_router.md)	 - Inspect the inference router, keys, and models
 * [iai router models get](iai_router_models_get.md)	 - Get a router model
 * [iai router models list](iai_router_models_list.md)	 - List router models
 


### PR DESCRIPTION
## Summary

- move `iai router-keys` to `iai router keys`
- keep the existing `list`, `create`, `update`, and `delete` behavior and flags unchanged
- add `key` as the singular alias for the new `keys` parent
- regenerate CLI documentation for the new command paths

## Commands

```bash
iai router keys list
iai router keys create <name>
iai router keys update <id>
iai router keys delete <id>
```

## Breaking change

The top-level `iai router-keys` path is removed. Its replacement is `iai router keys`.

## Version

Based on `v0.38.2` and bumped to `v0.38.3` after approval. The tag will be created automatically after merge.

## Verification

- `pre-commit run`
- `go test ./...`
- `make docs`
- `go run . router`
- `go run . router keys --help`
- confirmed `go run . router-keys --help` returns an unknown-command error
