### PR TITLE
fix(DEV-868): update router-key endpoints to renamed platform paths

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.38.3"
+current_version = "0.38.4"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version            = "0.38.3"
+	version            = "0.38.4"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second

--- a/internal/clients/api_client_keys.go
+++ b/internal/clients/api_client_keys.go
@@ -204,7 +204,7 @@ func (c *APIClient) ListRouterAPIKeys(
 		return RouterAPIKeyListResponse{}, err
 	}
 
-	path := fmt.Sprintf("/api/v1/projects/%s/openrouter-keys", url.PathEscape(projectID))
+	path := fmt.Sprintf("/api/v1/projects/%s/router-keys", url.PathEscape(projectID))
 	req, err := c.newRequest(ctx, http.MethodGet, path)
 	if err != nil {
 		return RouterAPIKeyListResponse{}, err
@@ -229,7 +229,7 @@ func (c *APIClient) CreateRouterAPIKey(
 		return CreateRouterAPIKeyResponse{}, err
 	}
 
-	path := fmt.Sprintf("/api/v1/projects/%s/openrouter-keys", url.PathEscape(projectID))
+	path := fmt.Sprintf("/api/v1/projects/%s/router-keys", url.PathEscape(projectID))
 	req, err := c.newJSONRequest(ctx, http.MethodPost, path, body)
 	if err != nil {
 		return CreateRouterAPIKeyResponse{}, err
@@ -247,7 +247,7 @@ func (c *APIClient) CreateRouterAPIKey(
 
 func routerAPIKeyPath(projectID, keyID string) string {
 	return fmt.Sprintf(
-		"/api/v1/projects/%s/openrouter-keys/%s",
+		"/api/v1/projects/%s/router-keys/%s",
 		url.PathEscape(projectID),
 		url.PathEscape(keyID),
 	)

--- a/internal/clients/api_client_keys.go
+++ b/internal/clients/api_client_keys.go
@@ -204,8 +204,7 @@ func (c *APIClient) ListRouterAPIKeys(
 		return RouterAPIKeyListResponse{}, err
 	}
 
-	path := fmt.Sprintf("/api/v1/projects/%s/router-keys", url.PathEscape(projectID))
-	req, err := c.newRequest(ctx, http.MethodGet, path)
+	req, err := c.newRequest(ctx, http.MethodGet, routerAPIKeysPath(projectID))
 	if err != nil {
 		return RouterAPIKeyListResponse{}, err
 	}
@@ -229,8 +228,7 @@ func (c *APIClient) CreateRouterAPIKey(
 		return CreateRouterAPIKeyResponse{}, err
 	}
 
-	path := fmt.Sprintf("/api/v1/projects/%s/router-keys", url.PathEscape(projectID))
-	req, err := c.newJSONRequest(ctx, http.MethodPost, path, body)
+	req, err := c.newJSONRequest(ctx, http.MethodPost, routerAPIKeysPath(projectID), body)
 	if err != nil {
 		return CreateRouterAPIKeyResponse{}, err
 	}
@@ -243,6 +241,10 @@ func (c *APIClient) CreateRouterAPIKey(
 		return CreateRouterAPIKeyResponse{}, fmt.Errorf("failed to decode router key: %w", err)
 	}
 	return res, nil
+}
+
+func routerAPIKeysPath(projectID string) string {
+	return fmt.Sprintf("/api/v1/projects/%s/router-keys", url.PathEscape(projectID))
 }
 
 func routerAPIKeyPath(projectID, keyID string) string {

--- a/internal/clients/api_client_keys_test.go
+++ b/internal/clients/api_client_keys_test.go
@@ -98,6 +98,25 @@ func TestRouterAPIKeyPath(t *testing.T) {
 	}
 }
 
+func TestRouterAPIKeysPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		projectID string
+		want      string
+	}{
+		{name: "plain id", projectID: "project-1", want: "/api/v1/projects/project-1/router-keys"},
+		{name: "escapes path segment", projectID: "project 1", want: "/api/v1/projects/project%201/router-keys"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := routerAPIKeysPath(tt.projectID); got != tt.want {
+				t.Fatalf("routerAPIKeysPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRequireKeyManagementAuth(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/clients/api_client_keys_test.go
+++ b/internal/clients/api_client_keys_test.go
@@ -79,13 +79,13 @@ func TestRouterAPIKeyPath(t *testing.T) {
 			name:      "plain ids",
 			projectID: "project-1",
 			keyID:     "key-1",
-			want:      "/api/v1/projects/project-1/openrouter-keys/key-1",
+			want:      "/api/v1/projects/project-1/router-keys/key-1",
 		},
 		{
 			name:      "escapes path segments",
 			projectID: "project 1",
 			keyID:     "key/1",
-			want:      "/api/v1/projects/project%201/openrouter-keys/key%2F1",
+			want:      "/api/v1/projects/project%201/router-keys/key%2F1",
 		},
 	}
 

--- a/internal/clients/api_client_keys_test.go
+++ b/internal/clients/api_client_keys_test.go
@@ -105,7 +105,11 @@ func TestRouterAPIKeysPath(t *testing.T) {
 		want      string
 	}{
 		{name: "plain id", projectID: "project-1", want: "/api/v1/projects/project-1/router-keys"},
-		{name: "escapes path segment", projectID: "project 1", want: "/api/v1/projects/project%201/router-keys"},
+		{
+			name:      "escapes path segment",
+			projectID: "project 1",
+			want:      "/api/v1/projects/project%201/router-keys",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/output/router.go
+++ b/internal/output/router.go
@@ -83,7 +83,7 @@ func NewRouterInfo(hostname string) (RouterInfo, error) {
 			),
 			Health: endpoint(
 				"GET",
-				"/health/openrouter",
+				"/health/llm-router",
 				"Check whether the inference router is healthy.",
 			),
 		},

--- a/internal/output/router_test.go
+++ b/internal/output/router_test.go
@@ -81,7 +81,7 @@ Endpoints:
     Description:   List models available for the request region.
   Health:
     Method:        GET
-    URL:           https://app.interactive.ai/api/v1/health/openrouter
+    URL:           https://app.interactive.ai/api/v1/health/llm-router
     Description:   Check whether the inference router is healthy.
 `,
 		},
@@ -118,7 +118,7 @@ Endpoints:
     },
     "health": {
       "method": "GET",
-      "url": "https://app.interactive.ai/api/v1/health/openrouter",
+      "url": "https://app.interactive.ai/api/v1/health/llm-router",
       "description": "Check whether the inference router is healthy."
     }
   },


### PR DESCRIPTION
## What

The platform renamed its FE-visible API surface `openrouter` → `router` (platform PR #1266). This CLI calls the renamed paths, so it must move in lockstep:

- `/api/v1/projects/{id}/openrouter-keys` → `/router-keys` (`api_client_keys.go`)
- `/api/v1/health/openrouter` → `/health/llm-router` (`output/router.go`)

Plus the matching test expectations.

## ⚠️ Deploy coupling

The platform rename has **no back-compat aliases** — old paths are deleted, not aliased. So:

- **Do not merge/release this before** the platform backend with the renamed paths is deployed, **or**
- coordinate a lockstep deploy.

Merging this first would break the CLI against today's production backend (which still serves `/openrouter-keys`). Kept as a **draft** until the backend rollout is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)