### PR TITLE
DEV-854: Add iai images delete

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.38.5"
+current_version = "0.38.6"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/images.go
+++ b/cmd/images.go
@@ -24,6 +24,8 @@ var (
 	imageBuildContext  string
 	imageBuildPlatform string
 	imagePushTag       string
+	imageDeleteTag     string
+	imageDeleteForce   bool
 	imageOrganization  string
 	imageProject       string
 	imageListJSON      bool
@@ -33,7 +35,7 @@ var (
 var imageCmd = &cobra.Command{
 	Use:     "images",
 	Aliases: []string{"image"},
-	Short:   "Build and push container images",
+	Short:   "Manage container images",
 	GroupID: groupInfra,
 	Long:    `Manage container images used by services.`,
 }
@@ -69,6 +71,63 @@ var imageListCmd = &cobra.Command{
 		}
 
 		return output.PrintImageList(out, images)
+	},
+}
+
+var imageDeleteCmd = &cobra.Command{
+	Use:     "delete <image_name>",
+	Aliases: []string{"rm"},
+	Short:   "Delete an image from a project",
+	Long: `Delete the image version identified by its name and tag from a project.
+Other tags pointing to the same version are also deleted.`,
+	Example: `  iai images delete my-service --tag 1.2.3
+  iai images delete my-service --tag 1.2.3 --force
+  iai images delete my-service --tag 1.2.3 --organization my-org --project my-project`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		imageName := strings.TrimSpace(args[0])
+		if imageName == "" {
+			return fmt.Errorf("image name is required")
+		}
+		tag := strings.TrimSpace(imageDeleteTag)
+		if tag == "" {
+			return fmt.Errorf("tag is required; please provide --tag")
+		}
+
+		imageRef := fmt.Sprintf("%s:%s", imageName, tag)
+		if !imageDeleteForce {
+			confirmed, err := confirmDeletion(
+				cmd.InOrStdin(),
+				out,
+				fmt.Sprintf("image %q", imageRef),
+			)
+			if err != nil {
+				return err
+			}
+			if !confirmed {
+				fmt.Fprintln(out, "Aborted.")
+				return nil
+			}
+		}
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), imageOrganization, imageProject)
+		if err != nil {
+			return err
+		}
+
+		serverMessage, err := deployClient.DeleteImage(
+			cmd.Context(), pCtx.orgId, pCtx.projectId, imageName, tag,
+		)
+		if err != nil {
+			return err
+		}
+		if serverMessage != "" {
+			fmt.Fprintln(out, serverMessage)
+		} else {
+			fmt.Fprintf(out, "Deleted image %q.\n", imageRef)
+		}
+		return nil
 	},
 }
 
@@ -322,6 +381,16 @@ func init() {
 	imageListCmd.Flags().BoolVar(&imageListYAML, "yaml", false, "Output raw API response as YAML")
 	imageListCmd.MarkFlagsMutuallyExclusive("json", "yaml")
 
+	imageDeleteCmd.Flags().
+		StringVarP(&imageDeleteTag, "tag", "t", "", "Tag of the image version to delete")
+	imageDeleteCmd.Flags().
+		BoolVarP(&imageDeleteForce, "force", "f", false, "Skip confirmation prompt")
+	imageDeleteCmd.Flags().
+		StringVarP(&imageOrganization, "organization", "o", "", "Organization name that owns the project")
+	imageDeleteCmd.Flags().
+		StringVarP(&imageProject, "project", "p", "", "Project name the image belongs to")
+	_ = imageDeleteCmd.MarkFlagRequired("tag")
+
 	imagePushCmd.Flags().
 		StringVarP(&imagePushTag, "tag", "t", "", "Tag for the image in the fixed registry (e.g. 1.2.3)")
 	imagePushCmd.Flags().
@@ -332,6 +401,7 @@ func init() {
 
 	rootCmd.AddCommand(imageCmd)
 	imageCmd.AddCommand(imageBuildCmd)
+	imageCmd.AddCommand(imageDeleteCmd)
 	imageCmd.AddCommand(imagePushCmd)
 	imageCmd.AddCommand(imageListCmd)
 }

--- a/cmd/images_test.go
+++ b/cmd/images_test.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestImageDeleteValidation(t *testing.T) {
+	originalTag := imageDeleteTag
+	t.Cleanup(func() { imageDeleteTag = originalTag })
+
+	tests := []struct {
+		name string
+		args []string
+		tag  string
+		want string
+	}{
+		{
+			name: "empty image name",
+			args: []string{" "},
+			tag:  "v1",
+			want: "image name is required",
+		},
+		{
+			name: "empty tag",
+			args: []string{"app"},
+			tag:  " ",
+			want: "tag is required; please provide --tag",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			imageDeleteTag = tt.tag
+			err := imageDeleteCmd.RunE(imageDeleteCmd, tt.args)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if diff := cmp.Diff(tt.want, err.Error()); diff != "" {
+				t.Errorf("error mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/cmd/mcps.go
+++ b/cmd/mcps.go
@@ -518,8 +518,8 @@ reported and the command exits non-zero.`,
 }
 
 // confirmDeletion tolerates io.EOF so input without a trailing newline (echo -n y) still counts.
-func confirmDeletion(in io.Reader, out io.Writer, name string) (bool, error) {
-	fmt.Fprintf(out, "This will delete mcp %q. Continue? [y/N] ", name)
+func confirmDeletion(in io.Reader, out io.Writer, target string) (bool, error) {
+	fmt.Fprintf(out, "This will delete %s. Continue? [y/N] ", target)
 	answer, err := bufio.NewReader(in).ReadString('\n')
 	if err != nil && !errors.Is(err, io.EOF) {
 		return false, fmt.Errorf("failed to read confirmation: %w", err)
@@ -546,7 +546,7 @@ Detach it from any attached agent first with 'iai agents update <agent> --detach
 		mcpName := strings.TrimSpace(args[0])
 
 		if !mcpForce {
-			confirmed, err := confirmDeletion(cmd.InOrStdin(), out, mcpName)
+			confirmed, err := confirmDeletion(cmd.InOrStdin(), out, fmt.Sprintf("mcp %q", mcpName))
 			if err != nil {
 				return err
 			}

--- a/cmd/mcps_test.go
+++ b/cmd/mcps_test.go
@@ -23,7 +23,7 @@ func TestConfirmDeletion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var out bytes.Buffer
-			ok, err := confirmDeletion(strings.NewReader(tt.stdin), &out, "my-mcp")
+			ok, err := confirmDeletion(strings.NewReader(tt.stdin), &out, `mcp "my-mcp"`)
 			if err != nil {
 				t.Fatalf("stdin=%q unexpected error: %v", tt.stdin, err)
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version            = "0.38.5"
+	version            = "0.38.6"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second

--- a/docs/iai.md
+++ b/docs/iai.md
@@ -95,7 +95,7 @@ Prompt resources (`prompts`, `routines`, `policies`, `variables`, `glossaries`, 
 * [iai dataset-runs](iai_dataset-runs.md)	 - Run evaluations against datasets
 * [iai datasets](iai_datasets.md)	 - Create and list evaluation datasets
 * [iai glossaries](iai_glossaries.md)	 - Domain vocabularies for consistent term interpretation
-* [iai images](iai_images.md)	 - Build and push container images
+* [iai images](iai_images.md)	 - Manage container images
 * [iai login](iai_login.md)	 - Authenticate with InteractiveAI
 * [iai logout](iai_logout.md)	 - Clear local session
 * [iai macros](iai_macros.md)	 - Pre-approved response templates used in routines

--- a/docs/iai_images.md
+++ b/docs/iai_images.md
@@ -1,6 +1,6 @@
 ## iai images
 
-Build and push container images
+Manage container images
 
 ### Synopsis
 
@@ -25,6 +25,7 @@ Manage container images used by services.
 
 * [iai](iai.md)	 - InteractiveAI's CLI
 * [iai images build](iai_images_build.md)	 - Build a container image with Docker
+* [iai images delete](iai_images_delete.md)	 - Delete an image from a project
 * [iai images list](iai_images_list.md)	 - List images for a project
 * [iai images push](iai_images_push.md)	 - Push an image for a project
 

--- a/docs/iai_images_build.md
+++ b/docs/iai_images_build.md
@@ -42,5 +42,5 @@ iai images build [image_name] [flags]
 
 ### SEE ALSO
 
-* [iai images](iai_images.md)	 - Build and push container images
+* [iai images](iai_images.md)	 - Manage container images
 

--- a/docs/iai_images_delete.md
+++ b/docs/iai_images_delete.md
@@ -1,32 +1,32 @@
-## iai images list
+## iai images delete
 
-List images for a project
+Delete an image from a project
 
 ### Synopsis
 
-List container images in the deployment registry for a specific project.
+Delete the image version identified by its name and tag from a project.
+Other tags pointing to the same version are also deleted.
 
 ```
-iai images list [flags]
+iai images delete <image_name> [flags]
 ```
 
 ### Examples
 
 ```
-  iai images list
-  iai images list --organization my-org --project my-project
-  iai images list --json
-  iai images list --yaml
+  iai images delete my-service --tag 1.2.3
+  iai images delete my-service --tag 1.2.3 --force
+  iai images delete my-service --tag 1.2.3 --organization my-org --project my-project
 ```
 
 ### Options
 
 ```
-  -h, --help                  help for list
-      --json                  Output raw API response as JSON
+  -f, --force                 Skip confirmation prompt
+  -h, --help                  help for delete
   -o, --organization string   Organization name that owns the project
-  -p, --project string        Project name to list images for
-      --yaml                  Output raw API response as YAML
+  -p, --project string        Project name the image belongs to
+  -t, --tag string            Tag of the image version to delete
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_images_push.md
+++ b/docs/iai_images_push.md
@@ -37,5 +37,5 @@ iai images push [image_name] [flags]
 
 ### SEE ALSO
 
-* [iai images](iai_images.md)	 - Build and push container images
+* [iai images](iai_images.md)	 - Manage container images
 

--- a/internal/auth/browser_flow.go
+++ b/internal/auth/browser_flow.go
@@ -74,7 +74,8 @@ func RunBrowserFlow(
 	}
 
 	httpClient := &http.Client{Timeout: 15 * time.Second}
-	authorizeReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+	authorizeReq, err := http.NewRequestWithContext(
+		ctx, http.MethodPost,
 		hostname+"/api/v1/auth/cli/authorize",
 		bytes.NewReader(body),
 	)
@@ -148,7 +149,8 @@ func exchangeCode(
 		},
 	}
 
-	tokenReqHTTP, err := http.NewRequestWithContext(ctx, http.MethodPost,
+	tokenReqHTTP, err := http.NewRequestWithContext(
+		ctx, http.MethodPost,
 		hostname+"/api/v1/auth/cli/token",
 		bytes.NewReader(body),
 	)

--- a/internal/auth/device_flow.go
+++ b/internal/auth/device_flow.go
@@ -47,7 +47,8 @@ func RunDeviceFlow(
 	httpClient := &http.Client{Timeout: 15 * time.Second}
 
 	// 1. Request device code
-	deviceReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+	deviceReq, err := http.NewRequestWithContext(
+		ctx, http.MethodPost,
 		hostname+"/api/v1/auth/cli/device/authorize",
 		bytes.NewReader([]byte("{}")),
 	)
@@ -149,7 +150,8 @@ func pollDeviceToken(
 		},
 	}
 
-	pollReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+	pollReq, err := http.NewRequestWithContext(
+		ctx, http.MethodPost,
 		hostname+"/api/v1/auth/cli/device/token",
 		bytes.NewReader(body),
 	)

--- a/internal/clients/deployment_client.go
+++ b/internal/clients/deployment_client.go
@@ -1010,34 +1010,37 @@ func (c *DeploymentClient) ListImages(
 		url.PathEscape(orgId),
 		url.PathEscape(projectId),
 	)
-	req, err := c.newRequest(ctx, http.MethodGet, path)
+	body, err := c.sendJSONRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	resp, err := c.do(req)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read error response: %w", err)
-		}
-		if msg := ExtractServerMessage(body); msg != "" {
-			return nil, fmt.Errorf("%s", msg)
-		}
-		return nil, fmt.Errorf("failed to list images: server returned %s", resp.Status)
+		return nil, err
 	}
 
 	var result imagesResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.Unmarshal(body, &result); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
-
 	return result.Images, nil
+}
+
+func (c *DeploymentClient) DeleteImage(
+	ctx context.Context,
+	orgId,
+	projectId,
+	imageName,
+	tag string,
+) (string, error) {
+	path := fmt.Sprintf(
+		"/v1/organizations/%s/projects/%s/images/%s?%s",
+		url.PathEscape(orgId),
+		url.PathEscape(projectId),
+		url.PathEscape(imageName),
+		url.Values{"tag": {tag}}.Encode(),
+	)
+	body, err := c.sendJSONRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return "", err
+	}
+	return ExtractServerMessage(body), nil
 }
 
 func (c *DeploymentClient) ListReplicas(


### PR DESCRIPTION
## Summary
- add `iai images delete <image_name> --tag <tag>` with confirmation and `--force`
- surface operator errors and document that deleting a version removes every tag pointing to it
- support nested image names, validate empty values, and reuse existing confirmation and HTTP request helpers
- add table-driven validation coverage and regenerate CLI documentation
- bump CLI to `0.38.6`

## Test plan
- `pre-commit run --all-files`
- `go vet ./...`
- end-to-end in dev: push an internal image, create a service with `iai services create`, verify image deletion returns `409`, delete the service, then delete the image and confirm the image list is empty

Linear: https://linear.app/interactive-ai/issue/DEV-854/missing-iai-image-delete
