### PR TITLE
feat(mcps): surface a tool's JSON-RPC error from run-tool and exit non-zero (DEV-840)

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.38.4"
+current_version = "0.38.5"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/mcps.go
+++ b/cmd/mcps.go
@@ -481,8 +481,8 @@ var mcpRunToolCmd = &cobra.Command{
 	Long: `Call one of an mcp's tools and print the result.
 
 Pass arguments as a JSON object with --args or --args-file (mutually exclusive);
-omit both to send an empty object. Works for external mcps from anywhere;
-internal mcps need the in-cluster operator.`,
+omit both to send an empty object. If the tool itself returns an error, it is
+reported and the command exits non-zero.`,
 	Example: `  iai mcps run-tool github search_repositories --args '{"query":"interactiveai"}'
   iai mcps run-tool github search_repositories --args-file ./args.json`,
 	Args: cobra.ExactArgs(2),
@@ -506,6 +506,12 @@ internal mcps need the in-cluster operator.`,
 		)
 		if err != nil {
 			return err
+		}
+		if res.Error != nil {
+			return fmt.Errorf(
+				"mcp %q tool %q returned an error (JSON-RPC %d): %s",
+				mcpName, tool, res.Error.Code, res.Error.Message,
+			)
 		}
 		return output.PrintRawJSON(out, res.Result)
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version            = "0.38.4"
+	version            = "0.38.5"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second

--- a/docs/iai_mcps_run-tool.md
+++ b/docs/iai_mcps_run-tool.md
@@ -7,8 +7,8 @@ Run a tool on an mcp
 Call one of an mcp's tools and print the result.
 
 Pass arguments as a JSON object with --args or --args-file (mutually exclusive);
-omit both to send an empty object. Works for external mcps from anywhere;
-internal mcps need the in-cluster operator.
+omit both to send an empty object. If the tool itself returns an error, it is
+reported and the command exits non-zero.
 
 ```
 iai mcps run-tool <mcp_name> <tool_name> [flags]

--- a/internal/clients/api_client_mcp_test.go
+++ b/internal/clients/api_client_mcp_test.go
@@ -1,8 +1,47 @@
 package clients
 
 import (
+	"encoding/json"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
+
+func TestDecodeRunMcpToolResult(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		wantError  *McpToolError
+		wantResult bool
+	}{
+		{
+			name:       "error body populates Error, not Result",
+			body:       `{"mcp":"socket","tool":"depscore","error":{"code":-32603,"message":"boom"}}`,
+			wantError:  &McpToolError{Code: -32603, Message: "boom"},
+			wantResult: false,
+		},
+		{
+			name:       "success body populates Result, not Error",
+			body:       `{"mcp":"socket","tool":"depscore","result":{"ok":true}}`,
+			wantError:  nil,
+			wantResult: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var res RunMcpToolResult
+			if err := json.Unmarshal([]byte(tt.body), &res); err != nil {
+				t.Fatalf("decode error: %v", err)
+			}
+			if diff := cmp.Diff(tt.wantError, res.Error); diff != "" {
+				t.Errorf("Error mismatch (-want +got):\n%s", diff)
+			}
+			if hasResult := len(res.Result) > 0; hasResult != tt.wantResult {
+				t.Errorf("has Result = %v, want %v", hasResult, tt.wantResult)
+			}
+		})
+	}
+}
 
 func TestDecodeMcpCatalog(t *testing.T) {
 	data, err := decodeSuccess[McpCatalogListData](

--- a/internal/clients/deployment_client_mcps.go
+++ b/internal/clients/deployment_client_mcps.go
@@ -107,6 +107,13 @@ type RunMcpToolResult struct {
 	Tool string `json:"tool"`
 	// kept raw: a tool may return an object, array, or scalar at the top level
 	Result json.RawMessage `json:"result,omitempty"`
+	// Error is set instead of Result when the MCP reached but returned a JSON-RPC error.
+	Error *McpToolError `json:"error,omitempty"`
+}
+
+type McpToolError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
 }
 
 type verifyMcpResponse struct {


### PR DESCRIPTION
## Context

Pairs with deployment-operator PR #232. The operator now treats a JSON-RPC error from a **reached** MCP as a completed call whose result is an error: it returns **HTTP 200** with an `error` {code, message} object (the transport succeeded — the tool reported an error), rather than inventing an HTTP status. Genuine transport failures (MCP unreachable, timeout, non-2xx) return 424.

## Change

- `RunMcpToolResult` gains an `Error *McpToolError` field to decode the 200-with-error body.
- `iai mcps run-tool`: when the body carries an `error`, print a clear message naming the mcp, tool, and JSON-RPC code, and **return non-zero** so scripts using `&&` don't treat a tool failure as success. Success still prints the raw result as before.

Example:
```
$ iai mcps run-tool socket depscore --args '{"packages":[{"name":"lodash"}]}'
Error: mcp "socket" tool "depscore" returned an error (JSON-RPC -32603): Cannot read properties of undefined (reading 'startsWith')
$ echo $?
1
```

## Testing

- Pure decode test (`TestDecodeRunMcpToolResult`) covering both the error body and the success body — confirms the struct tags route correctly. No mocks.
- Verified against the operator change live: Socket `depscore` bad args → `-32603` in a 200 → this path; Socket `organizations` → real 401 → the existing 424 error path.

Requires operator PR #232 (returns the 200-with-error shape) to be deployed for the new path to trigger; until then run-tool behaves as today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)