### PR TITLE
feat(deploy): add deploy awareness warnings

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.38.7"
+current_version = "0.39.0"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -216,6 +216,18 @@ live-vs-incoming config diff.`,
 			return err
 		}
 
+		mcpOverlay := (cmd.Flags().Changed("mcp") ||
+			cmd.Flags().Changed("detach-mcp")) &&
+			!cmd.Flags().Changed("file")
+		if len(patch) == 0 && !mcpOverlay {
+			return fmt.Errorf("no fields to update; pass at least one flag")
+		}
+		if agentShowDiff {
+			if _, replacesConfig := patch["agentConfig"]; !replacesConfig && !mcpOverlay {
+				return fmt.Errorf("--show-diff requires --file, --mcp, or --detach-mcp")
+			}
+		}
+
 		// One live read feeds the pre-flight banner, --expect-revision, the
 		// pin summary, --show-diff, and the --mcp overlay below. A failed
 		// read never blocks the update (fail open) — except for the overlay
@@ -224,8 +236,7 @@ live-vs-incoming config diff.`,
 			cmd.Context(), pCtx.orgId, pCtx.projectId, agentName,
 		)
 
-		mcpFlagsChanged := cmd.Flags().Changed("mcp") || cmd.Flags().Changed("detach-mcp")
-		if mcpFlagsChanged && !cmd.Flags().Changed("file") {
+		if mcpOverlay {
 			// No --file: overlay onto the agent's current config instead of requiring the whole config resupplied.
 			if liveErr != nil {
 				return liveErr
@@ -250,14 +261,6 @@ live-vs-incoming config diff.`,
 				return fmt.Errorf("failed to encode agent config: %w", marshalErr)
 			}
 			patch["agentConfig"] = json.RawMessage(raw)
-		}
-		if len(patch) == 0 {
-			return fmt.Errorf("no fields to update; pass at least one flag")
-		}
-		if agentShowDiff {
-			if _, ok := patch["agentConfig"]; !ok {
-				return fmt.Errorf("--show-diff requires --file, --mcp, or --detach-mcp")
-			}
 		}
 
 		var liveRevision int

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -43,6 +43,7 @@ var (
 
 	agentExpectRevision int
 	agentShowDiff       bool
+	agentForce          bool
 
 	agentStackId string
 
@@ -173,9 +174,13 @@ Before applying, the CLI prints deploy-awareness output to stderr: the live
 revision this update replaces; the names of any env vars or secret refs that
 --env/--secret would drop from the live agent (the flags replace the entire
 list); and — when the update replaces the agent config — a summary of
-content pin changes, with downgrades and removals flagged (a stale local
-manifest silently reverts colleagues' work). These checks fail open and
-never block; use --expect-revision to fail instead when the live revision
+content pin changes (a stale local manifest silently reverts colleagues'
+work). The update is refused when it would downgrade or remove a live
+content pin, or drop live env vars or secret refs via --env/--secret; pass
+--force to apply anyway. --clear-env and --clear-secret never trigger the
+gate: clearing is explicit intent. Changes in unrecognized pin-shaped config
+sections warn without blocking. The checks fail open when live state cannot
+be fetched; use --expect-revision to fail instead when the live revision
 differs from what you expect, and --show-diff for a full live-vs-incoming
 config diff.`,
 	Example: `  iai agents update chat-agent --version 0.0.3
@@ -276,8 +281,9 @@ config diff.`,
 		); err != nil {
 			return err
 		}
+		var droppedEntries, pinRollback bool
 		if liveErr == nil {
-			printDroppedEnvSecretWarnings(
+			droppedEntries = printDroppedEnvSecretWarnings(
 				errW,
 				cmd.Flags().Changed("env"), cmd.Flags().Changed("secret"),
 				live.Env, live.SecretRefs,
@@ -285,7 +291,10 @@ config diff.`,
 			)
 		}
 		if rawCfg, ok := patch["agentConfig"]; ok && liveErr == nil {
-			printConfigPreflight(errW, live.AgentConfig, rawCfg, agentShowDiff)
+			pinRollback = printConfigPreflight(errW, live.AgentConfig, rawCfg, agentShowDiff)
+		}
+		if err := checkUpdateGates(agentForce, pinRollback, droppedEntries); err != nil {
+			return err
 		}
 
 		fmt.Fprintln(out)
@@ -1044,6 +1053,8 @@ func init() {
 		IntVar(&agentExpectRevision, "expect-revision", 0, "Fail without applying unless the live revision equals this value (opt-in staleness guard)")
 	agentUpdateCmd.Flags().
 		BoolVar(&agentShowDiff, "show-diff", false, "Print a live-vs-incoming agent config diff to stderr before applying; requires --file, --mcp, or --detach-mcp")
+	agentUpdateCmd.Flags().
+		BoolVar(&agentForce, "force", false, "Apply even when the update would downgrade/remove live content pins or drop live env vars or secret refs")
 
 	// Flags for "agents list"
 	agentListCmd.Flags().

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -1050,7 +1050,7 @@ func init() {
 	agentUpdateCmd.Flags().
 		StringArrayVar(&agentDetachMcpNames, "detach-mcp", nil, "Detach an MCP by name; can be repeated. Without --file, removes from the agent's current mcps (applied before --mcp)")
 	agentUpdateCmd.Flags().
-		IntVar(&agentExpectRevision, "expect-revision", 0, "Fail without applying unless the live revision equals this value (opt-in staleness guard)")
+		IntVar(&agentExpectRevision, "expect-revision", 0, "Fail without applying unless the live revision equals this value; 0 is valid and matches a never-updated agent (opt-in staleness guard)")
 	agentUpdateCmd.Flags().
 		BoolVar(&agentShowDiff, "show-diff", false, "Print a live-vs-incoming agent config diff to stderr before applying; requires --file, --mcp, or --detach-mcp")
 	agentUpdateCmd.Flags().

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -41,6 +41,9 @@ var (
 	agentClearSecret   bool
 	agentClearStackId  bool
 
+	agentExpectRevision int
+	agentShowDiff       bool
+
 	agentStackId string
 
 	agentListJSON      bool
@@ -164,9 +167,19 @@ remove those configurations entirely.
 --detach-mcp removes an mcp reference (bare or resolved) by name; combine
 with --mcp in the same command to swap one for another. Detach an mcp before
 deleting it — 'iai mcps delete' blocks by default while an agent still
-references it.`,
+references it.
+
+Before applying, the CLI prints deploy-awareness output to stderr: the live
+revision this update replaces, and — when the update replaces the agent
+config — a summary of content pin changes, with downgrades and removals
+flagged (a stale local manifest silently reverts colleagues' work). These
+checks fail open and never block; use --expect-revision to fail instead when
+the live revision differs from what you expect, and --show-diff for a full
+live-vs-incoming config diff.`,
 	Example: `  iai agents update chat-agent --version 0.0.3
   iai agents update chat-agent --file agent-config.yaml
+  iai agents update chat-agent --file agent-config.yaml --expect-revision 13
+  iai agents update chat-agent --file agent-config.yaml --show-diff
   iai agents update chat-agent --endpoint=false
   iai agents update chat-agent --schedule-uptime "Mon-Fri 07:30-20:30" --schedule-timezone Europe/Berlin
   iai agents update chat-agent --clear-schedule
@@ -177,6 +190,7 @@ references it.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
+		errW := cmd.ErrOrStderr()
 		agentName := strings.TrimSpace(args[0])
 
 		pCtx, _, deployClient, err := resolveProject(cmd.Context(), agentOrganization, agentProject)
@@ -202,16 +216,28 @@ references it.`,
 			return err
 		}
 
+		// One live read feeds the pre-flight banner, --expect-revision, the
+		// pin summary, --show-diff, and the --mcp overlay below. A failed
+		// read never blocks the update (fail open) — except for the overlay
+		// and --expect-revision, which cannot proceed without it.
+		live, liveErr := deployClient.DescribeAgent(
+			cmd.Context(), pCtx.orgId, pCtx.projectId, agentName,
+		)
+
 		mcpFlagsChanged := cmd.Flags().Changed("mcp") || cmd.Flags().Changed("detach-mcp")
 		if mcpFlagsChanged && !cmd.Flags().Changed("file") {
 			// No --file: overlay onto the agent's current config instead of requiring the whole config resupplied.
-			current, describeErr := deployClient.DescribeAgent(
-				cmd.Context(), pCtx.orgId, pCtx.projectId, agentName,
-			)
-			if describeErr != nil {
-				return describeErr
+			if liveErr != nil {
+				return liveErr
 			}
-			detached, detachErr := inputs.DetachMcpRefs(current.AgentConfig, agentDetachMcpNames)
+			// The overlay helpers mutate the config map in place; give them a
+			// copy so the pin summary and --show-diff below still compare
+			// against the true live state.
+			liveCopy, copyErr := cloneJSON(live.AgentConfig)
+			if copyErr != nil {
+				return fmt.Errorf("failed to copy agent config: %w", copyErr)
+			}
+			detached, detachErr := inputs.DetachMcpRefs(liveCopy, agentDetachMcpNames)
 			if detachErr != nil {
 				return detachErr
 			}
@@ -227,6 +253,26 @@ references it.`,
 		}
 		if len(patch) == 0 {
 			return fmt.Errorf("no fields to update; pass at least one flag")
+		}
+		if agentShowDiff {
+			if _, ok := patch["agentConfig"]; !ok {
+				return fmt.Errorf("--show-diff requires --file, --mcp, or --detach-mcp")
+			}
+		}
+
+		var liveRevision int
+		var liveUpdated string
+		if liveErr == nil {
+			liveRevision, liveUpdated = live.Revision, live.Updated
+		}
+		if err := runUpdatePreflight(
+			errW, liveRevision, liveUpdated, liveErr,
+			cmd.Flags().Changed("expect-revision"), agentExpectRevision,
+		); err != nil {
+			return err
+		}
+		if rawCfg, ok := patch["agentConfig"]; ok && liveErr == nil {
+			printConfigPreflight(errW, live.AgentConfig, rawCfg, agentShowDiff)
 		}
 
 		fmt.Fprintln(out)
@@ -899,6 +945,19 @@ Use the reported field names with 'iai agents logs --fields' to include them in 
 	},
 }
 
+// cloneJSON deep-copies a JSON-decoded value via a marshal/unmarshal round trip.
+func cloneJSON(v any) (any, error) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var out any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func init() {
 	// Flags for "agents create"
 	agentCreateCmd.Flags().
@@ -968,6 +1027,10 @@ func init() {
 		StringArrayVar(&agentMcpNames, "mcp", nil, "Attach an MCP by name (see 'iai mcps list'); can be repeated. Without --file, appends to the agent's current mcps")
 	agentUpdateCmd.Flags().
 		StringArrayVar(&agentDetachMcpNames, "detach-mcp", nil, "Detach an MCP by name; can be repeated. Without --file, removes from the agent's current mcps (applied before --mcp)")
+	agentUpdateCmd.Flags().
+		IntVar(&agentExpectRevision, "expect-revision", 0, "Fail without applying unless the live revision equals this value (opt-in staleness guard)")
+	agentUpdateCmd.Flags().
+		BoolVar(&agentShowDiff, "show-diff", false, "Print a live-vs-incoming agent config diff to stderr before applying; requires --file, --mcp, or --detach-mcp")
 
 	// Flags for "agents list"
 	agentListCmd.Flags().

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -170,12 +170,14 @@ deleting it — 'iai mcps delete' blocks by default while an agent still
 references it.
 
 Before applying, the CLI prints deploy-awareness output to stderr: the live
-revision this update replaces, and — when the update replaces the agent
-config — a summary of content pin changes, with downgrades and removals
-flagged (a stale local manifest silently reverts colleagues' work). These
-checks fail open and never block; use --expect-revision to fail instead when
-the live revision differs from what you expect, and --show-diff for a full
-live-vs-incoming config diff.`,
+revision this update replaces; the names of any env vars or secret refs that
+--env/--secret would drop from the live agent (the flags replace the entire
+list); and — when the update replaces the agent config — a summary of
+content pin changes, with downgrades and removals flagged (a stale local
+manifest silently reverts colleagues' work). These checks fail open and
+never block; use --expect-revision to fail instead when the live revision
+differs from what you expect, and --show-diff for a full live-vs-incoming
+config diff.`,
 	Example: `  iai agents update chat-agent --version 0.0.3
   iai agents update chat-agent --file agent-config.yaml
   iai agents update chat-agent --file agent-config.yaml --expect-revision 13
@@ -273,6 +275,14 @@ live-vs-incoming config diff.`,
 			cmd.Flags().Changed("expect-revision"), agentExpectRevision,
 		); err != nil {
 			return err
+		}
+		if liveErr == nil {
+			printDroppedEnvSecretWarnings(
+				errW,
+				cmd.Flags().Changed("env"), cmd.Flags().Changed("secret"),
+				live.Env, live.SecretRefs,
+				agentEnvVars, agentSecretRefs,
+			)
 		}
 		if rawCfg, ok := patch["agentConfig"]; ok && liveErr == nil {
 			printConfigPreflight(errW, live.AgentConfig, rawCfg, agentShowDiff)

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -235,22 +235,15 @@ config diff.`,
 			}
 		}
 
-		// One live read feeds the pre-flight banner, --expect-revision, the
-		// pin summary, --show-diff, and the --mcp overlay below. A failed
-		// read never blocks the update (fail open) — except for the overlay
-		// and --expect-revision, which cannot proceed without it.
 		live, liveErr := deployClient.DescribeAgent(
 			cmd.Context(), pCtx.orgId, pCtx.projectId, agentName,
 		)
 
 		if mcpOverlay {
-			// No --file: overlay onto the agent's current config instead of requiring the whole config resupplied.
 			if liveErr != nil {
 				return liveErr
 			}
-			// The overlay helpers mutate the config map in place; give them a
-			// copy so the pin summary and --show-diff below still compare
-			// against the true live state.
+			// Overlay mutates in place; copy so pin/diff still see live state.
 			liveCopy, copyErr := cloneJSON(live.AgentConfig)
 			if copyErr != nil {
 				return fmt.Errorf("failed to copy agent config: %w", copyErr)
@@ -967,7 +960,6 @@ Use the reported field names with 'iai agents logs --fields' to include them in 
 	},
 }
 
-// cloneJSON deep-copies a JSON-decoded value via a marshal/unmarshal round trip.
 func cloneJSON(v any) (any, error) {
 	raw, err := json.Marshal(v)
 	if err != nil {

--- a/cmd/agents_test.go
+++ b/cmd/agents_test.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestAgentUpdateMcpOverlayShowDiff runs the full update command for an
+// --mcp overlay (no --file) and checks the pre-flight diff on stderr.
+// Regression test: the overlay helpers mutate the live config map in place,
+// which used to make --show-diff compare the config against itself and
+// print "No differences found." for the very change being applied.
+func TestAgentUpdateMcpOverlayShowDiff(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/v1/session/organizations":
+				fmt.Fprint(w, `{"organizations":[{"id":"org-1","name":"acme"}]}`)
+			case r.Method == http.MethodGet &&
+				r.URL.Path == "/api/v1/session/organizations/org-1/projects":
+				fmt.Fprint(w, `{"projects":[{"id":"proj-1","name":"alunafi"}]}`)
+			case r.Method == http.MethodGet &&
+				r.URL.Path == "/v1/organizations/org-1/projects/proj-1/agents/chat-agent":
+				fmt.Fprint(
+					w,
+					`{"name":"chat-agent","projectId":"proj-1","revision":13,"status":"ready",`+
+						`"updated":"2026-07-24T11:20:00Z","id":"interactive-agent","version":"0.0.2",`+
+						`"agentConfig":{"mcps":["github"],"context":{"routines":[{"id":"welcome","version":13}]}}}`,
+				)
+			case r.Method == http.MethodPatch &&
+				r.URL.Path == "/v1/organizations/org-1/projects/proj-1/agents/chat-agent":
+				fmt.Fprint(w, `{"message":"Update submitted"}`)
+			default:
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}),
+	)
+	t.Cleanup(server.Close)
+
+	// Isolate every global the command reads, and restore afterwards.
+	t.Setenv("HOME", t.TempDir())
+	origHostname, origDeployHostname, origToken, origApiKey := hostname, deploymentHostname, token, apiKey
+	origOrg, origProject := agentOrganization, agentProject
+	t.Cleanup(func() {
+		hostname, deploymentHostname, token, apiKey = origHostname, origDeployHostname, origToken, origApiKey
+		agentOrganization, agentProject = origOrg, origProject
+		agentMcpNames = nil
+		agentShowDiff = false
+		for _, name := range []string{"mcp", "show-diff"} {
+			agentUpdateCmd.Flags().Lookup(name).Changed = false
+		}
+		agentUpdateCmd.SetOut(nil)
+		agentUpdateCmd.SetErr(nil)
+	})
+	hostname, deploymentHostname, token, apiKey = server.URL, server.URL, "test-token", ""
+	agentOrganization, agentProject = "acme", "alunafi"
+
+	if err := agentUpdateCmd.Flags().Set("mcp", "stripe"); err != nil {
+		t.Fatalf("set --mcp: %v", err)
+	}
+	if err := agentUpdateCmd.Flags().Set("show-diff", "true"); err != nil {
+		t.Fatalf("set --show-diff: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	agentUpdateCmd.SetOut(&stdout)
+	agentUpdateCmd.SetErr(&stderr)
+	agentUpdateCmd.SetContext(context.Background())
+
+	if err := agentUpdateCmd.RunE(agentUpdateCmd, []string{"chat-agent"}); err != nil {
+		t.Fatalf("agents update: %v", err)
+	}
+
+	wantStdout := "\nSubmitting agent update request...\nUpdate submitted\n"
+	if got := stdout.String(); got != wantStdout {
+		t.Errorf("stdout = %q, want %q", got, wantStdout)
+	}
+
+	errOut := stderr.String()
+	if !strings.Contains(
+		errOut,
+		"Live: revision 13, last updated 2026-07-24 11:20 UTC — this update creates revision 14",
+	) {
+		t.Errorf("stderr missing revision banner:\n%s", errOut)
+	}
+	if strings.Contains(errOut, "No differences found.") {
+		t.Errorf("diff compared the live config against itself:\n%s", errOut)
+	}
+	if !strings.Contains(errOut, "--- live") || !strings.Contains(errOut, "- stripe") {
+		t.Errorf("stderr missing live-vs-incoming diff with the attached mcp:\n%s", errOut)
+	}
+	if strings.Contains(errOut, "content pins changed") {
+		t.Errorf("mcp-only update must not report pin changes:\n%s", errOut)
+	}
+}

--- a/cmd/agents_test.go
+++ b/cmd/agents_test.go
@@ -99,3 +99,92 @@ func TestAgentUpdateMcpOverlayShowDiff(t *testing.T) {
 		t.Errorf("mcp-only update must not report pin changes:\n%s", errOut)
 	}
 }
+
+func TestAgentUpdateValidatesBeforeDescribe(t *testing.T) {
+	tests := []struct {
+		name    string
+		flags   map[string]string
+		wantErr string
+	}{
+		{
+			name:    "no fields",
+			wantErr: "no fields to update; pass at least one flag",
+		},
+		{
+			name: "show diff without config replacement",
+			flags: map[string]string{
+				"show-diff": "true",
+				"version":   "0.0.3",
+			},
+			wantErr: "--show-diff requires --file, --mcp, or --detach-mcp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			describeCalls := 0
+			server := httptest.NewServer(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch {
+					case r.Method == http.MethodGet &&
+						r.URL.Path == "/api/v1/session/organizations":
+						fmt.Fprint(w, `{"organizations":[{"id":"org-1","name":"acme"}]}`)
+					case r.Method == http.MethodGet &&
+						r.URL.Path == "/api/v1/session/organizations/org-1/projects":
+						fmt.Fprint(w, `{"projects":[{"id":"proj-1","name":"alunafi"}]}`)
+					case r.Method == http.MethodGet &&
+						r.URL.Path == "/v1/organizations/org-1/projects/proj-1/agents/chat-agent":
+						describeCalls++
+						fmt.Fprint(w, `{"name":"chat-agent","revision":1,"agentConfig":{}}`)
+					default:
+						t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+						w.WriteHeader(http.StatusNotFound)
+					}
+				}),
+			)
+			t.Cleanup(server.Close)
+
+			t.Setenv("HOME", t.TempDir())
+			origHostname, origDeployHostname := hostname, deploymentHostname
+			origToken, origApiKey := token, apiKey
+			origOrg, origProject := agentOrganization, agentProject
+			origVersion, origShowDiff := agentVersion, agentShowDiff
+			originalChanged := map[string]bool{}
+			for name := range tt.flags {
+				originalChanged[name] = agentUpdateCmd.Flags().Lookup(name).Changed
+			}
+			t.Cleanup(func() {
+				hostname, deploymentHostname = origHostname, origDeployHostname
+				token, apiKey = origToken, origApiKey
+				agentOrganization, agentProject = origOrg, origProject
+				agentVersion, agentShowDiff = origVersion, origShowDiff
+				for name, changed := range originalChanged {
+					agentUpdateCmd.Flags().Lookup(name).Changed = changed
+				}
+				agentUpdateCmd.SetOut(nil)
+				agentUpdateCmd.SetErr(nil)
+			})
+
+			hostname, deploymentHostname = server.URL, server.URL
+			token, apiKey = "test-token", ""
+			agentOrganization, agentProject = "acme", "alunafi"
+			for name, value := range tt.flags {
+				if err := agentUpdateCmd.Flags().Set(name, value); err != nil {
+					t.Fatalf("set --%s: %v", name, err)
+				}
+			}
+
+			agentUpdateCmd.SetOut(&bytes.Buffer{})
+			agentUpdateCmd.SetErr(&bytes.Buffer{})
+			agentUpdateCmd.SetContext(context.Background())
+
+			err := agentUpdateCmd.RunE(agentUpdateCmd, []string{"chat-agent"})
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want it to contain %q", err, tt.wantErr)
+			}
+			if describeCalls != 0 {
+				t.Errorf("DescribeAgent called %d times before validation", describeCalls)
+			}
+		})
+	}
+}

--- a/cmd/agents_test.go
+++ b/cmd/agents_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -186,6 +188,85 @@ func TestAgentUpdateValidatesBeforeDescribe(t *testing.T) {
 				t.Errorf("DescribeAgent called %d times before validation", describeCalls)
 			}
 		})
+	}
+}
+
+// TestAgentUpdateRefusesUnpinnedRoutine runs the full update command with a
+// --file config that keeps a routine entry but drops its version. Unpinning
+// has the same effect as removing the pin, so the update must be refused
+// before the PATCH unless --force is passed.
+func TestAgentUpdateRefusesUnpinnedRoutine(t *testing.T) {
+	patchCalls := 0
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/v1/session/organizations":
+				fmt.Fprint(w, `{"organizations":[{"id":"org-1","name":"acme"}]}`)
+			case r.Method == http.MethodGet &&
+				r.URL.Path == "/api/v1/session/organizations/org-1/projects":
+				fmt.Fprint(w, `{"projects":[{"id":"proj-1","name":"alunafi"}]}`)
+			case r.Method == http.MethodGet &&
+				r.URL.Path == "/v1/organizations/org-1/projects/proj-1/agents/chat-agent":
+				fmt.Fprint(
+					w,
+					`{"name":"chat-agent","projectId":"proj-1","revision":13,"status":"ready",`+
+						`"updated":"2026-07-24T11:20:00Z","id":"interactive-agent","version":"0.0.2",`+
+						`"agentConfig":{"context":{"routines":[{"id":"welcome","version":13}]}}}`,
+				)
+			case r.Method == http.MethodPatch &&
+				r.URL.Path == "/v1/organizations/org-1/projects/proj-1/agents/chat-agent":
+				patchCalls++
+				fmt.Fprint(w, `{"message":"Update submitted"}`)
+			default:
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}),
+	)
+	t.Cleanup(server.Close)
+
+	configPath := filepath.Join(t.TempDir(), "agent.yaml")
+	config := "context:\n  routines:\n    - id: welcome\n"
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+
+	t.Setenv("HOME", t.TempDir())
+	origHostname, origDeployHostname, origToken, origApiKey := hostname, deploymentHostname, token, apiKey
+	origOrg, origProject := agentOrganization, agentProject
+	t.Cleanup(func() {
+		hostname, deploymentHostname, token, apiKey = origHostname, origDeployHostname, origToken, origApiKey
+		agentOrganization, agentProject = origOrg, origProject
+		agentFile = ""
+		agentUpdateCmd.Flags().Lookup("file").Changed = false
+		agentUpdateCmd.SetOut(nil)
+		agentUpdateCmd.SetErr(nil)
+	})
+	hostname, deploymentHostname, token, apiKey = server.URL, server.URL, "test-token", ""
+	agentOrganization, agentProject = "acme", "alunafi"
+
+	if err := agentUpdateCmd.Flags().Set("file", configPath); err != nil {
+		t.Fatalf("set --file: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	agentUpdateCmd.SetOut(&stdout)
+	agentUpdateCmd.SetErr(&stderr)
+	agentUpdateCmd.SetContext(context.Background())
+
+	err := agentUpdateCmd.RunE(agentUpdateCmd, []string{"chat-agent"})
+
+	wantErr := "refusing to apply: this update downgrades or removes live content pins" +
+		" (details above) — pass --force if this is intended"
+	if err == nil || err.Error() != wantErr {
+		t.Fatalf("error = %v, want %q", err, wantErr)
+	}
+	if patchCalls != 0 {
+		t.Errorf("PATCH called %d times before the gate, want 0", patchCalls)
+	}
+	wantWarn := "routine welcome: v13 → (unpinned)  (REMOVED — this update drops the version pin)"
+	if !strings.Contains(stderr.String(), wantWarn) {
+		t.Errorf("stderr missing unpin detail %q:\n%s", wantWarn, stderr.String())
 	}
 }
 

--- a/cmd/agents_test.go
+++ b/cmd/agents_test.go
@@ -188,3 +188,79 @@ func TestAgentUpdateValidatesBeforeDescribe(t *testing.T) {
 		})
 	}
 }
+
+// TestAgentUpdateWarnsOnDroppedEnv runs the full update command with an
+// --env replacement that keeps only one of the two live env vars and checks
+// the dropped-name warning on stderr. --env replaces the whole list, so
+// "add one var" passed alone silently wipes the rest — the warning is the
+// only signal. The untouched secret list must stay silent.
+func TestAgentUpdateWarnsOnDroppedEnv(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/v1/session/organizations":
+				fmt.Fprint(w, `{"organizations":[{"id":"org-1","name":"acme"}]}`)
+			case r.Method == http.MethodGet &&
+				r.URL.Path == "/api/v1/session/organizations/org-1/projects":
+				fmt.Fprint(w, `{"projects":[{"id":"proj-1","name":"alunafi"}]}`)
+			case r.Method == http.MethodGet &&
+				r.URL.Path == "/v1/organizations/org-1/projects/proj-1/agents/chat-agent":
+				fmt.Fprint(
+					w,
+					`{"name":"chat-agent","projectId":"proj-1","revision":13,"status":"ready",`+
+						`"updated":"2026-07-24T11:20:00Z","id":"interactive-agent","version":"0.0.2",`+
+						`"agentConfig":{},`+
+						`"env":[{"name":"LOG_LEVEL","value":"info"},{"name":"DB_HOST","value":"db"}],`+
+						`"secretRefs":[{"secretName":"api-keys"}]}`,
+				)
+			case r.Method == http.MethodPatch &&
+				r.URL.Path == "/v1/organizations/org-1/projects/proj-1/agents/chat-agent":
+				fmt.Fprint(w, `{"message":"Update submitted"}`)
+			default:
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}),
+	)
+	t.Cleanup(server.Close)
+
+	t.Setenv("HOME", t.TempDir())
+	origHostname, origDeployHostname, origToken, origApiKey := hostname, deploymentHostname, token, apiKey
+	origOrg, origProject := agentOrganization, agentProject
+	t.Cleanup(func() {
+		hostname, deploymentHostname, token, apiKey = origHostname, origDeployHostname, origToken, origApiKey
+		agentOrganization, agentProject = origOrg, origProject
+		agentEnvVars = nil
+		agentUpdateCmd.Flags().Lookup("env").Changed = false
+		agentUpdateCmd.SetOut(nil)
+		agentUpdateCmd.SetErr(nil)
+	})
+	hostname, deploymentHostname, token, apiKey = server.URL, server.URL, "test-token", ""
+	agentOrganization, agentProject = "acme", "alunafi"
+
+	if err := agentUpdateCmd.Flags().Set("env", "LOG_LEVEL=debug"); err != nil {
+		t.Fatalf("set --env: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	agentUpdateCmd.SetOut(&stdout)
+	agentUpdateCmd.SetErr(&stderr)
+	agentUpdateCmd.SetContext(context.Background())
+
+	if err := agentUpdateCmd.RunE(agentUpdateCmd, []string{"chat-agent"}); err != nil {
+		t.Fatalf("agents update: %v", err)
+	}
+
+	errOut := stderr.String()
+	want := "⚠ this update drops live env vars: DB_HOST" +
+		" (--env replaces the entire list; pass every value you want to keep)"
+	if !strings.Contains(errOut, want) {
+		t.Errorf("stderr missing dropped-env warning %q:\n%s", want, errOut)
+	}
+	if strings.Contains(errOut, "secret refs") {
+		t.Errorf("untouched --secret list must not warn:\n%s", errOut)
+	}
+	if !strings.Contains(stdout.String(), "Update submitted") {
+		t.Errorf("update did not go through:\n%s", stdout.String())
+	}
+}

--- a/cmd/agents_test.go
+++ b/cmd/agents_test.go
@@ -189,78 +189,112 @@ func TestAgentUpdateValidatesBeforeDescribe(t *testing.T) {
 	}
 }
 
-// TestAgentUpdateWarnsOnDroppedEnv runs the full update command with an
-// --env replacement that keeps only one of the two live env vars and checks
-// the dropped-name warning on stderr. --env replaces the whole list, so
-// "add one var" passed alone silently wipes the rest — the warning is the
-// only signal. The untouched secret list must stay silent.
-func TestAgentUpdateWarnsOnDroppedEnv(t *testing.T) {
-	server := httptest.NewServer(
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch {
-			case r.Method == http.MethodGet && r.URL.Path == "/api/v1/session/organizations":
-				fmt.Fprint(w, `{"organizations":[{"id":"org-1","name":"acme"}]}`)
-			case r.Method == http.MethodGet &&
-				r.URL.Path == "/api/v1/session/organizations/org-1/projects":
-				fmt.Fprint(w, `{"projects":[{"id":"proj-1","name":"alunafi"}]}`)
-			case r.Method == http.MethodGet &&
-				r.URL.Path == "/v1/organizations/org-1/projects/proj-1/agents/chat-agent":
-				fmt.Fprint(
-					w,
-					`{"name":"chat-agent","projectId":"proj-1","revision":13,"status":"ready",`+
-						`"updated":"2026-07-24T11:20:00Z","id":"interactive-agent","version":"0.0.2",`+
-						`"agentConfig":{},`+
-						`"env":[{"name":"LOG_LEVEL","value":"info"},{"name":"DB_HOST","value":"db"}],`+
-						`"secretRefs":[{"secretName":"api-keys"}]}`,
-				)
-			case r.Method == http.MethodPatch &&
-				r.URL.Path == "/v1/organizations/org-1/projects/proj-1/agents/chat-agent":
-				fmt.Fprint(w, `{"message":"Update submitted"}`)
-			default:
-				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
-				w.WriteHeader(http.StatusNotFound)
+// TestAgentUpdateGatesDroppedEnv runs the full update command with an --env
+// replacement that keeps only one of the two live env vars. --env replaces
+// the whole list, so "add one var" passed alone silently wipes the rest:
+// the update is refused before the PATCH with the dropped names detailed on
+// stderr, and --force is the single override that lets it through. The
+// untouched secret list must stay silent either way.
+func TestAgentUpdateGatesDroppedEnv(t *testing.T) {
+	tests := []struct {
+		name  string
+		force bool
+	}{
+		{name: "refused without force"},
+		{name: "applied with force", force: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patchCalls := 0
+			server := httptest.NewServer(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch {
+					case r.Method == http.MethodGet && r.URL.Path == "/api/v1/session/organizations":
+						fmt.Fprint(w, `{"organizations":[{"id":"org-1","name":"acme"}]}`)
+					case r.Method == http.MethodGet &&
+						r.URL.Path == "/api/v1/session/organizations/org-1/projects":
+						fmt.Fprint(w, `{"projects":[{"id":"proj-1","name":"alunafi"}]}`)
+					case r.Method == http.MethodGet &&
+						r.URL.Path == "/v1/organizations/org-1/projects/proj-1/agents/chat-agent":
+						fmt.Fprint(
+							w,
+							`{"name":"chat-agent","projectId":"proj-1","revision":13,"status":"ready",`+
+								`"updated":"2026-07-24T11:20:00Z","id":"interactive-agent","version":"0.0.2",`+
+								`"agentConfig":{},`+
+								`"env":[{"name":"LOG_LEVEL","value":"info"},{"name":"DB_HOST","value":"db"}],`+
+								`"secretRefs":[{"secretName":"api-keys"}]}`,
+						)
+					case r.Method == http.MethodPatch &&
+						r.URL.Path == "/v1/organizations/org-1/projects/proj-1/agents/chat-agent":
+						patchCalls++
+						fmt.Fprint(w, `{"message":"Update submitted"}`)
+					default:
+						t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+						w.WriteHeader(http.StatusNotFound)
+					}
+				}),
+			)
+			t.Cleanup(server.Close)
+
+			t.Setenv("HOME", t.TempDir())
+			origHostname, origDeployHostname, origToken, origApiKey := hostname, deploymentHostname, token, apiKey
+			origOrg, origProject := agentOrganization, agentProject
+			t.Cleanup(func() {
+				hostname, deploymentHostname, token, apiKey = origHostname, origDeployHostname, origToken, origApiKey
+				agentOrganization, agentProject = origOrg, origProject
+				agentEnvVars = nil
+				agentForce = false
+				agentUpdateCmd.Flags().Lookup("env").Changed = false
+				agentUpdateCmd.SetOut(nil)
+				agentUpdateCmd.SetErr(nil)
+			})
+			hostname, deploymentHostname, token, apiKey = server.URL, server.URL, "test-token", ""
+			agentOrganization, agentProject = "acme", "alunafi"
+			agentForce = tt.force
+
+			if err := agentUpdateCmd.Flags().Set("env", "LOG_LEVEL=debug"); err != nil {
+				t.Fatalf("set --env: %v", err)
 			}
-		}),
-	)
-	t.Cleanup(server.Close)
 
-	t.Setenv("HOME", t.TempDir())
-	origHostname, origDeployHostname, origToken, origApiKey := hostname, deploymentHostname, token, apiKey
-	origOrg, origProject := agentOrganization, agentProject
-	t.Cleanup(func() {
-		hostname, deploymentHostname, token, apiKey = origHostname, origDeployHostname, origToken, origApiKey
-		agentOrganization, agentProject = origOrg, origProject
-		agentEnvVars = nil
-		agentUpdateCmd.Flags().Lookup("env").Changed = false
-		agentUpdateCmd.SetOut(nil)
-		agentUpdateCmd.SetErr(nil)
-	})
-	hostname, deploymentHostname, token, apiKey = server.URL, server.URL, "test-token", ""
-	agentOrganization, agentProject = "acme", "alunafi"
+			var stdout, stderr bytes.Buffer
+			agentUpdateCmd.SetOut(&stdout)
+			agentUpdateCmd.SetErr(&stderr)
+			agentUpdateCmd.SetContext(context.Background())
 
-	if err := agentUpdateCmd.Flags().Set("env", "LOG_LEVEL=debug"); err != nil {
-		t.Fatalf("set --env: %v", err)
-	}
+			err := agentUpdateCmd.RunE(agentUpdateCmd, []string{"chat-agent"})
 
-	var stdout, stderr bytes.Buffer
-	agentUpdateCmd.SetOut(&stdout)
-	agentUpdateCmd.SetErr(&stderr)
-	agentUpdateCmd.SetContext(context.Background())
+			errOut := stderr.String()
+			want := "⚠ this update drops live env vars: DB_HOST" +
+				" (--env replaces the entire list; pass every value you want to keep)"
+			if !strings.Contains(errOut, want) {
+				t.Errorf("stderr missing dropped-env warning %q:\n%s", want, errOut)
+			}
+			if strings.Contains(errOut, "secret refs") {
+				t.Errorf("untouched --secret list must not warn:\n%s", errOut)
+			}
 
-	if err := agentUpdateCmd.RunE(agentUpdateCmd, []string{"chat-agent"}); err != nil {
-		t.Fatalf("agents update: %v", err)
-	}
+			if tt.force {
+				if err != nil {
+					t.Fatalf("agents update with --force: %v", err)
+				}
+				if patchCalls != 1 {
+					t.Errorf("PATCH called %d times, want 1", patchCalls)
+				}
+				if !strings.Contains(stdout.String(), "Update submitted") {
+					t.Errorf("update did not go through:\n%s", stdout.String())
+				}
+				return
+			}
 
-	errOut := stderr.String()
-	want := "⚠ this update drops live env vars: DB_HOST" +
-		" (--env replaces the entire list; pass every value you want to keep)"
-	if !strings.Contains(errOut, want) {
-		t.Errorf("stderr missing dropped-env warning %q:\n%s", want, errOut)
-	}
-	if strings.Contains(errOut, "secret refs") {
-		t.Errorf("untouched --secret list must not warn:\n%s", errOut)
-	}
-	if !strings.Contains(stdout.String(), "Update submitted") {
-		t.Errorf("update did not go through:\n%s", stdout.String())
+			wantErr := "refusing to apply: this update drops live env vars or secret refs" +
+				" (details above) — pass --force if this is intended"
+			if err == nil || err.Error() != wantErr {
+				t.Fatalf("error = %v, want %q", err, wantErr)
+			}
+			if patchCalls != 0 {
+				t.Errorf("PATCH called %d times before the gate, want 0", patchCalls)
+			}
+		})
 	}
 }

--- a/cmd/agents_test.go
+++ b/cmd/agents_test.go
@@ -12,11 +12,6 @@ import (
 	"testing"
 )
 
-// TestAgentUpdateMcpOverlayShowDiff runs the full update command for an
-// --mcp overlay (no --file) and checks the pre-flight diff on stderr.
-// Regression test: the overlay helpers mutate the live config map in place,
-// which used to make --show-diff compare the config against itself and
-// print "No differences found." for the very change being applied.
 func TestAgentUpdateMcpOverlayShowDiff(t *testing.T) {
 	server := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -45,7 +40,6 @@ func TestAgentUpdateMcpOverlayShowDiff(t *testing.T) {
 	)
 	t.Cleanup(server.Close)
 
-	// Isolate every global the command reads, and restore afterwards.
 	t.Setenv("HOME", t.TempDir())
 	origHostname, origDeployHostname, origToken, origApiKey := hostname, deploymentHostname, token, apiKey
 	origOrg, origProject := agentOrganization, agentProject
@@ -191,10 +185,6 @@ func TestAgentUpdateValidatesBeforeDescribe(t *testing.T) {
 	}
 }
 
-// TestAgentUpdateRefusesUnpinnedRoutine runs the full update command with a
-// --file config that keeps a routine entry but drops its version. Unpinning
-// has the same effect as removing the pin, so the update must be refused
-// before the PATCH unless --force is passed.
 func TestAgentUpdateRefusesUnpinnedRoutine(t *testing.T) {
 	patchCalls := 0
 	server := httptest.NewServer(
@@ -270,12 +260,6 @@ func TestAgentUpdateRefusesUnpinnedRoutine(t *testing.T) {
 	}
 }
 
-// TestAgentUpdateGatesDroppedEnv runs the full update command with an --env
-// replacement that keeps only one of the two live env vars. --env replaces
-// the whole list, so "add one var" passed alone silently wipes the rest:
-// the update is refused before the PATCH with the dropped names detailed on
-// stderr, and --force is the single override that lets it through. The
-// untouched secret list must stay silent either way.
 func TestAgentUpdateGatesDroppedEnv(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/cmd/images.go
+++ b/cmd/images.go
@@ -233,6 +233,13 @@ open when the existing tags cannot be listed.`,
 			return err
 		}
 
+		deployClient, err := clients.NewDeploymentClient(
+			deploymentHostname, defaultHTTPTimeout, token, apiKey, cookies,
+		)
+		if err != nil {
+			return err
+		}
+
 		sess := session.NewSession(cfgDirName)
 
 		orgName, err := sess.ResolveOrganization(cfg.Organization, imageOrganization)
@@ -270,7 +277,13 @@ open when the existing tags cannot be listed.`,
 		// listed. Runs after the cheap local checks, before anything is
 		// saved or uploaded.
 		if existingImageTag(
-			cmd.Context(), cmd.ErrOrStderr(), orgId, projectId, imageName, imagePushTag, cookies,
+			cmd.Context(),
+			cmd.ErrOrStderr(),
+			deployClient,
+			orgId,
+			projectId,
+			imageName,
+			imagePushTag,
 		) {
 			if !imagePushForce {
 				return fmt.Errorf(
@@ -376,16 +389,9 @@ open when the existing tags cannot be listed.`,
 func existingImageTag(
 	ctx context.Context,
 	errW io.Writer,
+	deployClient *clients.DeploymentClient,
 	orgId, projectId, imageName, tag string,
-	cookies []*http.Cookie,
 ) bool {
-	deployClient, err := clients.NewDeploymentClient(
-		deploymentHostname, defaultHTTPTimeout, token, apiKey, cookies,
-	)
-	if err != nil {
-		preflight.PrintFailOpenNote(errW, "list existing image tags", err)
-		return false
-	}
 	images, err := deployClient.ListImages(ctx, orgId, projectId)
 	if err != nil {
 		preflight.PrintFailOpenNote(errW, "list existing image tags", err)

--- a/cmd/images.go
+++ b/cmd/images.go
@@ -270,28 +270,21 @@ open when the existing tags cannot be listed.`,
 			return err
 		}
 
-		// Deploy awareness: pushing to an existing tag replaces the previous
-		// image with no way to recover it or tell that the code changed —
-		// the CLI's only unrecoverable operation, so an occupied tag blocks
-		// unless --force names the intent. Fails open when tags can't be
-		// listed. Runs after the cheap local checks, before anything is
-		// saved or uploaded.
-		if existingImageTag(
-			cmd.Context(),
+		if err := refuseTagOverwrite(
 			cmd.ErrOrStderr(),
-			deployClient,
-			orgId,
-			projectId,
-			imageName,
 			imagePushTag,
-		) {
-			if !imagePushForce {
-				return fmt.Errorf(
-					"tag %s already exists upstream — pushing would replace it and the previous image is unrecoverable; pick a fresh tag, or pass --force to replace",
-					imagePushTag,
-				)
-			}
-			preflight.PrintTagOverwriteWarning(cmd.ErrOrStderr(), imagePushTag)
+			existingImageTag(
+				cmd.Context(),
+				cmd.ErrOrStderr(),
+				deployClient,
+				orgId,
+				projectId,
+				imageName,
+				imagePushTag,
+			),
+			imagePushForce,
+		); err != nil {
+			return err
 		}
 
 		tmpFile, err := os.CreateTemp("", "image-*.tar")
@@ -383,9 +376,24 @@ open when the existing tags cannot be listed.`,
 	},
 }
 
-// existingImageTag reports whether the tag is already present upstream for
-// the image. A failed lookup fails open (note on errW, false) — the gate
-// must not add a new way for a legitimate push to break.
+func refuseTagOverwrite(errW io.Writer, tag string, exists, force bool) error {
+	if !exists {
+		return nil
+	}
+	if !force {
+		return fmt.Errorf(
+			"tag %s already exists upstream — pushing would replace it and the previous image is unrecoverable; pick a fresh tag, or pass --force to replace",
+			tag,
+		)
+	}
+	fmt.Fprintf(
+		errW,
+		"⚠ tag %s already exists upstream — pushing replaces it; the previous image is unrecoverable.\n",
+		tag,
+	)
+	return nil
+}
+
 func existingImageTag(
 	ctx context.Context,
 	errW io.Writer,

--- a/cmd/images.go
+++ b/cmd/images.go
@@ -27,6 +27,7 @@ var (
 	imageBuildContext  string
 	imageBuildPlatform string
 	imagePushTag       string
+	imagePushForce     bool
 	imageDeleteTag     string
 	imageDeleteForce   bool
 	imageOrganization  string
@@ -200,9 +201,11 @@ var imagePushCmd = &cobra.Command{
 
 Pushing to a tag that already exists upstream replaces the previous image:
 the old bytes are unrecoverable and nothing records that the code changed.
-The CLI warns on stderr before pushing to an existing tag — prefer a fresh
-tag (or the git SHA) unless replacing is intended.`,
+The push is refused when the tag already exists — prefer a fresh tag (or
+the git SHA), or pass --force when replacing is intended. The check fails
+open when the existing tags cannot be listed.`,
 	Example: `  iai images push my-service --tag 1.2.3
+  iai images push my-service --tag 1.2.3 --force
   iai images push my-service --tag 1.2.3 --organization my-org --project my-project`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -248,11 +251,21 @@ tag (or the git SHA) unless replacing is intended.`,
 		}
 
 		// Deploy awareness: pushing to an existing tag replaces the previous
-		// image with no way to recover it or tell that the code changed.
-		// Warn before doing the work; fails open, never blocks the push.
-		warnExistingImageTag(
+		// image with no way to recover it or tell that the code changed —
+		// the CLI's only unrecoverable operation, so an occupied tag blocks
+		// unless --force names the intent. Fails open when tags can't be
+		// listed.
+		if existingImageTag(
 			cmd.Context(), cmd.ErrOrStderr(), orgId, projectId, imageName, imagePushTag, cookies,
-		)
+		) {
+			if !imagePushForce {
+				return fmt.Errorf(
+					"tag %s already exists upstream — pushing would replace it and the previous image is unrecoverable; pick a fresh tag, or pass --force to replace",
+					imagePushTag,
+				)
+			}
+			preflight.PrintTagOverwriteWarning(cmd.ErrOrStderr(), imagePushTag)
+		}
 
 		if _, err := exec.LookPath("docker"); err != nil {
 			return fmt.Errorf(
@@ -356,30 +369,33 @@ tag (or the git SHA) unless replacing is intended.`,
 	},
 }
 
-func warnExistingImageTag(
+// existingImageTag reports whether the tag is already present upstream for
+// the image. A failed lookup fails open (note on errW, false) — the gate
+// must not add a new way for a legitimate push to break.
+func existingImageTag(
 	ctx context.Context,
 	errW io.Writer,
 	orgId, projectId, imageName, tag string,
 	cookies []*http.Cookie,
-) {
+) bool {
 	deployClient, err := clients.NewDeploymentClient(
 		deploymentHostname, defaultHTTPTimeout, token, apiKey, cookies,
 	)
 	if err != nil {
 		preflight.PrintFailOpenNote(errW, "list existing image tags", err)
-		return
+		return false
 	}
 	images, err := deployClient.ListImages(ctx, orgId, projectId)
 	if err != nil {
 		preflight.PrintFailOpenNote(errW, "list existing image tags", err)
-		return
+		return false
 	}
 	for _, img := range images {
 		if img.Name == imageName && slices.Contains(img.Tags, tag) {
-			preflight.PrintTagOverwriteWarning(errW, tag)
-			return
+			return true
 		}
 	}
+	return false
 }
 
 func validateImageArchitecture(imageRef string) error {
@@ -438,6 +454,8 @@ func init() {
 		StringVarP(&imageOrganization, "organization", "o", "", "Organization name that owns the project")
 	imagePushCmd.Flags().
 		StringVarP(&imageProject, "project", "p", "", "Project name the image belongs to")
+	imagePushCmd.Flags().
+		BoolVar(&imagePushForce, "force", false, "Push even when the tag already exists upstream, replacing the previous image (unrecoverable)")
 	_ = imagePushCmd.MarkFlagRequired("tag")
 
 	rootCmd.AddCommand(imageCmd)

--- a/cmd/images.go
+++ b/cmd/images.go
@@ -250,23 +250,6 @@ open when the existing tags cannot be listed.`,
 			return fmt.Errorf("failed to resolve project %q: %w", projectName, err)
 		}
 
-		// Deploy awareness: pushing to an existing tag replaces the previous
-		// image with no way to recover it or tell that the code changed —
-		// the CLI's only unrecoverable operation, so an occupied tag blocks
-		// unless --force names the intent. Fails open when tags can't be
-		// listed.
-		if existingImageTag(
-			cmd.Context(), cmd.ErrOrStderr(), orgId, projectId, imageName, imagePushTag, cookies,
-		) {
-			if !imagePushForce {
-				return fmt.Errorf(
-					"tag %s already exists upstream — pushing would replace it and the previous image is unrecoverable; pick a fresh tag, or pass --force to replace",
-					imagePushTag,
-				)
-			}
-			preflight.PrintTagOverwriteWarning(cmd.ErrOrStderr(), imagePushTag)
-		}
-
 		if _, err := exec.LookPath("docker"); err != nil {
 			return fmt.Errorf(
 				"docker CLI not found in PATH; please install Docker and ensure 'docker' is available: %w",
@@ -278,6 +261,24 @@ open when the existing tags cannot be listed.`,
 
 		if err := validateImageArchitecture(imageRef); err != nil {
 			return err
+		}
+
+		// Deploy awareness: pushing to an existing tag replaces the previous
+		// image with no way to recover it or tell that the code changed —
+		// the CLI's only unrecoverable operation, so an occupied tag blocks
+		// unless --force names the intent. Fails open when tags can't be
+		// listed. Runs after the cheap local checks, before anything is
+		// saved or uploaded.
+		if existingImageTag(
+			cmd.Context(), cmd.ErrOrStderr(), orgId, projectId, imageName, imagePushTag, cookies,
+		) {
+			if !imagePushForce {
+				return fmt.Errorf(
+					"tag %s already exists upstream — pushing would replace it and the previous image is unrecoverable; pick a fresh tag, or pass --force to replace",
+					imagePushTag,
+				)
+			}
+			preflight.PrintTagOverwriteWarning(cmd.ErrOrStderr(), imagePushTag)
 		}
 
 		tmpFile, err := os.CreateTemp("", "image-*.tar")

--- a/cmd/images.go
+++ b/cmd/images.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -8,12 +9,14 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
 	"github.com/Interactive-AI-Labs/interactive-cli/internal/files"
 	"github.com/Interactive-AI-Labs/interactive-cli/internal/output"
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/preflight"
 	"github.com/Interactive-AI-Labs/interactive-cli/internal/session"
 	"github.com/spf13/cobra"
 )
@@ -193,7 +196,12 @@ var imagePushCmd = &cobra.Command{
 	Use:     "push [image_name]",
 	Aliases: []string{"p"},
 	Short:   "Push an image for a project",
-	Long:    `Create a Docker image tarball and push it to the deployment images endpoint for a specific project.`,
+	Long: `Create a Docker image tarball and push it to the deployment images endpoint for a specific project.
+
+Pushing to a tag that already exists upstream replaces the previous image:
+the old bytes are unrecoverable and nothing records that the code changed.
+The CLI warns on stderr before pushing to an existing tag — prefer a fresh
+tag (or the git SHA) unless replacing is intended.`,
 	Example: `  iai images push my-service --tag 1.2.3
   iai images push my-service --tag 1.2.3 --organization my-org --project my-project`,
 	Args: cobra.ExactArgs(1),
@@ -238,6 +246,13 @@ var imagePushCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("failed to resolve project %q: %w", projectName, err)
 		}
+
+		// Deploy awareness: pushing to an existing tag replaces the previous
+		// image with no way to recover it or tell that the code changed.
+		// Warn before doing the work; fails open, never blocks the push.
+		warnExistingImageTag(
+			cmd.Context(), cmd.ErrOrStderr(), orgId, projectId, imageName, imagePushTag, cookies,
+		)
 
 		if _, err := exec.LookPath("docker"); err != nil {
 			return fmt.Errorf(
@@ -339,6 +354,32 @@ var imagePushCmd = &cobra.Command{
 
 		return nil
 	},
+}
+
+func warnExistingImageTag(
+	ctx context.Context,
+	errW io.Writer,
+	orgId, projectId, imageName, tag string,
+	cookies []*http.Cookie,
+) {
+	deployClient, err := clients.NewDeploymentClient(
+		deploymentHostname, defaultHTTPTimeout, token, apiKey, cookies,
+	)
+	if err != nil {
+		preflight.PrintFailOpenNote(errW, "list existing image tags", err)
+		return
+	}
+	images, err := deployClient.ListImages(ctx, orgId, projectId)
+	if err != nil {
+		preflight.PrintFailOpenNote(errW, "list existing image tags", err)
+		return
+	}
+	for _, img := range images {
+		if img.Name == imageName && slices.Contains(img.Tags, tag) {
+			preflight.PrintTagOverwriteWarning(errW, tag)
+			return
+		}
+	}
 }
 
 func validateImageArchitecture(imageRef string) error {

--- a/cmd/images_test.go
+++ b/cmd/images_test.go
@@ -85,7 +85,7 @@ func TestWarnExistingImageTag(t *testing.T) {
 			status:     http.StatusInternalServerError,
 			imagesJSON: `{}`,
 			tag:        "0.2.36",
-			wantPrefix: "could not list existing image tags (",
+			wantPrefix: "⚠ could not list existing image tags (",
 		},
 	}
 

--- a/cmd/images_test.go
+++ b/cmd/images_test.go
@@ -50,41 +50,42 @@ func TestImageDeleteValidation(t *testing.T) {
 	}
 }
 
-func TestWarnExistingImageTag(t *testing.T) {
+func TestExistingImageTag(t *testing.T) {
 	tests := []struct {
 		name       string
 		status     int
 		imagesJSON string
 		tag        string
-		want       string
+		wantExists bool
 		wantPrefix string
 	}{
 		{
-			name:       "existing tag warns",
+			name:       "existing tag detected",
 			status:     http.StatusOK,
 			imagesJSON: `{"images":[{"name":"app","tags":["0.2.35","0.2.36"]}]}`,
 			tag:        "0.2.36",
-			want:       "⚠ tag 0.2.36 already exists upstream — pushing replaces it; the previous image is unrecoverable.\n",
+			wantExists: true,
 		},
 		{
-			name:       "new tag stays silent",
+			name:       "new tag reports absent",
 			status:     http.StatusOK,
 			imagesJSON: `{"images":[{"name":"app","tags":["0.2.35"]}]}`,
 			tag:        "0.2.36",
-			want:       "",
+			wantExists: false,
 		},
 		{
-			name:       "same tag on another image stays silent",
+			name:       "same tag on another image reports absent",
 			status:     http.StatusOK,
 			imagesJSON: `{"images":[{"name":"other","tags":["0.2.36"]}]}`,
 			tag:        "0.2.36",
-			want:       "",
+			wantExists: false,
 		},
 		{
 			name:       "list failure fails open with a note",
 			status:     http.StatusInternalServerError,
 			imagesJSON: `{}`,
 			tag:        "0.2.36",
+			wantExists: false,
 			wantPrefix: "⚠ could not list existing image tags (",
 		},
 	}
@@ -104,8 +105,11 @@ func TestWarnExistingImageTag(t *testing.T) {
 			deploymentHostname, token = server.URL, "test-token"
 
 			var buf bytes.Buffer
-			warnExistingImageTag(context.Background(), &buf, "o1", "p1", "app", tt.tag, nil)
+			exists := existingImageTag(context.Background(), &buf, "o1", "p1", "app", tt.tag, nil)
 
+			if exists != tt.wantExists {
+				t.Errorf("exists = %v, want %v", exists, tt.wantExists)
+			}
 			got := buf.String()
 			if tt.wantPrefix != "" {
 				if !strings.HasPrefix(got, tt.wantPrefix) ||
@@ -114,8 +118,11 @@ func TestWarnExistingImageTag(t *testing.T) {
 				}
 				return
 			}
-			if got != tt.want {
-				t.Errorf("output = %q, want %q", got, tt.want)
+			if got != "" {
+				t.Errorf(
+					"output = %q, want none (the caller decides whether to warn or refuse)",
+					got,
+				)
 			}
 		})
 	}

--- a/cmd/images_test.go
+++ b/cmd/images_test.go
@@ -1,6 +1,12 @@
 package cmd
 
 import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -39,6 +45,77 @@ func TestImageDeleteValidation(t *testing.T) {
 			}
 			if diff := cmp.Diff(tt.want, err.Error()); diff != "" {
 				t.Errorf("error mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestWarnExistingImageTag(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		imagesJSON string
+		tag        string
+		want       string
+		wantPrefix string
+	}{
+		{
+			name:       "existing tag warns",
+			status:     http.StatusOK,
+			imagesJSON: `{"images":[{"name":"app","tags":["0.2.35","0.2.36"]}]}`,
+			tag:        "0.2.36",
+			want:       "⚠ tag 0.2.36 already exists upstream — pushing replaces it; the previous image is unrecoverable.\n",
+		},
+		{
+			name:       "new tag stays silent",
+			status:     http.StatusOK,
+			imagesJSON: `{"images":[{"name":"app","tags":["0.2.35"]}]}`,
+			tag:        "0.2.36",
+			want:       "",
+		},
+		{
+			name:       "same tag on another image stays silent",
+			status:     http.StatusOK,
+			imagesJSON: `{"images":[{"name":"other","tags":["0.2.36"]}]}`,
+			tag:        "0.2.36",
+			want:       "",
+		},
+		{
+			name:       "list failure fails open with a note",
+			status:     http.StatusInternalServerError,
+			imagesJSON: `{}`,
+			tag:        "0.2.36",
+			wantPrefix: "could not list existing image tags (",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(tt.status)
+					fmt.Fprint(w, tt.imagesJSON)
+				}),
+			)
+			t.Cleanup(server.Close)
+
+			origHostname, origToken := deploymentHostname, token
+			t.Cleanup(func() { deploymentHostname, token = origHostname, origToken })
+			deploymentHostname, token = server.URL, "test-token"
+
+			var buf bytes.Buffer
+			warnExistingImageTag(context.Background(), &buf, "o1", "p1", "app", tt.tag, nil)
+
+			got := buf.String()
+			if tt.wantPrefix != "" {
+				if !strings.HasPrefix(got, tt.wantPrefix) ||
+					!strings.HasSuffix(got, "— proceeding without pre-flight check\n") {
+					t.Errorf("output = %q, want fail-open note with prefix %q", got, tt.wantPrefix)
+				}
+				return
+			}
+			if got != tt.want {
+				t.Errorf("output = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/cmd/images_test.go
+++ b/cmd/images_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -100,12 +101,17 @@ func TestExistingImageTag(t *testing.T) {
 			)
 			t.Cleanup(server.Close)
 
-			origHostname, origToken := deploymentHostname, token
-			t.Cleanup(func() { deploymentHostname, token = origHostname, origToken })
-			deploymentHostname, token = server.URL, "test-token"
+			deployClient, err := clients.NewDeploymentClient(
+				server.URL, defaultHTTPTimeout, "test-token", "", nil,
+			)
+			if err != nil {
+				t.Fatalf("NewDeploymentClient: %v", err)
+			}
 
 			var buf bytes.Buffer
-			exists := existingImageTag(context.Background(), &buf, "o1", "p1", "app", tt.tag, nil)
+			exists := existingImageTag(
+				context.Background(), &buf, deployClient, "o1", "p1", "app", tt.tag,
+			)
 
 			if exists != tt.wantExists {
 				t.Errorf("exists = %v, want %v", exists, tt.wantExists)

--- a/cmd/images_test.go
+++ b/cmd/images_test.go
@@ -133,3 +133,45 @@ func TestExistingImageTag(t *testing.T) {
 		})
 	}
 }
+
+func TestRefuseTagOverwrite(t *testing.T) {
+	tests := []struct {
+		name     string
+		exists   bool
+		force    bool
+		wantErr  string
+		wantWarn string
+	}{
+		{
+			name: "absent tag proceeds",
+		},
+		{
+			name:    "existing tag without force refuses",
+			exists:  true,
+			wantErr: "tag 0.2.36 already exists upstream — pushing would replace it and the previous image is unrecoverable; pick a fresh tag, or pass --force to replace",
+		},
+		{
+			name:     "existing tag with force warns and proceeds",
+			exists:   true,
+			force:    true,
+			wantWarn: "⚠ tag 0.2.36 already exists upstream — pushing replaces it; the previous image is unrecoverable.\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := refuseTagOverwrite(&buf, "0.2.36", tt.exists, tt.force)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			} else if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("error = %v, want %q", err, tt.wantErr)
+			}
+			if got := buf.String(); got != tt.wantWarn {
+				t.Errorf("warn = %q, want %q", got, tt.wantWarn)
+			}
+		})
+	}
+}

--- a/cmd/preflight.go
+++ b/cmd/preflight.go
@@ -11,11 +11,6 @@ import (
 	"github.com/Interactive-AI-Labs/interactive-cli/internal/preflight"
 )
 
-// runUpdatePreflight prints the deploy-awareness banner for a pending
-// agent/service update — or the fail-open note when live state could not be
-// fetched — and enforces --expect-revision when set. Everything goes to errW
-// (stderr) so stdout and exit codes stay identical for scripts; the only new
-// error path is the opt-in --expect-revision mismatch.
 func runUpdatePreflight(
 	errW io.Writer,
 	revision int,
@@ -24,8 +19,6 @@ func runUpdatePreflight(
 	expectSet bool,
 	expectRevision int,
 ) error {
-	// --expect-revision runs first: an update that will be refused must not
-	// print "proceeding" or "this update creates revision N+1" beforehand.
 	if expectSet {
 		if liveErr != nil {
 			return fmt.Errorf(
@@ -33,8 +26,11 @@ func runUpdatePreflight(
 				expectRevision, liveErr,
 			)
 		}
-		if err := preflight.CheckExpectedRevision(expectRevision, revision); err != nil {
-			return err
+		if revision != expectRevision {
+			return fmt.Errorf(
+				"live revision is %d, expected %d — not applying (--expect-revision)",
+				revision, expectRevision,
+			)
 		}
 	}
 	if liveErr != nil {
@@ -45,13 +41,6 @@ func runUpdatePreflight(
 	return nil
 }
 
-// printDroppedEnvSecretWarnings warns when a --env / --secret full-list
-// replacement drops names that exist on the live resource (the flags
-// replace, not merge — the documented footgun is passing only the one new
-// value), and reports whether anything was dropped so the caller can gate
-// on it. Callers pass each flag's Changed state so an untouched list never
-// warns; --clear-env / --clear-secret stay silent by design, since clearing
-// is explicit intent. Call only when live state was fetched successfully.
 func printDroppedEnvSecretWarnings(
 	errW io.Writer,
 	envChanged, secretChanged bool,
@@ -89,11 +78,6 @@ func printDroppedEnvSecretWarnings(
 	return dropped
 }
 
-// checkUpdateGates refuses an update whose pre-flight detected destruction
-// implied by omission — a content pin downgrade/removal versus live, or
-// env/secret entries a full-list replacement drops. The details were already
-// printed to stderr; --force is the single explicit override, so the first
-// attempt fails before any mutation and a deliberate second command applies.
 func checkUpdateGates(force, pinRollback, droppedEntries bool) error {
 	var reasons []string
 	if pinRollback {
@@ -111,11 +95,6 @@ func checkUpdateGates(force, pinRollback, droppedEntries bool) error {
 	)
 }
 
-// printConfigPreflight prints the content pin summary — and, with
-// --show-diff, the full live-vs-incoming diff — for an update that replaces
-// the whole agent config, and reports whether a known pin section downgraded
-// or removed a pin (the caller gates on it). rawIncoming is the config as it
-// will be PATCHed. Rendering problems never block.
 func printConfigPreflight(
 	errW io.Writer,
 	liveConfig any,

--- a/cmd/preflight.go
+++ b/cmd/preflight.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/output"
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/preflight"
+)
+
+// runUpdatePreflight prints the deploy-awareness banner for a pending
+// agent/service update — or the fail-open note when live state could not be
+// fetched — and enforces --expect-revision when set. Everything goes to errW
+// (stderr) so stdout and exit codes stay identical for scripts; the only new
+// error path is the opt-in --expect-revision mismatch.
+func runUpdatePreflight(
+	errW io.Writer,
+	revision int,
+	updated string,
+	liveErr error,
+	expectSet bool,
+	expectRevision int,
+) error {
+	// --expect-revision runs first: an update that will be refused must not
+	// print "proceeding" or "this update creates revision N+1" beforehand.
+	if expectSet {
+		if liveErr != nil {
+			return fmt.Errorf(
+				"--expect-revision %d: could not verify live revision: %w",
+				expectRevision, liveErr,
+			)
+		}
+		if err := preflight.CheckExpectedRevision(expectRevision, revision); err != nil {
+			return err
+		}
+	}
+	if liveErr != nil {
+		preflight.PrintFailOpenNote(errW, "fetch live state", liveErr)
+		return nil
+	}
+	preflight.PrintUpdateBanner(errW, "", revision, updated)
+	return nil
+}
+
+// printConfigPreflight prints the content pin summary — and, with
+// --show-diff, the full live-vs-incoming diff — for an update that replaces
+// the whole agent config. rawIncoming is the config as it will be PATCHed.
+// Best-effort like all pre-flight output: rendering problems never block.
+func printConfigPreflight(
+	errW io.Writer,
+	liveConfig any,
+	rawIncoming json.RawMessage,
+	showDiff bool,
+) {
+	var incoming any
+	if err := json.Unmarshal(rawIncoming, &incoming); err != nil {
+		return
+	}
+	preflight.PrintPinChanges(errW, liveConfig, incoming)
+	if showDiff {
+		if err := output.PrintYAMLDiff(errW, "live", liveConfig, "incoming", incoming); err != nil {
+			preflight.PrintFailOpenNote(errW, "render config diff", err)
+		}
+	}
+}

--- a/cmd/preflight.go
+++ b/cmd/preflight.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
 	"github.com/Interactive-AI-Labs/interactive-cli/internal/output"
 	"github.com/Interactive-AI-Labs/interactive-cli/internal/preflight"
 )
@@ -41,6 +43,43 @@ func runUpdatePreflight(
 	}
 	preflight.PrintUpdateBanner(errW, "", revision, updated)
 	return nil
+}
+
+// printDroppedEnvSecretWarnings warns when a --env / --secret full-list
+// replacement drops names that exist on the live resource (the flags
+// replace, not merge — the documented footgun is passing only the one new
+// value). Callers pass each flag's Changed state so an untouched list never
+// warns; --clear-env / --clear-secret stay silent by design, since clearing
+// is explicit intent. Call only when live state was fetched successfully.
+func printDroppedEnvSecretWarnings(
+	errW io.Writer,
+	envChanged, secretChanged bool,
+	liveEnv []clients.EnvVar,
+	liveRefs []clients.SecretRef,
+	envArgs, secretArgs []string,
+) {
+	if envChanged {
+		live := make([]string, 0, len(liveEnv))
+		for _, e := range liveEnv {
+			live = append(live, e.Name)
+		}
+		incoming := make([]string, 0, len(envArgs))
+		for _, e := range envArgs {
+			incoming = append(incoming, strings.TrimSpace(strings.SplitN(e, "=", 2)[0]))
+		}
+		preflight.PrintDroppedListEntries(errW, "env vars", "--env", live, incoming)
+	}
+	if secretChanged {
+		live := make([]string, 0, len(liveRefs))
+		for _, r := range liveRefs {
+			live = append(live, r.SecretName)
+		}
+		incoming := make([]string, 0, len(secretArgs))
+		for _, s := range secretArgs {
+			incoming = append(incoming, strings.TrimSpace(s))
+		}
+		preflight.PrintDroppedListEntries(errW, "secret refs", "--secret", live, incoming)
+	}
 }
 
 // printConfigPreflight prints the content pin summary — and, with

--- a/cmd/preflight.go
+++ b/cmd/preflight.go
@@ -48,7 +48,8 @@ func runUpdatePreflight(
 // printDroppedEnvSecretWarnings warns when a --env / --secret full-list
 // replacement drops names that exist on the live resource (the flags
 // replace, not merge — the documented footgun is passing only the one new
-// value). Callers pass each flag's Changed state so an untouched list never
+// value), and reports whether anything was dropped so the caller can gate
+// on it. Callers pass each flag's Changed state so an untouched list never
 // warns; --clear-env / --clear-secret stay silent by design, since clearing
 // is explicit intent. Call only when live state was fetched successfully.
 func printDroppedEnvSecretWarnings(
@@ -57,7 +58,8 @@ func printDroppedEnvSecretWarnings(
 	liveEnv []clients.EnvVar,
 	liveRefs []clients.SecretRef,
 	envArgs, secretArgs []string,
-) {
+) bool {
+	dropped := false
 	if envChanged {
 		live := make([]string, 0, len(liveEnv))
 		for _, e := range liveEnv {
@@ -67,7 +69,9 @@ func printDroppedEnvSecretWarnings(
 		for _, e := range envArgs {
 			incoming = append(incoming, strings.TrimSpace(strings.SplitN(e, "=", 2)[0]))
 		}
-		preflight.PrintDroppedListEntries(errW, "env vars", "--env", live, incoming)
+		if preflight.PrintDroppedListEntries(errW, "env vars", "--env", live, incoming) {
+			dropped = true
+		}
 	}
 	if secretChanged {
 		live := make([]string, 0, len(liveRefs))
@@ -78,28 +82,55 @@ func printDroppedEnvSecretWarnings(
 		for _, s := range secretArgs {
 			incoming = append(incoming, strings.TrimSpace(s))
 		}
-		preflight.PrintDroppedListEntries(errW, "secret refs", "--secret", live, incoming)
+		if preflight.PrintDroppedListEntries(errW, "secret refs", "--secret", live, incoming) {
+			dropped = true
+		}
 	}
+	return dropped
+}
+
+// checkUpdateGates refuses an update whose pre-flight detected destruction
+// implied by omission — a content pin downgrade/removal versus live, or
+// env/secret entries a full-list replacement drops. The details were already
+// printed to stderr; --force is the single explicit override, so the first
+// attempt fails before any mutation and a deliberate second command applies.
+func checkUpdateGates(force, pinRollback, droppedEntries bool) error {
+	var reasons []string
+	if pinRollback {
+		reasons = append(reasons, "downgrades or removes live content pins")
+	}
+	if droppedEntries {
+		reasons = append(reasons, "drops live env vars or secret refs")
+	}
+	if len(reasons) == 0 || force {
+		return nil
+	}
+	return fmt.Errorf(
+		"refusing to apply: this update %s (details above) — pass --force if this is intended",
+		strings.Join(reasons, " and "),
+	)
 }
 
 // printConfigPreflight prints the content pin summary — and, with
 // --show-diff, the full live-vs-incoming diff — for an update that replaces
-// the whole agent config. rawIncoming is the config as it will be PATCHed.
-// Best-effort like all pre-flight output: rendering problems never block.
+// the whole agent config, and reports whether a known pin section downgraded
+// or removed a pin (the caller gates on it). rawIncoming is the config as it
+// will be PATCHed. Rendering problems never block.
 func printConfigPreflight(
 	errW io.Writer,
 	liveConfig any,
 	rawIncoming json.RawMessage,
 	showDiff bool,
-) {
+) bool {
 	var incoming any
 	if err := json.Unmarshal(rawIncoming, &incoming); err != nil {
-		return
+		return false
 	}
-	preflight.PrintPinChanges(errW, liveConfig, incoming)
+	pinRollback := preflight.PrintPinChanges(errW, liveConfig, incoming)
 	if showDiff {
 		if err := output.PrintYAMLDiff(errW, "live", liveConfig, "incoming", incoming); err != nil {
 			preflight.PrintFailOpenNote(errW, "render config diff", err)
 		}
 	}
+	return pinRollback
 }

--- a/cmd/preflight_test.go
+++ b/cmd/preflight_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
 )
 
 func TestRunUpdatePreflight(t *testing.T) {
@@ -74,6 +76,74 @@ func TestRunUpdatePreflight(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), tt.wantErr) {
 				t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestPrintDroppedEnvSecretWarnings(t *testing.T) {
+	liveEnv := []clients.EnvVar{
+		{Name: "LOG_LEVEL", Value: "info"},
+		{Name: "DB_HOST", Value: "db"},
+	}
+	liveRefs := []clients.SecretRef{{SecretName: "api-keys"}}
+
+	tests := []struct {
+		name          string
+		envChanged    bool
+		secretChanged bool
+		envArgs       []string
+		secretArgs    []string
+		want          string
+	}{
+		{
+			name:       "env replacement dropping a live var warns",
+			envChanged: true,
+			envArgs:    []string{"LOG_LEVEL=debug"},
+			want: "⚠ this update drops live env vars: DB_HOST" +
+				" (--env replaces the entire list; pass every value you want to keep)\n",
+		},
+		{
+			name:          "secret replacement dropping a live ref warns",
+			secretChanged: true,
+			secretArgs:    []string{"other-secret"},
+			want: "⚠ this update drops live secret refs: api-keys" +
+				" (--secret replaces the entire list; pass every value you want to keep)\n",
+		},
+		{
+			name:       "full list passed stays silent",
+			envChanged: true,
+			envArgs:    []string{"DB_HOST=db2", "LOG_LEVEL=debug", "EXTRA=1"},
+			want:       "",
+		},
+		{
+			name: "untouched flags stay silent",
+			want: "",
+		},
+		{
+			name:          "both lists dropping warn env first",
+			envChanged:    true,
+			secretChanged: true,
+			envArgs:       []string{"NEW=1"},
+			secretArgs:    []string{"other-secret"},
+			want: "⚠ this update drops live env vars: DB_HOST, LOG_LEVEL" +
+				" (--env replaces the entire list; pass every value you want to keep)\n" +
+				"⚠ this update drops live secret refs: api-keys" +
+				" (--secret replaces the entire list; pass every value you want to keep)\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			printDroppedEnvSecretWarnings(
+				&buf,
+				tt.envChanged, tt.secretChanged,
+				liveEnv, liveRefs,
+				tt.envArgs, tt.secretArgs,
+			)
+			if got := buf.String(); got != tt.want {
+				t.Errorf("warnings = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/cmd/preflight_test.go
+++ b/cmd/preflight_test.go
@@ -27,7 +27,7 @@ func TestRunUpdatePreflight(t *testing.T) {
 		{
 			name:    "fails open on describe error",
 			liveErr: errors.New("boom"),
-			wantOut: "could not fetch live state (boom) — proceeding without pre-flight check\n",
+			wantOut: "⚠ could not fetch live state (boom) — proceeding without pre-flight check\n",
 		},
 		{
 			name:           "expect-revision match proceeds",

--- a/cmd/preflight_test.go
+++ b/cmd/preflight_test.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRunUpdatePreflight(t *testing.T) {
+	tests := []struct {
+		name           string
+		revision       int
+		updated        string
+		liveErr        error
+		expectSet      bool
+		expectRevision int
+		wantOut        string
+		wantErr        string
+	}{
+		{
+			name:     "prints banner",
+			revision: 12,
+			updated:  "2026-07-23T16:40:00Z",
+			wantOut:  "Live: revision 12, last updated 2026-07-23 16:40 UTC — this update creates revision 13\n",
+		},
+		{
+			name:    "fails open on describe error",
+			liveErr: errors.New("boom"),
+			wantOut: "could not fetch live state (boom) — proceeding without pre-flight check\n",
+		},
+		{
+			name:           "expect-revision match proceeds",
+			revision:       12,
+			expectSet:      true,
+			expectRevision: 12,
+			wantOut:        "Live: revision 12 — this update creates revision 13\n",
+		},
+		{
+			name:           "expect-revision mismatch errors without banner",
+			revision:       14,
+			expectSet:      true,
+			expectRevision: 12,
+			wantOut:        "",
+			wantErr:        "live revision is 14, expected 12 — not applying (--expect-revision)",
+		},
+		{
+			name:           "expect-revision with describe error errors without fail-open note",
+			liveErr:        errors.New("boom"),
+			expectSet:      true,
+			expectRevision: 12,
+			wantOut:        "",
+			wantErr:        "--expect-revision 12: could not verify live revision: boom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := runUpdatePreflight(
+				&buf, tt.revision, tt.updated, tt.liveErr, tt.expectSet, tt.expectRevision,
+			)
+			if got := buf.String(); got != tt.wantOut {
+				t.Errorf("output = %q, want %q", got, tt.wantOut)
+			}
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/preflight_test.go
+++ b/cmd/preflight_test.go
@@ -95,6 +95,7 @@ func TestPrintDroppedEnvSecretWarnings(t *testing.T) {
 		envArgs       []string
 		secretArgs    []string
 		want          string
+		wantDropped   bool
 	}{
 		{
 			name:       "env replacement dropping a live var warns",
@@ -102,6 +103,7 @@ func TestPrintDroppedEnvSecretWarnings(t *testing.T) {
 			envArgs:    []string{"LOG_LEVEL=debug"},
 			want: "⚠ this update drops live env vars: DB_HOST" +
 				" (--env replaces the entire list; pass every value you want to keep)\n",
+			wantDropped: true,
 		},
 		{
 			name:          "secret replacement dropping a live ref warns",
@@ -109,6 +111,7 @@ func TestPrintDroppedEnvSecretWarnings(t *testing.T) {
 			secretArgs:    []string{"other-secret"},
 			want: "⚠ this update drops live secret refs: api-keys" +
 				" (--secret replaces the entire list; pass every value you want to keep)\n",
+			wantDropped: true,
 		},
 		{
 			name:       "full list passed stays silent",
@@ -130,13 +133,14 @@ func TestPrintDroppedEnvSecretWarnings(t *testing.T) {
 				" (--env replaces the entire list; pass every value you want to keep)\n" +
 				"⚠ this update drops live secret refs: api-keys" +
 				" (--secret replaces the entire list; pass every value you want to keep)\n",
+			wantDropped: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			printDroppedEnvSecretWarnings(
+			dropped := printDroppedEnvSecretWarnings(
 				&buf,
 				tt.envChanged, tt.secretChanged,
 				liveEnv, liveRefs,
@@ -144,6 +148,67 @@ func TestPrintDroppedEnvSecretWarnings(t *testing.T) {
 			)
 			if got := buf.String(); got != tt.want {
 				t.Errorf("warnings = %q, want %q", got, tt.want)
+			}
+			if dropped != tt.wantDropped {
+				t.Errorf("dropped = %v, want %v", dropped, tt.wantDropped)
+			}
+		})
+	}
+}
+
+func TestCheckUpdateGates(t *testing.T) {
+	tests := []struct {
+		name           string
+		force          bool
+		pinRollback    bool
+		droppedEntries bool
+		wantErr        string
+	}{
+		{
+			name: "nothing detected proceeds",
+		},
+		{
+			name:        "pin rollback refuses",
+			pinRollback: true,
+			wantErr: "refusing to apply: this update downgrades or removes live content pins" +
+				" (details above) — pass --force if this is intended",
+		},
+		{
+			name:           "dropped entries refuse",
+			droppedEntries: true,
+			wantErr: "refusing to apply: this update drops live env vars or secret refs" +
+				" (details above) — pass --force if this is intended",
+		},
+		{
+			name:           "both reasons listed together",
+			pinRollback:    true,
+			droppedEntries: true,
+			wantErr: "refusing to apply: this update downgrades or removes live content pins" +
+				" and drops live env vars or secret refs" +
+				" (details above) — pass --force if this is intended",
+		},
+		{
+			name:           "force overrides everything",
+			force:          true,
+			pinRollback:    true,
+			droppedEntries: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkUpdateGates(tt.force, tt.pinRollback, tt.droppedEntries)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error %q, got nil", tt.wantErr)
+			}
+			if err.Error() != tt.wantErr {
+				t.Errorf("error = %q, want %q", err.Error(), tt.wantErr)
 			}
 		})
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version            = "0.38.7"
+	version            = "0.39.0"
 	cfgDirName         = ".interactiveai"
 	sessionFileName    = "session_cookies.json"
 	defaultHTTPTimeout = 30 * time.Second

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -65,6 +65,7 @@ var (
 	serviceStackId string
 
 	serviceExpectRevision int
+	serviceForce          bool
 )
 
 var servicesCmd = &cobra.Command{
@@ -170,7 +171,10 @@ Use --clear-env, --clear-secret, --clear-healthcheck, --clear-schedule, or
 Before applying, the CLI prints deploy-awareness output to stderr: the live
 revision this update replaces, and the names of any env vars or secret refs
 that --env/--secret would drop from the live service (the flags replace the
-entire list). These checks fail open and never block; use --expect-revision
+entire list). The update is refused when it would drop live env vars or
+secret refs via --env/--secret; pass --force to apply anyway. --clear-env
+and --clear-secret never trigger the gate: clearing is explicit intent. The
+checks fail open when live state cannot be fetched; use --expect-revision
 to fail instead when the live revision differs from what you expect.`,
 	Example: `  iai services update my-svc --image-tag v2
   iai services update my-svc --image-tag v2 --expect-revision 47
@@ -241,13 +245,17 @@ to fail instead when the live revision differs from what you expect.`,
 		); err != nil {
 			return err
 		}
+		droppedEntries := false
 		if liveErr == nil {
-			printDroppedEnvSecretWarnings(
+			droppedEntries = printDroppedEnvSecretWarnings(
 				cmd.ErrOrStderr(),
 				cmd.Flags().Changed("env"), cmd.Flags().Changed("secret"),
 				live.Env, live.SecretRefs,
 				serviceEnvVars, serviceSecretRefs,
 			)
+		}
+		if err := checkUpdateGates(serviceForce, false, droppedEntries); err != nil {
+			return err
 		}
 
 		fmt.Fprintln(out)
@@ -727,6 +735,7 @@ Use the reported field names with 'iai services logs --fields' to include them i
 var (
 	syncProject      string
 	syncOrganization string
+	syncAllowDelete  []string
 )
 
 var servRevisionsCmd = &cobra.Command{
@@ -861,18 +870,19 @@ var servicesSyncCmd = &cobra.Command{
 The sync command will:
 - Create services that exist in the config but not in the project
 - Update services that exist in both the config and the project
-- Delete services that exist in the project but not in the config (for the specified stack)
+- Delete services that exist in the project but not in the config, only
+  with --allow-delete=services; otherwise those deletions are refused and
+  reported on stderr while creates and updates still apply
 
 Updates replace the whole live spec of each service. For every service
 updated, the live revision being replaced is printed to stderr so a sync
-from a stale config file is visible before it lands. Services the config
-file no longer mentions are deleted; those deletions are announced on
-stderr before service changes begin, and run after service creates/updates,
-so an unintended delete from a stale config can still be aborted.
+from a stale config file is visible before it lands. With
+--allow-delete=services, deletes run after service creates/updates.
 
 The project is selected with --project or via 'iai projects select', and the config file with --cfg-file.`,
 	Example: `  iai services sync --cfg-file stack.yaml
-  iai services sync --cfg-file stack.yaml --project my-project`,
+  iai services sync --cfg-file stack.yaml --project my-project
+  iai services sync --cfg-file stack.yaml --allow-delete services`,
 	Args:       cobra.NoArgs,
 	Deprecated: "use 'iai stack sync' instead",
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -964,6 +974,9 @@ The project is selected with --project or via 'iai projects select', and the con
 			projectId,
 			cfg.StackId,
 			svcBodies,
+			sync.Options{
+				AllowDelete: sync.AllowDeleteResource(syncAllowDelete, "services"),
+			},
 		)
 		close(done)
 		fmt.Fprintln(out)
@@ -1086,6 +1099,8 @@ func init() {
 		BoolVar(&serviceClearStackId, "clear-stack-id", false, "Remove the service from its stack")
 	servUCmd.Flags().
 		IntVar(&serviceExpectRevision, "expect-revision", 0, "Fail without applying unless the live revision equals this value (opt-in staleness guard)")
+	servUCmd.Flags().
+		BoolVar(&serviceForce, "force", false, "Apply even when the update would drop live env vars or secret refs")
 
 	// Flags for "services list"
 	servListCmd.Flags().
@@ -1208,6 +1223,8 @@ func init() {
 		StringVarP(&syncProject, "project", "p", "", "Project name to sync services in")
 	servicesSyncCmd.Flags().
 		StringVarP(&syncOrganization, "organization", "o", "", "Organization name that owns the project")
+	servicesSyncCmd.Flags().
+		StringSliceVar(&syncAllowDelete, "allow-delete", nil, "Resource types the sync may delete when the config omits them (services); deletions are refused otherwise")
 
 	// Register commands
 	rootCmd.AddCommand(servicesCmd)

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -167,10 +167,11 @@ alongside either to change the timezone.
 Use --clear-env, --clear-secret, --clear-healthcheck, --clear-schedule, or
 --clear-stack-id to remove those configurations entirely.
 
-Before applying, the CLI prints the live revision this update replaces to
-stderr, so a deploy based on stale local state is visible before it lands.
-The check fails open and never blocks; use --expect-revision to fail instead
-when the live revision differs from what you expect.`,
+Before applying, the CLI prints deploy-awareness output to stderr: the live
+revision this update replaces, and the names of any env vars or secret refs
+that --env/--secret would drop from the live service (the flags replace the
+entire list). These checks fail open and never block; use --expect-revision
+to fail instead when the live revision differs from what you expect.`,
 	Example: `  iai services update my-svc --image-tag v2
   iai services update my-svc --image-tag v2 --expect-revision 47
   iai services update my-svc --memory 1G --cpu 0.5
@@ -239,6 +240,14 @@ when the live revision differs from what you expect.`,
 			cmd.Flags().Changed("expect-revision"), serviceExpectRevision,
 		); err != nil {
 			return err
+		}
+		if liveErr == nil {
+			printDroppedEnvSecretWarnings(
+				cmd.ErrOrStderr(),
+				cmd.Flags().Changed("env"), cmd.Flags().Changed("secret"),
+				live.Env, live.SecretRefs,
+				serviceEnvVars, serviceSecretRefs,
+			)
 		}
 
 		fmt.Fprintln(out)
@@ -856,7 +865,10 @@ The sync command will:
 
 Updates replace the whole live spec of each service. For every service
 updated, the live revision being replaced is printed to stderr so a sync
-from a stale config file is visible before it lands.
+from a stale config file is visible before it lands. Services the config
+file no longer mentions are deleted; those deletions are announced on
+stderr before the sync writes anything, and run last, so an unintended
+delete from a stale config can still be aborted.
 
 The project is selected with --project or via 'iai projects select', and the config file with --cfg-file.`,
 	Example: `  iai services sync --cfg-file stack.yaml

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -229,8 +229,6 @@ to fail instead when the live revision differs from what you expect.`,
 			return fmt.Errorf("no fields to update; pass at least one flag")
 		}
 
-		// Deploy awareness: surface the live revision this update replaces.
-		// Fails open unless --expect-revision demands the check.
 		live, liveErr := deployClient.DescribeService(
 			cmd.Context(), pCtx.orgId, pCtx.projectId, serviceName,
 		)

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -1098,7 +1098,7 @@ func init() {
 	servUCmd.Flags().
 		BoolVar(&serviceClearStackId, "clear-stack-id", false, "Remove the service from its stack")
 	servUCmd.Flags().
-		IntVar(&serviceExpectRevision, "expect-revision", 0, "Fail without applying unless the live revision equals this value (opt-in staleness guard)")
+		IntVar(&serviceExpectRevision, "expect-revision", 0, "Fail without applying unless the live revision equals this value; 0 is valid and matches a never-updated service (opt-in staleness guard)")
 	servUCmd.Flags().
 		BoolVar(&serviceForce, "force", false, "Apply even when the update would drop live env vars or secret refs")
 

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -867,8 +867,8 @@ Updates replace the whole live spec of each service. For every service
 updated, the live revision being replaced is printed to stderr so a sync
 from a stale config file is visible before it lands. Services the config
 file no longer mentions are deleted; those deletions are announced on
-stderr before the sync writes anything, and run last, so an unintended
-delete from a stale config can still be aborted.
+stderr before service changes begin, and run after service creates/updates,
+so an unintended delete from a stale config can still be aborted.
 
 The project is selected with --project or via 'iai projects select', and the config file with --cfg-file.`,
 	Example: `  iai services sync --cfg-file stack.yaml

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -63,6 +63,8 @@ var (
 	serviceClearStackId     bool
 
 	serviceStackId string
+
+	serviceExpectRevision int
 )
 
 var servicesCmd = &cobra.Command{
@@ -163,8 +165,14 @@ and --schedule-downtime auto-clears any existing uptime. Pass --schedule-timezon
 alongside either to change the timezone.
 
 Use --clear-env, --clear-secret, --clear-healthcheck, --clear-schedule, or
---clear-stack-id to remove those configurations entirely.`,
+--clear-stack-id to remove those configurations entirely.
+
+Before applying, the CLI prints the live revision this update replaces to
+stderr, so a deploy based on stale local state is visible before it lands.
+The check fails open and never blocks; use --expect-revision to fail instead
+when the live revision differs from what you expect.`,
 	Example: `  iai services update my-svc --image-tag v2
+  iai services update my-svc --image-tag v2 --expect-revision 47
   iai services update my-svc --memory 1G --cpu 0.5
   iai services update my-svc --replicas 3
   iai services update my-svc --autoscaling-max-replicas 8
@@ -214,6 +222,23 @@ Use --clear-env, --clear-secret, --clear-healthcheck, --clear-schedule, or
 		}
 		if len(patch) == 0 {
 			return fmt.Errorf("no fields to update; pass at least one flag")
+		}
+
+		// Deploy awareness: surface the live revision this update replaces.
+		// Fails open unless --expect-revision demands the check.
+		live, liveErr := deployClient.DescribeService(
+			cmd.Context(), pCtx.orgId, pCtx.projectId, serviceName,
+		)
+		var liveRevision int
+		var liveUpdated string
+		if liveErr == nil {
+			liveRevision, liveUpdated = live.Revision, live.Updated
+		}
+		if err := runUpdatePreflight(
+			cmd.ErrOrStderr(), liveRevision, liveUpdated, liveErr,
+			cmd.Flags().Changed("expect-revision"), serviceExpectRevision,
+		); err != nil {
+			return err
 		}
 
 		fmt.Fprintln(out)
@@ -829,6 +854,10 @@ The sync command will:
 - Update services that exist in both the config and the project
 - Delete services that exist in the project but not in the config (for the specified stack)
 
+Updates replace the whole live spec of each service. For every service
+updated, the live revision being replaced is printed to stderr so a sync
+from a stale config file is visible before it lands.
+
 The project is selected with --project or via 'iai projects select', and the config file with --cfg-file.`,
 	Example: `  iai services sync --cfg-file stack.yaml
   iai services sync --cfg-file stack.yaml --project my-project`,
@@ -917,6 +946,7 @@ The project is selected with --project or via 'iai projects select', and the con
 
 		result, err := sync.Services(
 			cmd.Context(),
+			cmd.ErrOrStderr(),
 			deployClient,
 			orgId,
 			projectId,
@@ -1042,6 +1072,8 @@ func init() {
 		StringVar(&serviceStackId, "stack-id", "", "Stack ID to assign the service to")
 	servUCmd.Flags().
 		BoolVar(&serviceClearStackId, "clear-stack-id", false, "Remove the service from its stack")
+	servUCmd.Flags().
+		IntVar(&serviceExpectRevision, "expect-revision", 0, "Fail without applying unless the live revision equals this value (opt-in staleness guard)")
 
 	// Flags for "services list"
 	servListCmd.Flags().

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -252,6 +252,7 @@ The organization and project are read from the config file, flags, or resolved v
 
 			dbResult, err := sync.Databases(
 				cmd.Context(),
+				cmd.ErrOrStderr(),
 				deployClient,
 				orgId,
 				projectId,

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -39,8 +39,9 @@ Updates replace the whole live spec of each resource. For every service or
 agent updated, the live revision being replaced is printed to stderr so a
 sync from a stale config file is visible before it lands. Services and
 agents the config file no longer mentions are deleted; those deletions are
-announced on stderr before the sync writes anything, and run last, so an
-unintended delete from a stale config can still be aborted.
+announced on stderr before changes to that resource type begin, and run
+after its creates/updates, so an unintended delete from a stale config can
+still be aborted.
 
 The organization and project are read from the config file, flags, or resolved via 'iai organizations select' / 'iai projects select'.`,
 	Example: `  iai stacks sync --file stack.yaml

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -37,7 +37,10 @@ Databases are created, updated, or deleted (--allow-delete=databases) to match t
 
 Updates replace the whole live spec of each resource. For every service or
 agent updated, the live revision being replaced is printed to stderr so a
-sync from a stale config file is visible before it lands.
+sync from a stale config file is visible before it lands. Services and
+agents the config file no longer mentions are deleted; those deletions are
+announced on stderr before the sync writes anything, and run last, so an
+unintended delete from a stale config can still be aborted.
 
 The organization and project are read from the config file, flags, or resolved via 'iai organizations select' / 'iai projects select'.`,
 	Example: `  iai stacks sync --file stack.yaml

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -125,11 +125,6 @@ The organization and project are read from the config file, flags, or resolved v
 		}
 		ranSync := false
 
-		// runPhase runs one resource type's sync with its progress line and
-		// prints the outcome: in a dry run the plan on stdout is the
-		// deliverable; otherwise results print as applied, with refused
-		// deletions reported. label is the plural noun, which is also the
-		// --allow-delete value.
 		runPhase := func(label string, run func(sync.Options) (*sync.Result, error)) error {
 			ranSync = true
 			fmt.Fprint(out, verb+" "+label)

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -16,6 +16,7 @@ var (
 	stackSyncProject      string
 	stackSyncOrganization string
 	stackSyncAllowDelete  []string
+	stackSyncDryRun       bool
 )
 
 var stackCmd = &cobra.Command{
@@ -31,22 +32,26 @@ var stackSyncCmd = &cobra.Command{
 	Short: "Sync services, agents, and databases from a stack config file",
 	Long: `Sync services, agents, and databases in a project from a stack configuration file.
 
-Services are created, updated, or deleted to match the config file.
-Agents are created, updated, or deleted to match the config file.
-Databases are created, updated, or deleted (--allow-delete=databases) to match the config file.
+Services, agents, and databases are created and updated to match the config
+file. Resources the config file no longer mentions are NOT deleted by
+default: a config that omits a resource looks identical to a stale one, so
+the sync refuses each deletion, reports it on stderr, and continues with the
+creates and updates. Pass --allow-delete with the resource types you intend
+to decommission (services, agents, databases, or all) to delete them; within
+each resource type, deletes run after that type's creates and updates.
 
 Updates replace the whole live spec of each resource. For every service or
 agent updated, the live revision being replaced is printed to stderr so a
-sync from a stale config file is visible before it lands. Services and
-agents the config file no longer mentions are deleted; those deletions are
-announced on stderr before changes to that resource type begin, and run
-after its creates/updates, so an unintended delete from a stale config can
-still be aborted.
+sync from a stale config file is visible before it lands.
+
+Use --dry-run to print the full plan — creates, updates, deletes, and
+refused deletions — without applying anything.
 
 The organization and project are read from the config file, flags, or resolved via 'iai organizations select' / 'iai projects select'.`,
 	Example: `  iai stacks sync --file stack.yaml
   iai stacks sync --file stack.yaml --project my-project --organization my-org
-  iai stacks sync --file stack.yaml --allow-delete databases`,
+  iai stacks sync --file stack.yaml --dry-run
+  iai stacks sync --file stack.yaml --allow-delete services,agents`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
@@ -107,8 +112,31 @@ The organization and project are read from the config file, flags, or resolved v
 		}
 
 		fmt.Fprintln(out)
-		fmt.Fprintf(out, "Syncing stack %q...\n", cfg.StackId)
+		verb := "Syncing"
+		if stackSyncDryRun {
+			verb = "Planning"
+			fmt.Fprintf(
+				out,
+				"Dry run: planning stack %q — no changes will be applied.\n",
+				cfg.StackId,
+			)
+		} else {
+			fmt.Fprintf(out, "Syncing stack %q...\n", cfg.StackId)
+		}
 		ranSync := false
+
+		// In a dry run the plan on stdout is the deliverable; otherwise
+		// results print as applied, with refused deletions reported.
+		printOutcome := func(label string, result *sync.Result, err error) error {
+			if stackSyncDryRun {
+				if err != nil {
+					return err
+				}
+				sync.PrintPlan(out, label, result)
+				return nil
+			}
+			return sync.PrintResult(out, label, result, err)
+		}
 
 		svcBodies := make(map[string]clients.CreateServiceBody)
 		for name, svcCfg := range cfg.Services {
@@ -131,7 +159,7 @@ The organization and project are read from the config file, flags, or resolved v
 
 		if len(svcBodies) > 0 || hasServices {
 			ranSync = true
-			fmt.Fprint(out, "Syncing services")
+			fmt.Fprint(out, verb+" services")
 			done := output.PrintLoadingDots(out)
 
 			svcResult, err := sync.Services(
@@ -142,10 +170,14 @@ The organization and project are read from the config file, flags, or resolved v
 				projectId,
 				cfg.StackId,
 				svcBodies,
+				sync.Options{
+					AllowDelete: sync.AllowDeleteResource(stackSyncAllowDelete, "services"),
+					DryRun:      stackSyncDryRun,
+				},
 			)
 			close(done)
 			fmt.Fprintln(out)
-			if err := sync.PrintResult(out, "services", svcResult, err); err != nil {
+			if err := printOutcome("services", svcResult, err); err != nil {
 				return err
 			}
 		}
@@ -171,7 +203,7 @@ The organization and project are read from the config file, flags, or resolved v
 
 		if len(agentBodies) > 0 || hasAgents {
 			ranSync = true
-			fmt.Fprint(out, "Syncing agents")
+			fmt.Fprint(out, verb+" agents")
 			done := output.PrintLoadingDots(out)
 
 			agentResult, err := sync.Agents(
@@ -182,10 +214,14 @@ The organization and project are read from the config file, flags, or resolved v
 				projectId,
 				cfg.StackId,
 				agentBodies,
+				sync.Options{
+					AllowDelete: sync.AllowDeleteResource(stackSyncAllowDelete, "agents"),
+					DryRun:      stackSyncDryRun,
+				},
 			)
 			close(done)
 			fmt.Fprintln(out)
-			if err := sync.PrintResult(out, "agents", agentResult, err); err != nil {
+			if err := printOutcome("agents", agentResult, err); err != nil {
 				return err
 			}
 		}
@@ -211,13 +247,9 @@ The organization and project are read from the config file, flags, or resolved v
 
 		if len(dbBodies) > 0 || hasDatabases {
 			ranSync = true
-			fmt.Fprint(out, "Syncing databases")
+			fmt.Fprint(out, verb+" databases")
 			done := output.PrintLoadingDots(out)
 
-			allowDeleteDB := sync.AllowDeleteResource(
-				stackSyncAllowDelete,
-				"databases",
-			)
 			dbResult, err := sync.Databases(
 				cmd.Context(),
 				deployClient,
@@ -225,11 +257,14 @@ The organization and project are read from the config file, flags, or resolved v
 				projectId,
 				cfg.StackId,
 				dbBodies,
-				allowDeleteDB,
+				sync.Options{
+					AllowDelete: sync.AllowDeleteResource(stackSyncAllowDelete, "databases"),
+					DryRun:      stackSyncDryRun,
+				},
 			)
 			close(done)
 			fmt.Fprintln(out)
-			if err := sync.PrintResult(out, "databases", dbResult, err); err != nil {
+			if err := printOutcome("databases", dbResult, err); err != nil {
 				return err
 			}
 		}
@@ -250,7 +285,9 @@ func init() {
 	stackSyncCmd.Flags().
 		StringVarP(&stackSyncOrganization, "organization", "o", "", "Organization name that owns the project")
 	stackSyncCmd.Flags().
-		StringSliceVar(&stackSyncAllowDelete, "allow-delete", nil, "Resource types to allow deletion for (e.g. databases)")
+		StringSliceVar(&stackSyncAllowDelete, "allow-delete", nil, "Resource types the sync may delete when the config omits them (services, agents, databases, or all); deletions are refused otherwise")
+	stackSyncCmd.Flags().
+		BoolVar(&stackSyncDryRun, "dry-run", false, "Print the full plan (creates, updates, deletes, refused deletions) without applying anything")
 
 	stackCmd.AddCommand(stackSyncCmd)
 	rootCmd.AddCommand(stackCmd)

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -35,6 +35,10 @@ Services are created, updated, or deleted to match the config file.
 Agents are created, updated, or deleted to match the config file.
 Databases are created, updated, or deleted (--allow-delete=databases) to match the config file.
 
+Updates replace the whole live spec of each resource. For every service or
+agent updated, the live revision being replaced is printed to stderr so a
+sync from a stale config file is visible before it lands.
+
 The organization and project are read from the config file, flags, or resolved via 'iai organizations select' / 'iai projects select'.`,
 	Example: `  iai stacks sync --file stack.yaml
   iai stacks sync --file stack.yaml --project my-project --organization my-org
@@ -128,6 +132,7 @@ The organization and project are read from the config file, flags, or resolved v
 
 			svcResult, err := sync.Services(
 				cmd.Context(),
+				cmd.ErrOrStderr(),
 				deployClient,
 				orgId,
 				projectId,
@@ -167,6 +172,7 @@ The organization and project are read from the config file, flags, or resolved v
 
 			agentResult, err := sync.Agents(
 				cmd.Context(),
+				cmd.ErrOrStderr(),
 				deployClient,
 				orgId,
 				projectId,

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -125,9 +125,21 @@ The organization and project are read from the config file, flags, or resolved v
 		}
 		ranSync := false
 
-		// In a dry run the plan on stdout is the deliverable; otherwise
-		// results print as applied, with refused deletions reported.
-		printOutcome := func(label string, result *sync.Result, err error) error {
+		// runPhase runs one resource type's sync with its progress line and
+		// prints the outcome: in a dry run the plan on stdout is the
+		// deliverable; otherwise results print as applied, with refused
+		// deletions reported. label is the plural noun, which is also the
+		// --allow-delete value.
+		runPhase := func(label string, run func(sync.Options) (*sync.Result, error)) error {
+			ranSync = true
+			fmt.Fprint(out, verb+" "+label)
+			done := output.PrintLoadingDots(out)
+			result, err := run(sync.Options{
+				AllowDelete: sync.AllowDeleteResource(stackSyncAllowDelete, label),
+				DryRun:      stackSyncDryRun,
+			})
+			close(done)
+			fmt.Fprintln(out)
 			if stackSyncDryRun {
 				if err != nil {
 					return err
@@ -158,26 +170,19 @@ The organization and project are read from the config file, flags, or resolved v
 		}
 
 		if len(svcBodies) > 0 || hasServices {
-			ranSync = true
-			fmt.Fprint(out, verb+" services")
-			done := output.PrintLoadingDots(out)
-
-			svcResult, err := sync.Services(
-				cmd.Context(),
-				cmd.ErrOrStderr(),
-				deployClient,
-				orgId,
-				projectId,
-				cfg.StackId,
-				svcBodies,
-				sync.Options{
-					AllowDelete: sync.AllowDeleteResource(stackSyncAllowDelete, "services"),
-					DryRun:      stackSyncDryRun,
-				},
-			)
-			close(done)
-			fmt.Fprintln(out)
-			if err := printOutcome("services", svcResult, err); err != nil {
+			err := runPhase("services", func(opts sync.Options) (*sync.Result, error) {
+				return sync.Services(
+					cmd.Context(),
+					cmd.ErrOrStderr(),
+					deployClient,
+					orgId,
+					projectId,
+					cfg.StackId,
+					svcBodies,
+					opts,
+				)
+			})
+			if err != nil {
 				return err
 			}
 		}
@@ -202,26 +207,19 @@ The organization and project are read from the config file, flags, or resolved v
 		}
 
 		if len(agentBodies) > 0 || hasAgents {
-			ranSync = true
-			fmt.Fprint(out, verb+" agents")
-			done := output.PrintLoadingDots(out)
-
-			agentResult, err := sync.Agents(
-				cmd.Context(),
-				cmd.ErrOrStderr(),
-				deployClient,
-				orgId,
-				projectId,
-				cfg.StackId,
-				agentBodies,
-				sync.Options{
-					AllowDelete: sync.AllowDeleteResource(stackSyncAllowDelete, "agents"),
-					DryRun:      stackSyncDryRun,
-				},
-			)
-			close(done)
-			fmt.Fprintln(out)
-			if err := printOutcome("agents", agentResult, err); err != nil {
+			err := runPhase("agents", func(opts sync.Options) (*sync.Result, error) {
+				return sync.Agents(
+					cmd.Context(),
+					cmd.ErrOrStderr(),
+					deployClient,
+					orgId,
+					projectId,
+					cfg.StackId,
+					agentBodies,
+					opts,
+				)
+			})
+			if err != nil {
 				return err
 			}
 		}
@@ -246,26 +244,19 @@ The organization and project are read from the config file, flags, or resolved v
 		}
 
 		if len(dbBodies) > 0 || hasDatabases {
-			ranSync = true
-			fmt.Fprint(out, verb+" databases")
-			done := output.PrintLoadingDots(out)
-
-			dbResult, err := sync.Databases(
-				cmd.Context(),
-				cmd.ErrOrStderr(),
-				deployClient,
-				orgId,
-				projectId,
-				cfg.StackId,
-				dbBodies,
-				sync.Options{
-					AllowDelete: sync.AllowDeleteResource(stackSyncAllowDelete, "databases"),
-					DryRun:      stackSyncDryRun,
-				},
-			)
-			close(done)
-			fmt.Fprintln(out)
-			if err := printOutcome("databases", dbResult, err); err != nil {
+			err := runPhase("databases", func(opts sync.Options) (*sync.Result, error) {
+				return sync.Databases(
+					cmd.Context(),
+					cmd.ErrOrStderr(),
+					deployClient,
+					orgId,
+					projectId,
+					cfg.StackId,
+					dbBodies,
+					opts,
+				)
+			})
+			if err != nil {
 				return err
 			}
 		}

--- a/docs/iai_agents_update.md
+++ b/docs/iai_agents_update.md
@@ -78,7 +78,7 @@ iai agents update <agent_name> [flags]
       --detach-mcp stringArray     Detach an MCP by name; can be repeated. Without --file, removes from the agent's current mcps (applied before --mcp)
       --endpoint                   Expose the agent at <agent-name>-<project-hash>.interactive.ai
       --env stringArray            Environment variable (NAME=VALUE); can be repeated
-      --expect-revision int        Fail without applying unless the live revision equals this value (opt-in staleness guard)
+      --expect-revision int        Fail without applying unless the live revision equals this value; 0 is valid and matches a never-updated agent (opt-in staleness guard)
       --file string                Path to YAML file matching the agent_config schema (run 'iai agents schema' to see it)
       --force                      Apply even when the update would downgrade/remove live content pins or drop live env vars or secret refs
   -h, --help                       help for update

--- a/docs/iai_agents_update.md
+++ b/docs/iai_agents_update.md
@@ -38,9 +38,13 @@ Before applying, the CLI prints deploy-awareness output to stderr: the live
 revision this update replaces; the names of any env vars or secret refs that
 --env/--secret would drop from the live agent (the flags replace the entire
 list); and — when the update replaces the agent config — a summary of
-content pin changes, with downgrades and removals flagged (a stale local
-manifest silently reverts colleagues' work). These checks fail open and
-never block; use --expect-revision to fail instead when the live revision
+content pin changes (a stale local manifest silently reverts colleagues'
+work). The update is refused when it would downgrade or remove a live
+content pin, or drop live env vars or secret refs via --env/--secret; pass
+--force to apply anyway. --clear-env and --clear-secret never trigger the
+gate: clearing is explicit intent. Changes in unrecognized pin-shaped config
+sections warn without blocking. The checks fail open when live state cannot
+be fetched; use --expect-revision to fail instead when the live revision
 differs from what you expect, and --show-diff for a full live-vs-incoming
 config diff.
 
@@ -76,6 +80,7 @@ iai agents update <agent_name> [flags]
       --env stringArray            Environment variable (NAME=VALUE); can be repeated
       --expect-revision int        Fail without applying unless the live revision equals this value (opt-in staleness guard)
       --file string                Path to YAML file matching the agent_config schema (run 'iai agents schema' to see it)
+      --force                      Apply even when the update would downgrade/remove live content pins or drop live env vars or secret refs
   -h, --help                       help for update
       --id string                  Agent type from the marketplace (e.g. interactive-agent)
       --mcp stringArray            Attach an MCP by name (see 'iai mcps list'); can be repeated. Without --file, appends to the agent's current mcps

--- a/docs/iai_agents_update.md
+++ b/docs/iai_agents_update.md
@@ -35,12 +35,14 @@ deleting it — 'iai mcps delete' blocks by default while an agent still
 references it.
 
 Before applying, the CLI prints deploy-awareness output to stderr: the live
-revision this update replaces, and — when the update replaces the agent
-config — a summary of content pin changes, with downgrades and removals
-flagged (a stale local manifest silently reverts colleagues' work). These
-checks fail open and never block; use --expect-revision to fail instead when
-the live revision differs from what you expect, and --show-diff for a full
-live-vs-incoming config diff.
+revision this update replaces; the names of any env vars or secret refs that
+--env/--secret would drop from the live agent (the flags replace the entire
+list); and — when the update replaces the agent config — a summary of
+content pin changes, with downgrades and removals flagged (a stale local
+manifest silently reverts colleagues' work). These checks fail open and
+never block; use --expect-revision to fail instead when the live revision
+differs from what you expect, and --show-diff for a full live-vs-incoming
+config diff.
 
 ```
 iai agents update <agent_name> [flags]

--- a/docs/iai_agents_update.md
+++ b/docs/iai_agents_update.md
@@ -34,6 +34,14 @@ with --mcp in the same command to swap one for another. Detach an mcp before
 deleting it — 'iai mcps delete' blocks by default while an agent still
 references it.
 
+Before applying, the CLI prints deploy-awareness output to stderr: the live
+revision this update replaces, and — when the update replaces the agent
+config — a summary of content pin changes, with downgrades and removals
+flagged (a stale local manifest silently reverts colleagues' work). These
+checks fail open and never block; use --expect-revision to fail instead when
+the live revision differs from what you expect, and --show-diff for a full
+live-vs-incoming config diff.
+
 ```
 iai agents update <agent_name> [flags]
 ```
@@ -43,6 +51,8 @@ iai agents update <agent_name> [flags]
 ```
   iai agents update chat-agent --version 0.0.3
   iai agents update chat-agent --file agent-config.yaml
+  iai agents update chat-agent --file agent-config.yaml --expect-revision 13
+  iai agents update chat-agent --file agent-config.yaml --show-diff
   iai agents update chat-agent --endpoint=false
   iai agents update chat-agent --schedule-uptime "Mon-Fri 07:30-20:30" --schedule-timezone Europe/Berlin
   iai agents update chat-agent --clear-schedule
@@ -62,6 +72,7 @@ iai agents update <agent_name> [flags]
       --detach-mcp stringArray     Detach an MCP by name; can be repeated. Without --file, removes from the agent's current mcps (applied before --mcp)
       --endpoint                   Expose the agent at <agent-name>-<project-hash>.interactive.ai
       --env stringArray            Environment variable (NAME=VALUE); can be repeated
+      --expect-revision int        Fail without applying unless the live revision equals this value (opt-in staleness guard)
       --file string                Path to YAML file matching the agent_config schema (run 'iai agents schema' to see it)
   -h, --help                       help for update
       --id string                  Agent type from the marketplace (e.g. interactive-agent)
@@ -72,6 +83,7 @@ iai agents update <agent_name> [flags]
       --schedule-timezone string   IANA timezone for the schedule (e.g. Europe/Berlin, US/Eastern, UTC); required with --schedule-uptime or --schedule-downtime
       --schedule-uptime string     When the agent should be running (mutually exclusive with --schedule-downtime). Format: comma-separated entries of DAY_FROM-DAY_TO HH:MM-HH:MM. Example: 'Mon-Fri 07:30-20:30'
       --secret stringArray         Secret to inject as environment variables; can be repeated
+      --show-diff                  Print a live-vs-incoming agent config diff to stderr before applying; requires --file, --mcp, or --detach-mcp
       --stack-id string            Stack ID to assign the agent to
       --version string             Agent image version to deploy (e.g. 0.0.1)
 ```

--- a/docs/iai_images_push.md
+++ b/docs/iai_images_push.md
@@ -6,6 +6,11 @@ Push an image for a project
 
 Create a Docker image tarball and push it to the deployment images endpoint for a specific project.
 
+Pushing to a tag that already exists upstream replaces the previous image:
+the old bytes are unrecoverable and nothing records that the code changed.
+The CLI warns on stderr before pushing to an existing tag — prefer a fresh
+tag (or the git SHA) unless replacing is intended.
+
 ```
 iai images push [image_name] [flags]
 ```

--- a/docs/iai_images_push.md
+++ b/docs/iai_images_push.md
@@ -8,8 +8,9 @@ Create a Docker image tarball and push it to the deployment images endpoint for 
 
 Pushing to a tag that already exists upstream replaces the previous image:
 the old bytes are unrecoverable and nothing records that the code changed.
-The CLI warns on stderr before pushing to an existing tag — prefer a fresh
-tag (or the git SHA) unless replacing is intended.
+The push is refused when the tag already exists — prefer a fresh tag (or
+the git SHA), or pass --force when replacing is intended. The check fails
+open when the existing tags cannot be listed.
 
 ```
 iai images push [image_name] [flags]
@@ -19,12 +20,14 @@ iai images push [image_name] [flags]
 
 ```
   iai images push my-service --tag 1.2.3
+  iai images push my-service --tag 1.2.3 --force
   iai images push my-service --tag 1.2.3 --organization my-org --project my-project
 ```
 
 ### Options
 
 ```
+      --force                 Push even when the tag already exists upstream, replacing the previous image (unrecoverable)
   -h, --help                  help for push
   -o, --organization string   Organization name that owns the project
   -p, --project string        Project name the image belongs to

--- a/docs/iai_services_sync.md
+++ b/docs/iai_services_sync.md
@@ -15,8 +15,8 @@ Updates replace the whole live spec of each service. For every service
 updated, the live revision being replaced is printed to stderr so a sync
 from a stale config file is visible before it lands. Services the config
 file no longer mentions are deleted; those deletions are announced on
-stderr before the sync writes anything, and run last, so an unintended
-delete from a stale config can still be aborted.
+stderr before service changes begin, and run after service creates/updates,
+so an unintended delete from a stale config can still be aborted.
 
 The project is selected with --project or via 'iai projects select', and the config file with --cfg-file.
 
@@ -91,4 +91,3 @@ services:
 ### SEE ALSO
 
 * [iai services](iai_services.md)	 - Manage services
-

--- a/docs/iai_services_sync.md
+++ b/docs/iai_services_sync.md
@@ -9,14 +9,14 @@ Sync services in a specific project from a stack configuration file.
 The sync command will:
 - Create services that exist in the config but not in the project
 - Update services that exist in both the config and the project
-- Delete services that exist in the project but not in the config (for the specified stack)
+- Delete services that exist in the project but not in the config, only
+  with --allow-delete=services; otherwise those deletions are refused and
+  reported on stderr while creates and updates still apply
 
 Updates replace the whole live spec of each service. For every service
 updated, the live revision being replaced is printed to stderr so a sync
-from a stale config file is visible before it lands. Services the config
-file no longer mentions are deleted; those deletions are announced on
-stderr before service changes begin, and run after service creates/updates,
-so an unintended delete from a stale config can still be aborted.
+from a stale config file is visible before it lands. With
+--allow-delete=services, deletes run after service creates/updates.
 
 The project is selected with --project or via 'iai projects select', and the config file with --cfg-file.
 
@@ -74,9 +74,10 @@ services:
 ### Options
 
 ```
-  -h, --help                  help for sync
-  -o, --organization string   Organization name that owns the project
-  -p, --project string        Project name to sync services in
+      --allow-delete strings   Resource types the sync may delete when the config omits them (services); deletions are refused otherwise
+  -h, --help                   help for sync
+  -o, --organization string    Organization name that owns the project
+  -p, --project string         Project name to sync services in
 ```
 
 ### Options inherited from parent commands

--- a/docs/iai_services_sync.md
+++ b/docs/iai_services_sync.md
@@ -11,6 +11,10 @@ The sync command will:
 - Update services that exist in both the config and the project
 - Delete services that exist in the project but not in the config (for the specified stack)
 
+Updates replace the whole live spec of each service. For every service
+updated, the live revision being replaced is printed to stderr so a sync
+from a stale config file is visible before it lands.
+
 The project is selected with --project or via 'iai projects select', and the config file with --cfg-file.
 
 ```

--- a/docs/iai_services_sync.md
+++ b/docs/iai_services_sync.md
@@ -13,7 +13,10 @@ The sync command will:
 
 Updates replace the whole live spec of each service. For every service
 updated, the live revision being replaced is printed to stderr so a sync
-from a stale config file is visible before it lands.
+from a stale config file is visible before it lands. Services the config
+file no longer mentions are deleted; those deletions are announced on
+stderr before the sync writes anything, and run last, so an unintended
+delete from a stale config can still be aborted.
 
 The project is selected with --project or via 'iai projects select', and the config file with --cfg-file.
 

--- a/docs/iai_services_update.md
+++ b/docs/iai_services_update.md
@@ -64,7 +64,7 @@ iai services update <service_name> [flags]
       --cpu string                          CPU cores or millicores (e.g. 0.5, 1, 2, 500m, 1000m)
       --endpoint                            Expose the service at <service-name>-<project-hash>.interactive.ai
       --env stringArray                     Environment variable (NAME=VALUE); can be repeated
-      --expect-revision int                 Fail without applying unless the live revision equals this value (opt-in staleness guard)
+      --expect-revision int                 Fail without applying unless the live revision equals this value; 0 is valid and matches a never-updated service (opt-in staleness guard)
       --force                               Apply even when the update would drop live env vars or secret refs
       --healthcheck-initial-delay int       Initial delay in seconds before starting healthchecks
       --healthcheck-path string             HTTP path for healthcheck endpoint (e.g. /health)

--- a/docs/iai_services_update.md
+++ b/docs/iai_services_update.md
@@ -22,6 +22,11 @@ alongside either to change the timezone.
 Use --clear-env, --clear-secret, --clear-healthcheck, --clear-schedule, or
 --clear-stack-id to remove those configurations entirely.
 
+Before applying, the CLI prints the live revision this update replaces to
+stderr, so a deploy based on stale local state is visible before it lands.
+The check fails open and never blocks; use --expect-revision to fail instead
+when the live revision differs from what you expect.
+
 ```
 iai services update <service_name> [flags]
 ```
@@ -30,6 +35,7 @@ iai services update <service_name> [flags]
 
 ```
   iai services update my-svc --image-tag v2
+  iai services update my-svc --image-tag v2 --expect-revision 47
   iai services update my-svc --memory 1G --cpu 0.5
   iai services update my-svc --replicas 3
   iai services update my-svc --autoscaling-max-replicas 8
@@ -54,6 +60,7 @@ iai services update <service_name> [flags]
       --cpu string                          CPU cores or millicores (e.g. 0.5, 1, 2, 500m, 1000m)
       --endpoint                            Expose the service at <service-name>-<project-hash>.interactive.ai
       --env stringArray                     Environment variable (NAME=VALUE); can be repeated
+      --expect-revision int                 Fail without applying unless the live revision equals this value (opt-in staleness guard)
       --healthcheck-initial-delay int       Initial delay in seconds before starting healthchecks
       --healthcheck-path string             HTTP path for healthcheck endpoint (e.g. /health)
   -h, --help                                help for update

--- a/docs/iai_services_update.md
+++ b/docs/iai_services_update.md
@@ -22,10 +22,11 @@ alongside either to change the timezone.
 Use --clear-env, --clear-secret, --clear-healthcheck, --clear-schedule, or
 --clear-stack-id to remove those configurations entirely.
 
-Before applying, the CLI prints the live revision this update replaces to
-stderr, so a deploy based on stale local state is visible before it lands.
-The check fails open and never blocks; use --expect-revision to fail instead
-when the live revision differs from what you expect.
+Before applying, the CLI prints deploy-awareness output to stderr: the live
+revision this update replaces, and the names of any env vars or secret refs
+that --env/--secret would drop from the live service (the flags replace the
+entire list). These checks fail open and never block; use --expect-revision
+to fail instead when the live revision differs from what you expect.
 
 ```
 iai services update <service_name> [flags]

--- a/docs/iai_services_update.md
+++ b/docs/iai_services_update.md
@@ -25,7 +25,10 @@ Use --clear-env, --clear-secret, --clear-healthcheck, --clear-schedule, or
 Before applying, the CLI prints deploy-awareness output to stderr: the live
 revision this update replaces, and the names of any env vars or secret refs
 that --env/--secret would drop from the live service (the flags replace the
-entire list). These checks fail open and never block; use --expect-revision
+entire list). The update is refused when it would drop live env vars or
+secret refs via --env/--secret; pass --force to apply anyway. --clear-env
+and --clear-secret never trigger the gate: clearing is explicit intent. The
+checks fail open when live state cannot be fetched; use --expect-revision
 to fail instead when the live revision differs from what you expect.
 
 ```
@@ -62,6 +65,7 @@ iai services update <service_name> [flags]
       --endpoint                            Expose the service at <service-name>-<project-hash>.interactive.ai
       --env stringArray                     Environment variable (NAME=VALUE); can be repeated
       --expect-revision int                 Fail without applying unless the live revision equals this value (opt-in staleness guard)
+      --force                               Apply even when the update would drop live env vars or secret refs
       --healthcheck-initial-delay int       Initial delay in seconds before starting healthchecks
       --healthcheck-path string             HTTP path for healthcheck endpoint (e.g. /health)
   -h, --help                                help for update

--- a/docs/iai_stacks_sync.md
+++ b/docs/iai_stacks_sync.md
@@ -12,7 +12,10 @@ Databases are created, updated, or deleted (--allow-delete=databases) to match t
 
 Updates replace the whole live spec of each resource. For every service or
 agent updated, the live revision being replaced is printed to stderr so a
-sync from a stale config file is visible before it lands.
+sync from a stale config file is visible before it lands. Services and
+agents the config file no longer mentions are deleted; those deletions are
+announced on stderr before the sync writes anything, and run last, so an
+unintended delete from a stale config can still be aborted.
 
 The organization and project are read from the config file, flags, or resolved via 'iai organizations select' / 'iai projects select'.
 

--- a/docs/iai_stacks_sync.md
+++ b/docs/iai_stacks_sync.md
@@ -10,6 +10,10 @@ Services are created, updated, or deleted to match the config file.
 Agents are created, updated, or deleted to match the config file.
 Databases are created, updated, or deleted (--allow-delete=databases) to match the config file.
 
+Updates replace the whole live spec of each resource. For every service or
+agent updated, the live revision being replaced is printed to stderr so a
+sync from a stale config file is visible before it lands.
+
 The organization and project are read from the config file, flags, or resolved via 'iai organizations select' / 'iai projects select'.
 
 ```

--- a/docs/iai_stacks_sync.md
+++ b/docs/iai_stacks_sync.md
@@ -14,8 +14,9 @@ Updates replace the whole live spec of each resource. For every service or
 agent updated, the live revision being replaced is printed to stderr so a
 sync from a stale config file is visible before it lands. Services and
 agents the config file no longer mentions are deleted; those deletions are
-announced on stderr before the sync writes anything, and run last, so an
-unintended delete from a stale config can still be aborted.
+announced on stderr before changes to that resource type begin, and run
+after its creates/updates, so an unintended delete from a stale config can
+still be aborted.
 
 The organization and project are read from the config file, flags, or resolved via 'iai organizations select' / 'iai projects select'.
 

--- a/docs/iai_stacks_sync.md
+++ b/docs/iai_stacks_sync.md
@@ -6,17 +6,20 @@ Sync services, agents, and databases from a stack config file
 
 Sync services, agents, and databases in a project from a stack configuration file.
 
-Services are created, updated, or deleted to match the config file.
-Agents are created, updated, or deleted to match the config file.
-Databases are created, updated, or deleted (--allow-delete=databases) to match the config file.
+Services, agents, and databases are created and updated to match the config
+file. Resources the config file no longer mentions are NOT deleted by
+default: a config that omits a resource looks identical to a stale one, so
+the sync refuses each deletion, reports it on stderr, and continues with the
+creates and updates. Pass --allow-delete with the resource types you intend
+to decommission (services, agents, databases, or all) to delete them; within
+each resource type, deletes run after that type's creates and updates.
 
 Updates replace the whole live spec of each resource. For every service or
 agent updated, the live revision being replaced is printed to stderr so a
-sync from a stale config file is visible before it lands. Services and
-agents the config file no longer mentions are deleted; those deletions are
-announced on stderr before changes to that resource type begin, and run
-after its creates/updates, so an unintended delete from a stale config can
-still be aborted.
+sync from a stale config file is visible before it lands.
+
+Use --dry-run to print the full plan — creates, updates, deletes, and
+refused deletions — without applying anything.
 
 The organization and project are read from the config file, flags, or resolved via 'iai organizations select' / 'iai projects select'.
 
@@ -29,7 +32,8 @@ iai stacks sync [flags]
 ```
   iai stacks sync --file stack.yaml
   iai stacks sync --file stack.yaml --project my-project --organization my-org
-  iai stacks sync --file stack.yaml --allow-delete databases
+  iai stacks sync --file stack.yaml --dry-run
+  iai stacks sync --file stack.yaml --allow-delete services,agents
 ```
 
 ### Example config file
@@ -81,7 +85,8 @@ services:
 ### Options
 
 ```
-      --allow-delete strings   Resource types to allow deletion for (e.g. databases)
+      --allow-delete strings   Resource types the sync may delete when the config omits them (services, agents, databases, or all); deletions are refused otherwise
+      --dry-run                Print the full plan (creates, updates, deletes, refused deletions) without applying anything
   -f, --file string            Path to stack configuration file
   -h, --help                   help for sync
   -o, --organization string    Organization name that owns the project

--- a/internal/output/diff.go
+++ b/internal/output/diff.go
@@ -37,14 +37,19 @@ func PrintRevisionDiff(out io.Writer, nameA string, a any, nameB string, b any) 
 	if err != nil {
 		return fmt.Errorf("failed to process revision %s: %w", nameB, err)
 	}
+	return PrintYAMLDiff(out, "revision "+nameA, mapA, "revision "+nameB, mapB)
+}
 
-	yamlA, err := yaml.Marshal(mapA)
+// PrintYAMLDiff prints a unified diff between the YAML renderings of two
+// values, labeled verbatim.
+func PrintYAMLDiff(out io.Writer, labelA string, a any, labelB string, b any) error {
+	yamlA, err := yaml.Marshal(a)
 	if err != nil {
-		return fmt.Errorf("failed to marshal revision %s: %w", nameA, err)
+		return fmt.Errorf("failed to marshal %s: %w", labelA, err)
 	}
-	yamlB, err := yaml.Marshal(mapB)
+	yamlB, err := yaml.Marshal(b)
 	if err != nil {
-		return fmt.Errorf("failed to marshal revision %s: %w", nameB, err)
+		return fmt.Errorf("failed to marshal %s: %w", labelB, err)
 	}
 
 	if string(yamlA) == string(yamlB) {
@@ -55,11 +60,11 @@ func PrintRevisionDiff(out io.Writer, nameA string, a any, nameB string, b any) 
 	var opts []textdiff.Option
 	if IsTerminal(out) {
 		opts = append(opts, textdiff.TerminalColors())
-		fmt.Fprintf(out, "%s--- revision %s%s\n", colorRed, nameA, colorReset)
-		fmt.Fprintf(out, "%s+++ revision %s%s\n", colorGreen, nameB, colorReset)
+		fmt.Fprintf(out, "%s--- %s%s\n", colorRed, labelA, colorReset)
+		fmt.Fprintf(out, "%s+++ %s%s\n", colorGreen, labelB, colorReset)
 	} else {
-		fmt.Fprintf(out, "--- revision %s\n", nameA)
-		fmt.Fprintf(out, "+++ revision %s\n", nameB)
+		fmt.Fprintf(out, "--- %s\n", labelA)
+		fmt.Fprintf(out, "+++ %s\n", labelB)
 	}
 
 	diff := textdiff.Unified(string(yamlA), string(yamlB), opts...)

--- a/internal/output/diff.go
+++ b/internal/output/diff.go
@@ -26,8 +26,6 @@ func stripRevisionMeta(v any) (map[string]any, error) {
 	return m, nil
 }
 
-// PrintRevisionDiff prints a colored unified diff between two revision snapshots.
-// RevisionMeta fields (revision, updated, status) are excluded.
 func PrintRevisionDiff(out io.Writer, nameA string, a any, nameB string, b any) error {
 	mapA, err := stripRevisionMeta(a)
 	if err != nil {
@@ -40,8 +38,6 @@ func PrintRevisionDiff(out io.Writer, nameA string, a any, nameB string, b any) 
 	return PrintYAMLDiff(out, "revision "+nameA, mapA, "revision "+nameB, mapB)
 }
 
-// PrintYAMLDiff prints a unified diff between the YAML renderings of two
-// values, labeled verbatim.
 func PrintYAMLDiff(out io.Writer, labelA string, a any, labelB string, b any) error {
 	yamlA, err := yaml.Marshal(a)
 	if err != nil {

--- a/internal/output/diff_test.go
+++ b/internal/output/diff_test.go
@@ -154,3 +154,41 @@ func TestPrintRevisionDiff(t *testing.T) {
 		})
 	}
 }
+
+func TestPrintYAMLDiff(t *testing.T) {
+	tests := []struct {
+		name string
+		a    any
+		b    any
+		want string
+	}{
+		{
+			name: "identical values",
+			a:    map[string]any{"id": "agent"},
+			b:    map[string]any{"id": "agent"},
+			want: "No differences found.\n",
+		},
+		{
+			name: "labels are used verbatim and nothing is stripped",
+			a:    map[string]any{"id": "agent", "status": "ready"},
+			b:    map[string]any{"id": "agent", "status": "failed"},
+			want: "--- live\n+++ incoming\n" +
+				"@@ -1,2 +1,2 @@\n" +
+				" id: agent\n" +
+				"-status: ready\n" +
+				"+status: failed\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := PrintYAMLDiff(&buf, "live", tt.a, "incoming", tt.b); err != nil {
+				t.Fatalf("PrintYAMLDiff() error = %v", err)
+			}
+			if got := buf.String(); got != tt.want {
+				t.Errorf("diff = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -1,16 +1,3 @@
-// Package preflight detects deploy accidents: before a mutating deploy
-// command writes, it surfaces the live state the caller is about to replace
-// or destroy (revision, content pin deltas, existing image tags, resources
-// a sync would delete, env/secret entries a list replacement drops) so the
-// operator — human or LLM agent — can notice a stale-based deploy at the
-// moment it can still be stopped.
-//
-// Output contract: deterministic plain text intended for stderr, stable "⚠"
-// prefix on warnings, no colors, no prompts. Destruction implied by
-// omission (a sync deletion, a pin downgrade/removal, a dropped env/secret
-// entry, an occupied image tag) gates: the caller refuses until an explicit
-// flag (--allow-delete, --force) names the intent. Everything ambiguous
-// only warns, and callers fail open when live state cannot be fetched.
 package preflight
 
 import (
@@ -22,9 +9,6 @@ import (
 	"time"
 )
 
-// PrintUpdateBanner prints the live revision a pending update replaces.
-// target names the resource (e.g. "agent chat-agent") for multi-resource
-// flows like sync; leave it empty when the command line already names it.
 func PrintUpdateBanner(w io.Writer, target string, revision int, updated string) {
 	var b strings.Builder
 	b.WriteString("Live:")
@@ -41,29 +25,10 @@ func PrintUpdateBanner(w io.Writer, target string, revision int, updated string)
 	fmt.Fprintln(w, b.String())
 }
 
-// PrintFailOpenNote reports that a pre-flight lookup failed and the command
-// is proceeding without it. what describes the lookup, e.g. "fetch live state".
 func PrintFailOpenNote(w io.Writer, what string, err error) {
 	fmt.Fprintf(w, "⚠ could not %s (%v) — proceeding without pre-flight check\n", what, err)
 }
 
-// PrintTagOverwriteWarning warns that pushing to an already-existing tag
-// replaces the previous image with no way to recover it.
-func PrintTagOverwriteWarning(w io.Writer, tag string) {
-	fmt.Fprintf(
-		w,
-		"⚠ tag %s already exists upstream — pushing replaces it; the previous image is unrecoverable.\n",
-		tag,
-	)
-}
-
-// PrintSyncDeletions reports, before that resource type's sync phase writes
-// anything, the resources the config file no longer mentions. A stale stack
-// file doesn't say "delete X" — it just stops listing X — so deletion is
-// refused unless the matching --allow-delete value was passed; the refusal
-// names the flag that unblocks it. resource is the singular noun
-// ("service", "agent"); allowFlag is the --allow-delete value ("services",
-// "agents").
 func PrintSyncDeletions(w io.Writer, resource, allowFlag string, names []string, allowed bool) {
 	if len(names) == 0 {
 		return
@@ -96,13 +61,6 @@ func PrintSyncDeletions(w io.Writer, resource, allowFlag string, names []string,
 	)
 }
 
-// PrintDroppedListEntries warns when a full-list replacement flag (--env,
-// --secret) drops entries that exist on the live resource, and reports
-// whether it did — callers gate on the result. The flags replace, not merge
-// — the classic mistake is passing just the one new value and silently
-// wiping the rest. Only real disappearances warn: kept and added names
-// print nothing. kind is the plural noun ("env vars", "secret refs"); live
-// and incoming are entry names.
 func PrintDroppedListEntries(w io.Writer, kind, flag string, live, incoming []string) bool {
 	keep := make(map[string]bool, len(incoming))
 	for _, name := range incoming {
@@ -128,20 +86,6 @@ func PrintDroppedListEntries(w io.Writer, kind, flag string, live, incoming []st
 	return true
 }
 
-// CheckExpectedRevision enforces --expect-revision: the update must not be
-// applied when the live revision differs from what the caller expects.
-func CheckExpectedRevision(expected, live int) error {
-	if live != expected {
-		return fmt.Errorf(
-			"live revision is %d, expected %d — not applying (--expect-revision)",
-			live, expected,
-		)
-	}
-	return nil
-}
-
-// formatUpdated renders an RFC3339 timestamp as "2006-01-02 15:04 UTC",
-// falling back to the raw string when it doesn't parse.
 func formatUpdated(ts string) string {
 	if ts == "" {
 		return ""
@@ -153,13 +97,10 @@ func formatUpdated(ts string) string {
 	return t.UTC().Format("2006-01-02 15:04 UTC")
 }
 
-// pinSections maps the agent_config.context keys known to pin content
-// versions to their singular display labels. Known sections gate (their
-// downgrades/removals block without --force); any other context section
-// whose entries are {id, version}-shaped is picked up by shape and warns
-// only — never block on guessed semantics.
+// description is the legacy system_prompt key (prompt_id).
 var pinSections = map[string]string{
 	"system_prompt": "system_prompt",
+	"description":   "description",
 	"policies":      "policy",
 	"routines":      "routine",
 	"glossaries":    "glossary",
@@ -169,9 +110,7 @@ var pinSections = map[string]string{
 type pinKey struct {
 	section string
 	id      string
-	// known is derived from section alone (pinSections membership), so it is
-	// always identical for the live and incoming sides of the same pin.
-	known bool
+	known   bool
 }
 
 type pinVersion struct {
@@ -207,12 +146,6 @@ func parseVersion(v any) pinVersion {
 	}
 }
 
-// extractPins collects (section, id) → version from an agent config's
-// context block. The config schema is server-owned and opaque to the CLI,
-// so anything not shaped like a pin is ignored rather than an error.
-// Sections not in pinSections are scanned by shape: an entry counts as a
-// pin only when it carries both an id and a version, and is marked
-// unknown so its changes warn without gating.
 func extractPins(config any) map[pinKey]pinVersion {
 	pins := map[pinKey]pinVersion{}
 	cfg, ok := config.(map[string]any)
@@ -245,6 +178,9 @@ func extractPins(config any) map[pinKey]pinVersion {
 func addPin(pins map[pinKey]pinVersion, label string, known bool, entry map[string]any) {
 	id, _ := entry["id"].(string)
 	if id == "" {
+		id, _ = entry["prompt_id"].(string)
+	}
+	if id == "" {
 		return
 	}
 	if !known {
@@ -255,16 +191,6 @@ func addPin(pins map[pinKey]pinVersion, label string, known bool, entry map[stri
 	pins[pinKey{section: label, id: id, known: known}] = parseVersion(entry["version"])
 }
 
-// PrintPinChanges compares content pins between the live agent config and
-// the incoming replacement and prints the delta. A full-config update
-// replaces every pin, so a stale manifest silently reverts colleagues'
-// work: downgrades and removals are the loud cases. Additions and upgrades
-// print quietly, and an unchanged pin set prints nothing at all.
-//
-// The return value reports whether a known pin section (pinSections)
-// downgraded or removed a pin — the caller gates on it and refuses without
-// --force. Loud changes in unknown-but-pin-shaped sections warn but never
-// gate: their semantics are guessed from shape alone.
 func PrintPinChanges(w io.Writer, liveConfig, incomingConfig any) bool {
 	livePins := extractPins(liveConfig)
 	incomingPins := extractPins(incomingConfig)
@@ -305,10 +231,8 @@ func PrintPinChanges(w io.Writer, liveConfig, incomingConfig any) bool {
 			lines = append(lines, fmt.Sprintf("%s %s: (none) → %s", k.section, k.id, to))
 		case from.String() == to.String(),
 			from.numeric && to.numeric && from.num == to.num:
-			// unchanged (numeric compare catches "13" vs 13)
 		case from.display != "" && to.display == "":
-			// The entry stays but loses its version: same effect as removing
-			// the pin, so it gates the same way.
+			// Unpinning has the same effect as removing the pin.
 			lines = append(lines, fmt.Sprintf(
 				"%s %s: %s → %s  (REMOVED — this update drops the version pin)",
 				k.section, k.id, from, to,

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -54,12 +54,12 @@ func PrintTagOverwriteWarning(w io.Writer, tag string) {
 	)
 }
 
-// PrintSyncDeletions announces, before the sync writes anything, the
-// resources it will delete because the config file does not mention them. A
-// stale stack file doesn't say "delete X" — it just stops listing X — so
-// this is the only moment decommissioning looks different from a forgotten
-// pull. Deletes run after creates/updates, so aborting on this warning still
-// prevents them. resource is the singular noun ("service", "agent").
+// PrintSyncDeletions announces, before that resource type's sync phase
+// writes anything, the resources it will delete because the config file
+// does not mention them. A stale stack file doesn't say "delete X" — it just
+// stops listing X — so this is the only moment decommissioning looks
+// different from a forgotten pull. Deletes run after creates/updates for
+// that resource type. resource is the singular noun ("service", "agent").
 func PrintSyncDeletions(w io.Writer, resource string, names []string) {
 	if len(names) == 0 {
 		return
@@ -70,11 +70,13 @@ func PrintSyncDeletions(w io.Writer, resource string, names []string) {
 	}
 	fmt.Fprintf(
 		w,
-		"⚠ sync will DELETE %d %s%s not in the config: %s (deletes run last — Ctrl-C to abort if the config is stale)\n",
+		"⚠ sync will DELETE %d %s%s not in the config: %s (%s deletes run after %s creates/updates — Ctrl-C to abort if the config is stale)\n",
 		len(names),
 		resource,
 		plural,
 		strings.Join(names, ", "),
+		resource,
+		resource,
 	)
 }
 

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -1,8 +1,9 @@
 // Package preflight prints deploy-awareness warnings: before a mutating
 // deploy command writes, it surfaces the live state the caller is about to
-// replace (revision, content pin deltas, existing image tags) so the
-// operator — human or LLM agent — can notice a stale-based deploy at the
-// moment it can still be stopped.
+// replace or destroy (revision, content pin deltas, existing image tags,
+// resources a sync will delete, env/secret entries a list replacement
+// drops) so the operator — human or LLM agent — can notice a stale-based
+// deploy at the moment it can still be stopped.
 //
 // Output contract: deterministic plain text intended for stderr, stable "⚠"
 // prefix on warnings, no colors, no prompts. Checks warn but never block;
@@ -50,6 +51,60 @@ func PrintTagOverwriteWarning(w io.Writer, tag string) {
 		w,
 		"⚠ tag %s already exists upstream — pushing replaces it; the previous image is unrecoverable.\n",
 		tag,
+	)
+}
+
+// PrintSyncDeletions announces, before the sync writes anything, the
+// resources it will delete because the config file does not mention them. A
+// stale stack file doesn't say "delete X" — it just stops listing X — so
+// this is the only moment decommissioning looks different from a forgotten
+// pull. Deletes run after creates/updates, so aborting on this warning still
+// prevents them. resource is the singular noun ("service", "agent").
+func PrintSyncDeletions(w io.Writer, resource string, names []string) {
+	if len(names) == 0 {
+		return
+	}
+	plural := ""
+	if len(names) != 1 {
+		plural = "s"
+	}
+	fmt.Fprintf(
+		w,
+		"⚠ sync will DELETE %d %s%s not in the config: %s (deletes run last — Ctrl-C to abort if the config is stale)\n",
+		len(names),
+		resource,
+		plural,
+		strings.Join(names, ", "),
+	)
+}
+
+// PrintDroppedListEntries warns when a full-list replacement flag (--env,
+// --secret) drops entries that exist on the live resource. The flags
+// replace, not merge — the classic mistake is passing just the one new value
+// and silently wiping the rest. Only real disappearances warn: kept and
+// added names print nothing. kind is the plural noun ("env vars",
+// "secret refs"); live and incoming are entry names.
+func PrintDroppedListEntries(w io.Writer, kind, flag string, live, incoming []string) {
+	keep := make(map[string]bool, len(incoming))
+	for _, name := range incoming {
+		keep[name] = true
+	}
+	var dropped []string
+	for _, name := range live {
+		if !keep[name] {
+			dropped = append(dropped, name)
+		}
+	}
+	if len(dropped) == 0 {
+		return
+	}
+	sort.Strings(dropped)
+	fmt.Fprintf(
+		w,
+		"⚠ this update drops live %s: %s (%s replaces the entire list; pass every value you want to keep)\n",
+		kind,
+		strings.Join(dropped, ", "),
+		flag,
 	)
 }
 

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -40,7 +40,7 @@ func PrintUpdateBanner(w io.Writer, target string, revision int, updated string)
 // PrintFailOpenNote reports that a pre-flight lookup failed and the command
 // is proceeding without it. what describes the lookup, e.g. "fetch live state".
 func PrintFailOpenNote(w io.Writer, what string, err error) {
-	fmt.Fprintf(w, "could not %s (%v) — proceeding without pre-flight check\n", what, err)
+	fmt.Fprintf(w, "⚠ could not %s (%v) — proceeding without pre-flight check\n", what, err)
 }
 
 // PrintTagOverwriteWarning warns that pushing to an already-existing tag

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -1,13 +1,16 @@
-// Package preflight prints deploy-awareness warnings: before a mutating
-// deploy command writes, it surfaces the live state the caller is about to
-// replace or destroy (revision, content pin deltas, existing image tags,
-// resources a sync will delete, env/secret entries a list replacement
-// drops) so the operator — human or LLM agent — can notice a stale-based
-// deploy at the moment it can still be stopped.
+// Package preflight detects deploy accidents: before a mutating deploy
+// command writes, it surfaces the live state the caller is about to replace
+// or destroy (revision, content pin deltas, existing image tags, resources
+// a sync would delete, env/secret entries a list replacement drops) so the
+// operator — human or LLM agent — can notice a stale-based deploy at the
+// moment it can still be stopped.
 //
 // Output contract: deterministic plain text intended for stderr, stable "⚠"
-// prefix on warnings, no colors, no prompts. Checks warn but never block;
-// callers fail open when live state cannot be fetched.
+// prefix on warnings, no colors, no prompts. Destruction implied by
+// omission (a sync deletion, a pin downgrade/removal, a dropped env/secret
+// entry, an occupied image tag) gates: the caller refuses until an explicit
+// flag (--allow-delete, --force) names the intent. Everything ambiguous
+// only warns, and callers fail open when live state cannot be fetched.
 package preflight
 
 import (
@@ -54,13 +57,14 @@ func PrintTagOverwriteWarning(w io.Writer, tag string) {
 	)
 }
 
-// PrintSyncDeletions announces, before that resource type's sync phase
-// writes anything, the resources it will delete because the config file
-// does not mention them. A stale stack file doesn't say "delete X" — it just
-// stops listing X — so this is the only moment decommissioning looks
-// different from a forgotten pull. Deletes run after creates/updates for
-// that resource type. resource is the singular noun ("service", "agent").
-func PrintSyncDeletions(w io.Writer, resource string, names []string) {
+// PrintSyncDeletions reports, before that resource type's sync phase writes
+// anything, the resources the config file no longer mentions. A stale stack
+// file doesn't say "delete X" — it just stops listing X — so deletion is
+// refused unless the matching --allow-delete value was passed; the refusal
+// names the flag that unblocks it. resource is the singular noun
+// ("service", "agent"); allowFlag is the --allow-delete value ("services",
+// "agents").
+func PrintSyncDeletions(w io.Writer, resource, allowFlag string, names []string, allowed bool) {
 	if len(names) == 0 {
 		return
 	}
@@ -68,25 +72,39 @@ func PrintSyncDeletions(w io.Writer, resource string, names []string) {
 	if len(names) != 1 {
 		plural = "s"
 	}
+	if allowed {
+		fmt.Fprintf(
+			w,
+			"⚠ sync will DELETE %d %s%s not in the config: %s (--allow-delete=%s; %s deletes run after %s creates/updates)\n",
+			len(names),
+			resource,
+			plural,
+			strings.Join(names, ", "),
+			allowFlag,
+			resource,
+			resource,
+		)
+		return
+	}
 	fmt.Fprintf(
 		w,
-		"⚠ sync will DELETE %d %s%s not in the config: %s (%s deletes run after %s creates/updates — Ctrl-C to abort if the config is stale)\n",
+		"⚠ sync will NOT delete %d %s%s not in the config: %s (a config that omits a resource looks identical to a stale one — pass --allow-delete=%s to delete)\n",
 		len(names),
 		resource,
 		plural,
 		strings.Join(names, ", "),
-		resource,
-		resource,
+		allowFlag,
 	)
 }
 
 // PrintDroppedListEntries warns when a full-list replacement flag (--env,
-// --secret) drops entries that exist on the live resource. The flags
-// replace, not merge — the classic mistake is passing just the one new value
-// and silently wiping the rest. Only real disappearances warn: kept and
-// added names print nothing. kind is the plural noun ("env vars",
-// "secret refs"); live and incoming are entry names.
-func PrintDroppedListEntries(w io.Writer, kind, flag string, live, incoming []string) {
+// --secret) drops entries that exist on the live resource, and reports
+// whether it did — callers gate on the result. The flags replace, not merge
+// — the classic mistake is passing just the one new value and silently
+// wiping the rest. Only real disappearances warn: kept and added names
+// print nothing. kind is the plural noun ("env vars", "secret refs"); live
+// and incoming are entry names.
+func PrintDroppedListEntries(w io.Writer, kind, flag string, live, incoming []string) bool {
 	keep := make(map[string]bool, len(incoming))
 	for _, name := range incoming {
 		keep[name] = true
@@ -98,7 +116,7 @@ func PrintDroppedListEntries(w io.Writer, kind, flag string, live, incoming []st
 		}
 	}
 	if len(dropped) == 0 {
-		return
+		return false
 	}
 	sort.Strings(dropped)
 	fmt.Fprintf(
@@ -108,6 +126,7 @@ func PrintDroppedListEntries(w io.Writer, kind, flag string, live, incoming []st
 		strings.Join(dropped, ", "),
 		flag,
 	)
+	return true
 }
 
 // CheckExpectedRevision enforces --expect-revision: the update must not be
@@ -135,17 +154,23 @@ func formatUpdated(ts string) string {
 	return t.UTC().Format("2006-01-02 15:04 UTC")
 }
 
-// pinSections maps the agent_config.context keys that pin content versions
-// to their singular display labels.
+// pinSections maps the agent_config.context keys known to pin content
+// versions to their singular display labels. Known sections gate (their
+// downgrades/removals block without --force); any other context section
+// whose entries are {id, version}-shaped is picked up by shape and warns
+// only — never block on guessed semantics.
 var pinSections = map[string]string{
 	"system_prompt": "system_prompt",
 	"policies":      "policy",
 	"routines":      "routine",
+	"glossaries":    "glossary",
+	"macros":        "macro",
 }
 
 type pinKey struct {
 	section string
 	id      string
+	known   bool
 }
 
 type pinVersion struct {
@@ -184,6 +209,9 @@ func parseVersion(v any) pinVersion {
 // extractPins collects (section, id) → version from an agent config's
 // context block. The config schema is server-owned and opaque to the CLI,
 // so anything not shaped like a pin is ignored rather than an error.
+// Sections not in pinSections are scanned by shape: an entry counts as a
+// pin only when it carries both an id and a version, and is marked
+// unknown so its changes warn without gating.
 func extractPins(config any) map[pinKey]pinVersion {
 	pins := map[pinKey]pinVersion{}
 	cfg, ok := config.(map[string]any)
@@ -194,14 +222,18 @@ func extractPins(config any) map[pinKey]pinVersion {
 	if !ok {
 		return pins
 	}
-	for section, label := range pinSections {
-		switch v := ctx[section].(type) {
+	for section, v := range ctx {
+		label, known := pinSections[section]
+		if !known {
+			label = section
+		}
+		switch v := v.(type) {
 		case map[string]any:
-			addPin(pins, label, v)
+			addPin(pins, label, known, v)
 		case []any:
 			for _, entry := range v {
 				if m, ok := entry.(map[string]any); ok {
-					addPin(pins, label, m)
+					addPin(pins, label, known, m)
 				}
 			}
 		}
@@ -209,25 +241,30 @@ func extractPins(config any) map[pinKey]pinVersion {
 	return pins
 }
 
-func addPin(pins map[pinKey]pinVersion, label string, entry map[string]any) {
+func addPin(pins map[pinKey]pinVersion, label string, known bool, entry map[string]any) {
 	id, _ := entry["id"].(string)
 	if id == "" {
 		return
 	}
-	pins[pinKey{section: label, id: id}] = parseVersion(entry["version"])
+	if !known {
+		if _, hasVersion := entry["version"]; !hasVersion {
+			return
+		}
+	}
+	pins[pinKey{section: label, id: id, known: known}] = parseVersion(entry["version"])
 }
 
-// PrintPinChanges compares content pins (system_prompt / policies /
-// routines) between the live agent config and the incoming replacement and
-// prints the delta. A full-config update replaces every pin, so a stale
-// manifest silently reverts colleagues' work: downgrades and removals are
-// the loud cases. Additions and upgrades print quietly, and an unchanged
-// pin set prints nothing at all.
+// PrintPinChanges compares content pins between the live agent config and
+// the incoming replacement and prints the delta. A full-config update
+// replaces every pin, so a stale manifest silently reverts colleagues'
+// work: downgrades and removals are the loud cases. Additions and upgrades
+// print quietly, and an unchanged pin set prints nothing at all.
 //
-// Rollbacks are downgrades by definition, so the downgrade wording is
-// informational, never prohibitive — an agent mid-incident must not refuse
-// the documented recovery procedure.
-func PrintPinChanges(w io.Writer, liveConfig, incomingConfig any) {
+// The return value reports whether a known pin section (pinSections)
+// downgraded or removed a pin — the caller gates on it and refuses without
+// --force. Loud changes in unknown-but-pin-shaped sections warn but never
+// gate: their semantics are guessed from shape alone.
+func PrintPinChanges(w io.Writer, liveConfig, incomingConfig any) bool {
 	livePins := extractPins(liveConfig)
 	incomingPins := extractPins(incomingConfig)
 
@@ -251,6 +288,7 @@ func PrintPinChanges(w io.Writer, liveConfig, incomingConfig any) {
 
 	var lines []string
 	loud := false
+	blocking := false
 	for _, k := range keys {
 		from, inLive := livePins[k]
 		to, inIncoming := incomingPins[k]
@@ -261,6 +299,7 @@ func PrintPinChanges(w io.Writer, liveConfig, incomingConfig any) {
 				k.section, k.id, from,
 			))
 			loud = true
+			blocking = blocking || k.known
 		case !inLive && inIncoming:
 			lines = append(lines, fmt.Sprintf("%s %s: (none) → %s", k.section, k.id, to))
 		case from.String() == to.String(),
@@ -275,12 +314,13 @@ func PrintPinChanges(w io.Writer, liveConfig, incomingConfig any) {
 				to,
 			))
 			loud = true
+			blocking = blocking || k.known
 		default:
 			lines = append(lines, fmt.Sprintf("%s %s: %s → %s", k.section, k.id, from, to))
 		}
 	}
 	if len(lines) == 0 {
-		return
+		return false
 	}
 
 	header := "content pins changed by this update:"
@@ -291,4 +331,5 @@ func PrintPinChanges(w io.Writer, liveConfig, incomingConfig any) {
 	for _, l := range lines {
 		fmt.Fprintln(w, "    "+l)
 	}
+	return blocking
 }

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -72,28 +72,27 @@ func PrintSyncDeletions(w io.Writer, resource, allowFlag string, names []string,
 	if len(names) != 1 {
 		plural = "s"
 	}
+	verb := "NOT delete"
+	hint := fmt.Sprintf(
+		"a config that omits a resource looks identical to a stale one — pass --allow-delete=%s to delete",
+		allowFlag,
+	)
 	if allowed {
-		fmt.Fprintf(
-			w,
-			"⚠ sync will DELETE %d %s%s not in the config: %s (--allow-delete=%s; %s deletes run after %s creates/updates)\n",
-			len(names),
-			resource,
-			plural,
-			strings.Join(names, ", "),
-			allowFlag,
-			resource,
-			resource,
+		verb = "DELETE"
+		hint = fmt.Sprintf(
+			"--allow-delete=%s; %s deletes run after %s creates/updates",
+			allowFlag, resource, resource,
 		)
-		return
 	}
 	fmt.Fprintf(
 		w,
-		"⚠ sync will NOT delete %d %s%s not in the config: %s (a config that omits a resource looks identical to a stale one — pass --allow-delete=%s to delete)\n",
+		"⚠ sync will %s %d %s%s not in the config: %s (%s)\n",
+		verb,
 		len(names),
 		resource,
 		plural,
 		strings.Join(names, ", "),
-		allowFlag,
+		hint,
 	)
 }
 
@@ -170,7 +169,9 @@ var pinSections = map[string]string{
 type pinKey struct {
 	section string
 	id      string
-	known   bool
+	// known is derived from section alone (pinSections membership), so it is
+	// always identical for the live and incoming sides of the same pin.
+	known bool
 }
 
 type pinVersion struct {

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -305,6 +305,15 @@ func PrintPinChanges(w io.Writer, liveConfig, incomingConfig any) bool {
 		case from.String() == to.String(),
 			from.numeric && to.numeric && from.num == to.num:
 			// unchanged (numeric compare catches "13" vs 13)
+		case from.display != "" && to.display == "":
+			// The entry stays but loses its version: same effect as removing
+			// the pin, so it gates the same way.
+			lines = append(lines, fmt.Sprintf(
+				"%s %s: %s → %s  (REMOVED — this update drops the version pin)",
+				k.section, k.id, from, to,
+			))
+			loud = true
+			blocking = blocking || k.known
 		case from.numeric && to.numeric && to.num < from.num:
 			lines = append(lines, fmt.Sprintf(
 				"%s %s: %s → %s  (DOWNGRADE — if this is an intentional rollback, this is expected)",

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -1,0 +1,237 @@
+// Package preflight prints deploy-awareness warnings: before a mutating
+// deploy command writes, it surfaces the live state the caller is about to
+// replace (revision, content pin deltas, existing image tags) so the
+// operator — human or LLM agent — can notice a stale-based deploy at the
+// moment it can still be stopped.
+//
+// Output contract: deterministic plain text intended for stderr, stable "⚠"
+// prefix on warnings, no colors, no prompts. Checks warn but never block;
+// callers fail open when live state cannot be fetched.
+package preflight
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// PrintUpdateBanner prints the live revision a pending update replaces.
+// target names the resource (e.g. "agent chat-agent") for multi-resource
+// flows like sync; leave it empty when the command line already names it.
+func PrintUpdateBanner(w io.Writer, target string, revision int, updated string) {
+	var b strings.Builder
+	b.WriteString("Live:")
+	if target != "" {
+		b.WriteString(" ")
+		b.WriteString(target)
+	}
+	fmt.Fprintf(&b, " revision %d", revision)
+	if ts := formatUpdated(updated); ts != "" {
+		b.WriteString(", last updated ")
+		b.WriteString(ts)
+	}
+	fmt.Fprintf(&b, " — this update creates revision %d", revision+1)
+	fmt.Fprintln(w, b.String())
+}
+
+// PrintFailOpenNote reports that a pre-flight lookup failed and the command
+// is proceeding without it. what describes the lookup, e.g. "fetch live state".
+func PrintFailOpenNote(w io.Writer, what string, err error) {
+	fmt.Fprintf(w, "could not %s (%v) — proceeding without pre-flight check\n", what, err)
+}
+
+// PrintTagOverwriteWarning warns that pushing to an already-existing tag
+// replaces the previous image with no way to recover it.
+func PrintTagOverwriteWarning(w io.Writer, tag string) {
+	fmt.Fprintf(
+		w,
+		"⚠ tag %s already exists upstream — pushing replaces it; the previous image is unrecoverable.\n",
+		tag,
+	)
+}
+
+// CheckExpectedRevision enforces --expect-revision: the update must not be
+// applied when the live revision differs from what the caller expects.
+func CheckExpectedRevision(expected, live int) error {
+	if live != expected {
+		return fmt.Errorf(
+			"live revision is %d, expected %d — not applying (--expect-revision)",
+			live, expected,
+		)
+	}
+	return nil
+}
+
+// formatUpdated renders an RFC3339 timestamp as "2006-01-02 15:04 UTC",
+// falling back to the raw string when it doesn't parse.
+func formatUpdated(ts string) string {
+	if ts == "" {
+		return ""
+	}
+	t, err := time.Parse(time.RFC3339Nano, ts)
+	if err != nil {
+		return ts
+	}
+	return t.UTC().Format("2006-01-02 15:04 UTC")
+}
+
+// pinSections maps the agent_config.context keys that pin content versions
+// to their singular display labels.
+var pinSections = map[string]string{
+	"system_prompt": "system_prompt",
+	"policies":      "policy",
+	"routines":      "routine",
+}
+
+type pinKey struct {
+	section string
+	id      string
+}
+
+type pinVersion struct {
+	display string
+	num     float64
+	numeric bool
+}
+
+func (p pinVersion) String() string {
+	if p.display == "" {
+		return "(unpinned)"
+	}
+	return "v" + p.display
+}
+
+func parseVersion(v any) pinVersion {
+	switch n := v.(type) {
+	case nil:
+		return pinVersion{}
+	case int:
+		return pinVersion{display: strconv.Itoa(n), num: float64(n), numeric: true}
+	case int64:
+		return pinVersion{display: strconv.FormatInt(n, 10), num: float64(n), numeric: true}
+	case float64:
+		return pinVersion{display: strconv.FormatFloat(n, 'f', -1, 64), num: n, numeric: true}
+	case string:
+		if f, err := strconv.ParseFloat(n, 64); err == nil {
+			return pinVersion{display: n, num: f, numeric: true}
+		}
+		return pinVersion{display: n}
+	default:
+		return pinVersion{display: fmt.Sprintf("%v", v)}
+	}
+}
+
+// extractPins collects (section, id) → version from an agent config's
+// context block. The config schema is server-owned and opaque to the CLI,
+// so anything not shaped like a pin is ignored rather than an error.
+func extractPins(config any) map[pinKey]pinVersion {
+	pins := map[pinKey]pinVersion{}
+	cfg, ok := config.(map[string]any)
+	if !ok {
+		return pins
+	}
+	ctx, ok := cfg["context"].(map[string]any)
+	if !ok {
+		return pins
+	}
+	for section, label := range pinSections {
+		switch v := ctx[section].(type) {
+		case map[string]any:
+			addPin(pins, label, v)
+		case []any:
+			for _, entry := range v {
+				if m, ok := entry.(map[string]any); ok {
+					addPin(pins, label, m)
+				}
+			}
+		}
+	}
+	return pins
+}
+
+func addPin(pins map[pinKey]pinVersion, label string, entry map[string]any) {
+	id, _ := entry["id"].(string)
+	if id == "" {
+		return
+	}
+	pins[pinKey{section: label, id: id}] = parseVersion(entry["version"])
+}
+
+// PrintPinChanges compares content pins (system_prompt / policies /
+// routines) between the live agent config and the incoming replacement and
+// prints the delta. A full-config update replaces every pin, so a stale
+// manifest silently reverts colleagues' work: downgrades and removals are
+// the loud cases. Additions and upgrades print quietly, and an unchanged
+// pin set prints nothing at all.
+//
+// Rollbacks are downgrades by definition, so the downgrade wording is
+// informational, never prohibitive — an agent mid-incident must not refuse
+// the documented recovery procedure.
+func PrintPinChanges(w io.Writer, liveConfig, incomingConfig any) {
+	livePins := extractPins(liveConfig)
+	incomingPins := extractPins(incomingConfig)
+
+	keys := make([]pinKey, 0, len(livePins)+len(incomingPins))
+	seen := map[pinKey]bool{}
+	for k := range livePins {
+		keys = append(keys, k)
+		seen[k] = true
+	}
+	for k := range incomingPins {
+		if !seen[k] {
+			keys = append(keys, k)
+		}
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].section != keys[j].section {
+			return keys[i].section < keys[j].section
+		}
+		return keys[i].id < keys[j].id
+	})
+
+	var lines []string
+	loud := false
+	for _, k := range keys {
+		from, inLive := livePins[k]
+		to, inIncoming := incomingPins[k]
+		switch {
+		case inLive && !inIncoming:
+			lines = append(lines, fmt.Sprintf(
+				"%s %s: %s → (none)  (REMOVED — this update drops the pin entirely)",
+				k.section, k.id, from,
+			))
+			loud = true
+		case !inLive && inIncoming:
+			lines = append(lines, fmt.Sprintf("%s %s: (none) → %s", k.section, k.id, to))
+		case from.String() == to.String(),
+			from.numeric && to.numeric && from.num == to.num:
+			// unchanged (numeric compare catches "13" vs 13)
+		case from.numeric && to.numeric && to.num < from.num:
+			lines = append(lines, fmt.Sprintf(
+				"%s %s: %s → %s  (DOWNGRADE — if this is an intentional rollback, this is expected)",
+				k.section,
+				k.id,
+				from,
+				to,
+			))
+			loud = true
+		default:
+			lines = append(lines, fmt.Sprintf("%s %s: %s → %s", k.section, k.id, from, to))
+		}
+	}
+	if len(lines) == 0 {
+		return
+	}
+
+	header := "content pins changed by this update:"
+	if loud {
+		header = "⚠ " + header
+	}
+	fmt.Fprintln(w, header)
+	for _, l := range lines {
+		fmt.Fprintln(w, "    "+l)
+	}
+}

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -1,0 +1,237 @@
+package preflight
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func TestPrintUpdateBanner(t *testing.T) {
+	tests := []struct {
+		name     string
+		target   string
+		revision int
+		updated  string
+		want     string
+	}{
+		{
+			name:     "with timestamp",
+			revision: 12,
+			updated:  "2026-07-23T16:40:00Z",
+			want:     "Live: revision 12, last updated 2026-07-23 16:40 UTC — this update creates revision 13\n",
+		},
+		{
+			name:     "timestamp normalized to UTC",
+			revision: 12,
+			updated:  "2026-07-23T17:40:00+01:00",
+			want:     "Live: revision 12, last updated 2026-07-23 16:40 UTC — this update creates revision 13\n",
+		},
+		{
+			name:     "unparseable timestamp printed raw",
+			revision: 3,
+			updated:  "last Tuesday",
+			want:     "Live: revision 3, last updated last Tuesday — this update creates revision 4\n",
+		},
+		{
+			name:     "missing timestamp elided",
+			revision: 3,
+			want:     "Live: revision 3 — this update creates revision 4\n",
+		},
+		{
+			name:     "named target",
+			target:   "agent notify-agent-dev",
+			revision: 13,
+			updated:  "2026-07-24T11:20:00Z",
+			want:     "Live: agent notify-agent-dev revision 13, last updated 2026-07-24 11:20 UTC — this update creates revision 14\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			PrintUpdateBanner(&buf, tt.target, tt.revision, tt.updated)
+			if got := buf.String(); got != tt.want {
+				t.Errorf("banner = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrintFailOpenNote(t *testing.T) {
+	var buf bytes.Buffer
+	PrintFailOpenNote(&buf, "fetch live state", errors.New("connection refused"))
+	want := "could not fetch live state (connection refused) — proceeding without pre-flight check\n"
+	if got := buf.String(); got != want {
+		t.Errorf("note = %q, want %q", got, want)
+	}
+}
+
+func TestPrintTagOverwriteWarning(t *testing.T) {
+	var buf bytes.Buffer
+	PrintTagOverwriteWarning(&buf, "0.2.36")
+	want := "⚠ tag 0.2.36 already exists upstream — pushing replaces it; the previous image is unrecoverable.\n"
+	if got := buf.String(); got != want {
+		t.Errorf("warning = %q, want %q", got, want)
+	}
+}
+
+func TestCheckExpectedRevision(t *testing.T) {
+	if err := CheckExpectedRevision(12, 12); err != nil {
+		t.Errorf("matching revisions: unexpected error %v", err)
+	}
+	err := CheckExpectedRevision(12, 14)
+	if err == nil {
+		t.Fatal("expected error on revision mismatch")
+	}
+	want := "live revision is 14, expected 12 — not applying (--expect-revision)"
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+// configWithPins builds an agent config with the context shapes the CLI
+// sees: routines/policies as lists of {id, version}, system_prompt as a
+// single {id, version} object.
+func configWithPins(systemPrompt map[string]any, policies, routines []any) map[string]any {
+	ctx := map[string]any{}
+	if systemPrompt != nil {
+		ctx["system_prompt"] = systemPrompt
+	}
+	if policies != nil {
+		ctx["policies"] = policies
+	}
+	if routines != nil {
+		ctx["routines"] = routines
+	}
+	return map[string]any{"context": ctx}
+}
+
+func TestPrintPinChanges(t *testing.T) {
+	tests := []struct {
+		name     string
+		live     any
+		incoming any
+		want     string
+	}{
+		{
+			name: "downgrade is loud with rollback-aware wording",
+			live: configWithPins(nil, nil, []any{
+				map[string]any{"id": "notify-welcome-dev", "version": float64(13)},
+			}),
+			incoming: configWithPins(nil, nil, []any{
+				map[string]any{"id": "notify-welcome-dev", "version": 12},
+			}),
+			want: "⚠ content pins changed by this update:\n" +
+				"    routine notify-welcome-dev: v13 → v12  (DOWNGRADE — if this is an intentional rollback, this is expected)\n",
+		},
+		{
+			name: "removal is loud",
+			live: configWithPins(nil, []any{
+				map[string]any{"id": "handoff", "version": float64(4)},
+			}, nil),
+			incoming: configWithPins(nil, []any{}, nil),
+			want: "⚠ content pins changed by this update:\n" +
+				"    policy handoff: v4 → (none)  (REMOVED — this update drops the pin entirely)\n",
+		},
+		{
+			name: "upgrade and addition are quiet",
+			live: configWithPins(nil, nil, []any{
+				map[string]any{"id": "welcome", "version": float64(12)},
+			}),
+			incoming: configWithPins(
+				map[string]any{"id": "base-prompt", "version": 2},
+				nil,
+				[]any{map[string]any{"id": "welcome", "version": 13}},
+			),
+			want: "content pins changed by this update:\n" +
+				"    routine welcome: v12 → v13\n" +
+				"    system_prompt base-prompt: (none) → v2\n",
+		},
+		{
+			name: "unchanged pins print nothing",
+			live: configWithPins(nil, nil, []any{
+				map[string]any{"id": "welcome", "version": float64(13)},
+			}),
+			incoming: configWithPins(nil, nil, []any{
+				map[string]any{"id": "welcome", "version": 13},
+			}),
+			want: "",
+		},
+		{
+			name: "json float and yaml int compare equal",
+			live: configWithPins(nil, nil, []any{
+				map[string]any{"id": "welcome", "version": float64(13)},
+			}),
+			incoming: configWithPins(nil, nil, []any{
+				map[string]any{"id": "welcome", "version": "13"},
+			}),
+			want: "",
+		},
+		{
+			name: "non-numeric version change is quiet",
+			live: configWithPins(nil, nil, []any{
+				map[string]any{"id": "welcome", "version": "2026-06-01.a"},
+			}),
+			incoming: configWithPins(nil, nil, []any{
+				map[string]any{"id": "welcome", "version": "2026-07-01.b"},
+			}),
+			want: "content pins changed by this update:\n" +
+				"    routine welcome: v2026-06-01.a → v2026-07-01.b\n",
+		},
+		{
+			name: "mixed delta sorts by section then id and flags only the loud lines",
+			live: configWithPins(nil,
+				[]any{map[string]any{"id": "guard", "version": float64(3)}},
+				[]any{
+					map[string]any{"id": "goodbye", "version": float64(8)},
+					map[string]any{"id": "welcome", "version": float64(12)},
+				},
+			),
+			incoming: configWithPins(nil,
+				[]any{map[string]any{"id": "guard", "version": 3}},
+				[]any{
+					map[string]any{"id": "goodbye", "version": 7},
+					map[string]any{"id": "welcome", "version": 13},
+				},
+			),
+			want: "⚠ content pins changed by this update:\n" +
+				"    routine goodbye: v8 → v7  (DOWNGRADE — if this is an intentional rollback, this is expected)\n" +
+				"    routine welcome: v12 → v13\n",
+		},
+		{
+			name: "unpinned entries render as (unpinned)",
+			live: configWithPins(nil, nil, []any{
+				map[string]any{"id": "welcome", "version": float64(2)},
+			}),
+			incoming: configWithPins(nil, nil, []any{
+				map[string]any{"id": "welcome"},
+			}),
+			want: "content pins changed by this update:\n" +
+				"    routine welcome: v2 → (unpinned)\n",
+		},
+		{
+			name:     "non-map configs print nothing",
+			live:     "not a map",
+			incoming: 42,
+			want:     "",
+		},
+		{
+			name: "config without context prints nothing",
+			live: map[string]any{"mcps": []any{"github"}},
+			incoming: map[string]any{
+				"mcps": []any{"github", "stripe"},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			PrintPinChanges(&buf, tt.live, tt.incoming)
+			if got := buf.String(); got != tt.want {
+				t.Errorf("pin changes = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -60,7 +60,7 @@ func TestPrintUpdateBanner(t *testing.T) {
 func TestPrintFailOpenNote(t *testing.T) {
 	var buf bytes.Buffer
 	PrintFailOpenNote(&buf, "fetch live state", errors.New("connection refused"))
-	want := "could not fetch live state (connection refused) — proceeding without pre-flight check\n"
+	want := "⚠ could not fetch live state (connection refused) — proceeding without pre-flight check\n"
 	if got := buf.String(); got != want {
 		t.Errorf("note = %q, want %q", got, want)
 	}

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -77,37 +77,73 @@ func TestPrintTagOverwriteWarning(t *testing.T) {
 
 func TestPrintSyncDeletions(t *testing.T) {
 	tests := []struct {
-		name     string
-		resource string
-		names    []string
-		want     string
+		name      string
+		resource  string
+		allowFlag string
+		names     []string
+		allowed   bool
+		want      string
 	}{
 		{
-			name:     "no deletions print nothing",
-			resource: "service",
-			names:    nil,
-			want:     "",
+			name:      "no deletions print nothing",
+			resource:  "service",
+			allowFlag: "services",
+			names:     nil,
+			allowed:   false,
+			want:      "",
 		},
 		{
-			name:     "single deletion",
-			resource: "agent",
-			names:    []string{"chat-agent"},
+			name:      "no deletions print nothing even when allowed",
+			resource:  "service",
+			allowFlag: "services",
+			names:     nil,
+			allowed:   true,
+			want:      "",
+		},
+		{
+			name:      "refused single deletion names the unblocking flag",
+			resource:  "agent",
+			allowFlag: "agents",
+			names:     []string{"chat-agent"},
+			allowed:   false,
+			want: "⚠ sync will NOT delete 1 agent not in the config: chat-agent" +
+				" (a config that omits a resource looks identical to a stale one" +
+				" — pass --allow-delete=agents to delete)\n",
+		},
+		{
+			name:      "refused multiple deletions",
+			resource:  "service",
+			allowFlag: "services",
+			names:     []string{"api-gateway", "worker"},
+			allowed:   false,
+			want: "⚠ sync will NOT delete 2 services not in the config: api-gateway, worker" +
+				" (a config that omits a resource looks identical to a stale one" +
+				" — pass --allow-delete=services to delete)\n",
+		},
+		{
+			name:      "allowed single deletion",
+			resource:  "agent",
+			allowFlag: "agents",
+			names:     []string{"chat-agent"},
+			allowed:   true,
 			want: "⚠ sync will DELETE 1 agent not in the config: chat-agent" +
-				" (agent deletes run after agent creates/updates — Ctrl-C to abort if the config is stale)\n",
+				" (--allow-delete=agents; agent deletes run after agent creates/updates)\n",
 		},
 		{
-			name:     "multiple deletions",
-			resource: "service",
-			names:    []string{"api-gateway", "worker"},
+			name:      "allowed multiple deletions",
+			resource:  "service",
+			allowFlag: "services",
+			names:     []string{"api-gateway", "worker"},
+			allowed:   true,
 			want: "⚠ sync will DELETE 2 services not in the config: api-gateway, worker" +
-				" (service deletes run after service creates/updates — Ctrl-C to abort if the config is stale)\n",
+				" (--allow-delete=services; service deletes run after service creates/updates)\n",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			PrintSyncDeletions(&buf, tt.resource, tt.names)
+			PrintSyncDeletions(&buf, tt.resource, tt.allowFlag, tt.names, tt.allowed)
 			if got := buf.String(); got != tt.want {
 				t.Errorf("announcement = %q, want %q", got, tt.want)
 			}
@@ -117,12 +153,13 @@ func TestPrintSyncDeletions(t *testing.T) {
 
 func TestPrintDroppedListEntries(t *testing.T) {
 	tests := []struct {
-		name     string
-		kind     string
-		flag     string
-		live     []string
-		incoming []string
-		want     string
+		name        string
+		kind        string
+		flag        string
+		live        []string
+		incoming    []string
+		want        string
+		wantDropped bool
 	}{
 		{
 			name: "nothing dropped prints nothing",
@@ -145,6 +182,7 @@ func TestPrintDroppedListEntries(t *testing.T) {
 			incoming: []string{"NEW_VAR"},
 			want: "⚠ this update drops live env vars: DB_HOST, LOG_LEVEL" +
 				" (--env replaces the entire list; pass every value you want to keep)\n",
+			wantDropped: true,
 		},
 		{
 			name: "dropped secret ref",
@@ -153,15 +191,19 @@ func TestPrintDroppedListEntries(t *testing.T) {
 			incoming: []string{"db-creds"},
 			want: "⚠ this update drops live secret refs: api-keys" +
 				" (--secret replaces the entire list; pass every value you want to keep)\n",
+			wantDropped: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			PrintDroppedListEntries(&buf, tt.kind, tt.flag, tt.live, tt.incoming)
+			dropped := PrintDroppedListEntries(&buf, tt.kind, tt.flag, tt.live, tt.incoming)
 			if got := buf.String(); got != tt.want {
 				t.Errorf("warning = %q, want %q", got, tt.want)
+			}
+			if dropped != tt.wantDropped {
+				t.Errorf("dropped = %v, want %v", dropped, tt.wantDropped)
 			}
 		})
 	}
@@ -200,10 +242,11 @@ func configWithPins(systemPrompt map[string]any, policies, routines []any) map[s
 
 func TestPrintPinChanges(t *testing.T) {
 	tests := []struct {
-		name     string
-		live     any
-		incoming any
-		want     string
+		name         string
+		live         any
+		incoming     any
+		want         string
+		wantBlocking bool
 	}{
 		{
 			name: "downgrade is loud with rollback-aware wording",
@@ -215,6 +258,7 @@ func TestPrintPinChanges(t *testing.T) {
 			}),
 			want: "⚠ content pins changed by this update:\n" +
 				"    routine notify-welcome-dev: v13 → v12  (DOWNGRADE — if this is an intentional rollback, this is expected)\n",
+			wantBlocking: true,
 		},
 		{
 			name: "removal is loud",
@@ -224,6 +268,7 @@ func TestPrintPinChanges(t *testing.T) {
 			incoming: configWithPins(nil, []any{}, nil),
 			want: "⚠ content pins changed by this update:\n" +
 				"    policy handoff: v4 → (none)  (REMOVED — this update drops the pin entirely)\n",
+			wantBlocking: true,
 		},
 		{
 			name: "upgrade and addition are quiet",
@@ -289,6 +334,60 @@ func TestPrintPinChanges(t *testing.T) {
 			want: "⚠ content pins changed by this update:\n" +
 				"    routine goodbye: v8 → v7  (DOWNGRADE — if this is an intentional rollback, this is expected)\n" +
 				"    routine welcome: v12 → v13\n",
+			wantBlocking: true,
+		},
+		{
+			name: "glossary and macro sections gate like the original three",
+			live: map[string]any{"context": map[string]any{
+				"glossaries": []any{
+					map[string]any{"id": "billing-terms", "version": float64(6)},
+				},
+				"macros": []any{
+					map[string]any{"id": "refund-flow", "version": float64(3)},
+				},
+			}},
+			incoming: map[string]any{"context": map[string]any{
+				"glossaries": []any{
+					map[string]any{"id": "billing-terms", "version": 5},
+				},
+				"macros": []any{
+					map[string]any{"id": "refund-flow", "version": 3},
+				},
+			}},
+			want: "⚠ content pins changed by this update:\n" +
+				"    glossary billing-terms: v6 → v5  (DOWNGRADE — if this is an intentional rollback, this is expected)\n",
+			wantBlocking: true,
+		},
+		{
+			name: "unknown pin-shaped section warns loudly but never blocks",
+			live: map[string]any{"context": map[string]any{
+				"playbooks": []any{
+					map[string]any{"id": "escalation", "version": float64(9)},
+				},
+			}},
+			incoming: map[string]any{"context": map[string]any{
+				"playbooks": []any{
+					map[string]any{"id": "escalation", "version": 8},
+				},
+			}},
+			want: "⚠ content pins changed by this update:\n" +
+				"    playbooks escalation: v9 → v8  (DOWNGRADE — if this is an intentional rollback, this is expected)\n",
+			wantBlocking: false,
+		},
+		{
+			name: "unknown section entries without a version key are not pins",
+			live: map[string]any{"context": map[string]any{
+				"tools": []any{
+					map[string]any{"id": "github"},
+					map[string]any{"id": "stripe"},
+				},
+			}},
+			incoming: map[string]any{"context": map[string]any{
+				"tools": []any{
+					map[string]any{"id": "github"},
+				},
+			}},
+			want: "",
 		},
 		{
 			name: "unpinned entries render as (unpinned)",
@@ -320,9 +419,12 @@ func TestPrintPinChanges(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			PrintPinChanges(&buf, tt.live, tt.incoming)
+			blocking := PrintPinChanges(&buf, tt.live, tt.incoming)
 			if got := buf.String(); got != tt.want {
 				t.Errorf("pin changes = %q, want %q", got, tt.want)
+			}
+			if blocking != tt.wantBlocking {
+				t.Errorf("blocking = %v, want %v", blocking, tt.wantBlocking)
 			}
 		})
 	}

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -66,15 +66,6 @@ func TestPrintFailOpenNote(t *testing.T) {
 	}
 }
 
-func TestPrintTagOverwriteWarning(t *testing.T) {
-	var buf bytes.Buffer
-	PrintTagOverwriteWarning(&buf, "0.2.36")
-	want := "⚠ tag 0.2.36 already exists upstream — pushing replaces it; the previous image is unrecoverable.\n"
-	if got := buf.String(); got != want {
-		t.Errorf("warning = %q, want %q", got, want)
-	}
-}
-
 func TestPrintSyncDeletions(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -209,23 +200,6 @@ func TestPrintDroppedListEntries(t *testing.T) {
 	}
 }
 
-func TestCheckExpectedRevision(t *testing.T) {
-	if err := CheckExpectedRevision(12, 12); err != nil {
-		t.Errorf("matching revisions: unexpected error %v", err)
-	}
-	err := CheckExpectedRevision(12, 14)
-	if err == nil {
-		t.Fatal("expected error on revision mismatch")
-	}
-	want := "live revision is 14, expected 12 — not applying (--expect-revision)"
-	if err.Error() != want {
-		t.Errorf("error = %q, want %q", err.Error(), want)
-	}
-}
-
-// configWithPins builds an agent config with the context shapes the CLI
-// sees: routines/policies as lists of {id, version}, system_prompt as a
-// single {id, version} object.
 func configWithPins(systemPrompt map[string]any, policies, routines []any) map[string]any {
 	ctx := map[string]any{}
 	if systemPrompt != nil {
@@ -411,6 +385,59 @@ func TestPrintPinChanges(t *testing.T) {
 			}),
 			want: "content pins changed by this update:\n" +
 				"    routine welcome: (unpinned) → v2\n",
+		},
+		{
+			name: "legacy description.prompt_id downgrade gates",
+			live: map[string]any{"context": map[string]any{
+				"description": map[string]any{
+					"prompt_id": "camille-system-prompt",
+					"version":   float64(3),
+				},
+			}},
+			incoming: map[string]any{"context": map[string]any{
+				"description": map[string]any{
+					"prompt_id": "camille-system-prompt",
+					"version":   1,
+				},
+			}},
+			want: "⚠ content pins changed by this update:\n" +
+				"    description camille-system-prompt: v3 → v1  (DOWNGRADE — if this is an intentional rollback, this is expected)\n",
+			wantBlocking: true,
+		},
+		{
+			name: "legacy description.prompt_id removal gates",
+			live: map[string]any{"context": map[string]any{
+				"description": map[string]any{
+					"prompt_id": "camille-system-prompt",
+					"version":   float64(2),
+				},
+			}},
+			incoming: map[string]any{"context": map[string]any{
+				"description": map[string]any{},
+			}},
+			want: "⚠ content pins changed by this update:\n" +
+				"    description camille-system-prompt: v2 → (none)  (REMOVED — this update drops the pin entirely)\n",
+			wantBlocking: true,
+		},
+		{
+			name: "id takes precedence over prompt_id on the same entry",
+			live: map[string]any{"context": map[string]any{
+				"description": map[string]any{
+					"id":        "kept-id",
+					"prompt_id": "ignored-prompt-id",
+					"version":   float64(2),
+				},
+			}},
+			incoming: map[string]any{"context": map[string]any{
+				"description": map[string]any{
+					"id":        "kept-id",
+					"prompt_id": "ignored-prompt-id",
+					"version":   1,
+				},
+			}},
+			want: "⚠ content pins changed by this update:\n" +
+				"    description kept-id: v2 → v1  (DOWNGRADE — if this is an intentional rollback, this is expected)\n",
+			wantBlocking: true,
 		},
 		{
 			name:     "non-map configs print nothing",

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -75,6 +75,98 @@ func TestPrintTagOverwriteWarning(t *testing.T) {
 	}
 }
 
+func TestPrintSyncDeletions(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource string
+		names    []string
+		want     string
+	}{
+		{
+			name:     "no deletions print nothing",
+			resource: "service",
+			names:    nil,
+			want:     "",
+		},
+		{
+			name:     "single deletion",
+			resource: "agent",
+			names:    []string{"chat-agent"},
+			want: "⚠ sync will DELETE 1 agent not in the config: chat-agent" +
+				" (deletes run last — Ctrl-C to abort if the config is stale)\n",
+		},
+		{
+			name:     "multiple deletions",
+			resource: "service",
+			names:    []string{"api-gateway", "worker"},
+			want: "⚠ sync will DELETE 2 services not in the config: api-gateway, worker" +
+				" (deletes run last — Ctrl-C to abort if the config is stale)\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			PrintSyncDeletions(&buf, tt.resource, tt.names)
+			if got := buf.String(); got != tt.want {
+				t.Errorf("announcement = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrintDroppedListEntries(t *testing.T) {
+	tests := []struct {
+		name     string
+		kind     string
+		flag     string
+		live     []string
+		incoming []string
+		want     string
+	}{
+		{
+			name: "nothing dropped prints nothing",
+			kind: "env vars", flag: "--env",
+			live:     []string{"LOG_LEVEL"},
+			incoming: []string{"LOG_LEVEL", "NEW_VAR"},
+			want:     "",
+		},
+		{
+			name: "empty live list prints nothing",
+			kind: "env vars", flag: "--env",
+			live:     nil,
+			incoming: []string{"LOG_LEVEL"},
+			want:     "",
+		},
+		{
+			name: "dropped env vars listed sorted",
+			kind: "env vars", flag: "--env",
+			live:     []string{"LOG_LEVEL", "DB_HOST"},
+			incoming: []string{"NEW_VAR"},
+			want: "⚠ this update drops live env vars: DB_HOST, LOG_LEVEL" +
+				" (--env replaces the entire list; pass every value you want to keep)\n",
+		},
+		{
+			name: "dropped secret ref",
+			kind: "secret refs", flag: "--secret",
+			live:     []string{"api-keys", "db-creds"},
+			incoming: []string{"db-creds"},
+			want: "⚠ this update drops live secret refs: api-keys" +
+				" (--secret replaces the entire list; pass every value you want to keep)\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			PrintDroppedListEntries(&buf, tt.kind, tt.flag, tt.live, tt.incoming)
+			if got := buf.String(); got != tt.want {
+				t.Errorf("warning = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCheckExpectedRevision(t *testing.T) {
 	if err := CheckExpectedRevision(12, 12); err != nil {
 		t.Errorf("matching revisions: unexpected error %v", err)

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -390,15 +390,27 @@ func TestPrintPinChanges(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "unpinned entries render as (unpinned)",
+			name: "unpinning a known entry gates like a removal",
 			live: configWithPins(nil, nil, []any{
 				map[string]any{"id": "welcome", "version": float64(2)},
 			}),
 			incoming: configWithPins(nil, nil, []any{
 				map[string]any{"id": "welcome"},
 			}),
+			want: "⚠ content pins changed by this update:\n" +
+				"    routine welcome: v2 → (unpinned)  (REMOVED — this update drops the version pin)\n",
+			wantBlocking: true,
+		},
+		{
+			name: "pinning a previously unpinned entry is quiet",
+			live: configWithPins(nil, nil, []any{
+				map[string]any{"id": "welcome"},
+			}),
+			incoming: configWithPins(nil, nil, []any{
+				map[string]any{"id": "welcome", "version": 2},
+			}),
 			want: "content pins changed by this update:\n" +
-				"    routine welcome: v2 → (unpinned)\n",
+				"    routine welcome: (unpinned) → v2\n",
 		},
 		{
 			name:     "non-map configs print nothing",

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -93,14 +93,14 @@ func TestPrintSyncDeletions(t *testing.T) {
 			resource: "agent",
 			names:    []string{"chat-agent"},
 			want: "⚠ sync will DELETE 1 agent not in the config: chat-agent" +
-				" (deletes run last — Ctrl-C to abort if the config is stale)\n",
+				" (agent deletes run after agent creates/updates — Ctrl-C to abort if the config is stale)\n",
 		},
 		{
 			name:     "multiple deletions",
 			resource: "service",
 			names:    []string{"api-gateway", "worker"},
 			want: "⚠ sync will DELETE 2 services not in the config: api-gateway, worker" +
-				" (deletes run last — Ctrl-C to abort if the config is stale)\n",
+				" (service deletes run after service creates/updates — Ctrl-C to abort if the config is stale)\n",
 		},
 	}
 

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -139,10 +139,10 @@ func PrintPlan(out io.Writer, label string, result *Result) {
 	if len(result.Protected) > 0 {
 		fmt.Fprintf(
 			out,
-			"Would refuse to delete %s (needs --allow-delete=%s): %s\n",
-			label,
+			"Would refuse to delete %s: %s (a config that omits a resource looks identical to a stale one — pass --allow-delete=%s to delete)\n",
 			label,
 			strings.Join(result.Protected, ", "),
+			label,
 		)
 	}
 	if len(result.Created) == 0 && len(result.Updated) == 0 &&

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -114,7 +114,8 @@ func PrintResult(
 // Services syncs services: creates new ones, updates existing ones, and
 // deletes ones not present in the desired map. Updates go through PUT and
 // replace the whole live spec, so the live revision each one overwrites is
-// announced on warnW (deploy awareness).
+// announced on warnW (deploy awareness), and pending deletions are announced
+// there before any write happens.
 func Services(
 	ctx context.Context,
 	warnW io.Writer,
@@ -137,6 +138,9 @@ func Services(
 	}
 
 	result := &Result{}
+
+	toDelete := deletionList(existingByName, desired)
+	preflight.PrintSyncDeletions(warnW, "service", toDelete)
 
 	desiredNames := make([]string, 0, len(desired))
 	for name := range desired {
@@ -171,33 +175,39 @@ func Services(
 		}
 	}
 
-	existingNames := make([]string, 0, len(existingByName))
-	for name := range existingByName {
-		existingNames = append(existingNames, name)
-	}
-	sort.Strings(existingNames)
-
-	for _, name := range existingNames {
-		if _, ok := desired[name]; !ok {
-			_, err := deployClient.DeleteService(
-				ctx, orgId, projectId, name,
+	for _, name := range toDelete {
+		_, err := deployClient.DeleteService(
+			ctx, orgId, projectId, name,
+		)
+		if err != nil {
+			return result, fmt.Errorf(
+				"failed to delete service %q: %w", name, err,
 			)
-			if err != nil {
-				return result, fmt.Errorf(
-					"failed to delete service %q: %w", name, err,
-				)
-			}
-			result.Deleted = append(result.Deleted, name)
 		}
+		result.Deleted = append(result.Deleted, name)
 	}
 
 	return result, nil
 }
 
+// deletionList returns, sorted, the existing resource names a sync will
+// delete because the desired config no longer mentions them.
+func deletionList[E, D any](existing map[string]E, desired map[string]D) []string {
+	var names []string
+	for name := range existing {
+		if _, ok := desired[name]; !ok {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
 // Agents syncs agents: creates new ones, updates existing ones, and deletes ones
 // not present in the desired map. Updates go through PUT and replace the
 // whole live spec, so the live revision each one overwrites is announced on
-// warnW (deploy awareness).
+// warnW (deploy awareness), and pending deletions are announced there before
+// any write happens.
 func Agents(
 	ctx context.Context,
 	warnW io.Writer,
@@ -220,6 +230,9 @@ func Agents(
 	}
 
 	result := &Result{}
+
+	toDelete := deletionList(existingByName, desired)
+	preflight.PrintSyncDeletions(warnW, "agent", toDelete)
 
 	desiredNames := make([]string, 0, len(desired))
 	for name := range desired {
@@ -254,24 +267,16 @@ func Agents(
 		}
 	}
 
-	existingNames := make([]string, 0, len(existingByName))
-	for name := range existingByName {
-		existingNames = append(existingNames, name)
-	}
-	sort.Strings(existingNames)
-
-	for _, name := range existingNames {
-		if _, ok := desired[name]; !ok {
-			_, err := deployClient.DeleteAgent(
-				ctx, orgId, projectId, name,
+	for _, name := range toDelete {
+		_, err := deployClient.DeleteAgent(
+			ctx, orgId, projectId, name,
+		)
+		if err != nil {
+			return result, fmt.Errorf(
+				"failed to delete agent %q: %w", name, err,
 			)
-			if err != nil {
-				return result, fmt.Errorf(
-					"failed to delete agent %q: %w", name, err,
-				)
-			}
-			result.Deleted = append(result.Deleted, name)
 		}
+		result.Deleted = append(result.Deleted, name)
 	}
 
 	return result, nil

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -28,6 +28,18 @@ type Result struct {
 	Protected []string // would be deleted but deletion was not allowed
 }
 
+// Options controls how a sync applies its computed diff.
+type Options struct {
+	// AllowDelete permits deleting resources the config file no longer
+	// mentions. Off by default: a stale config is indistinguishable from a
+	// decommissioning one, so omitted resources are reported as Protected
+	// instead of deleted.
+	AllowDelete bool
+	// DryRun computes the full plan (creates, updates, deletes, protected)
+	// without writing anything.
+	DryRun bool
+}
+
 func HasServices(
 	ctx context.Context,
 	deployClient *clients.DeploymentClient,
@@ -111,11 +123,40 @@ func PrintResult(
 	return nil
 }
 
-// Services syncs services: creates new ones, updates existing ones, and
-// deletes ones not present in the desired map. Updates go through PUT and
-// replace the whole live spec, so the live revision each one overwrites is
-// announced on warnW (deploy awareness), and pending deletions are announced
-// there before any service write happens.
+// PrintPlan renders a dry-run Result as the changes a real run would make,
+// without implying anything was written. label is the plural noun, which is
+// also the --allow-delete value ("services", "agents", "databases").
+func PrintPlan(out io.Writer, label string, result *Result) {
+	if len(result.Created) > 0 {
+		fmt.Fprintf(out, "Would create %s: %s\n", label, strings.Join(result.Created, ", "))
+	}
+	if len(result.Updated) > 0 {
+		fmt.Fprintf(out, "Would update %s: %s\n", label, strings.Join(result.Updated, ", "))
+	}
+	if len(result.Deleted) > 0 {
+		fmt.Fprintf(out, "Would delete %s: %s\n", label, strings.Join(result.Deleted, ", "))
+	}
+	if len(result.Protected) > 0 {
+		fmt.Fprintf(
+			out,
+			"Would refuse to delete %s (needs --allow-delete=%s): %s\n",
+			label,
+			strings.ReplaceAll(label, " ", "-"),
+			strings.Join(result.Protected, ", "),
+		)
+	}
+	if len(result.Created) == 0 && len(result.Updated) == 0 &&
+		len(result.Deleted) == 0 && len(result.Protected) == 0 {
+		fmt.Fprintf(out, "No changes required; %s already match config.\n", label)
+	}
+}
+
+// Services syncs services: creates new ones, updates existing ones, and —
+// only with opts.AllowDelete — deletes ones not present in the desired map;
+// otherwise those are refused and reported as Protected. Updates go through
+// PUT and replace the whole live spec, so the live revision each one
+// overwrites is announced on warnW (deploy awareness), and the deletion
+// decision is announced there before any service write happens.
 func Services(
 	ctx context.Context,
 	warnW io.Writer,
@@ -124,6 +165,7 @@ func Services(
 	projectId,
 	stackId string,
 	desired map[string]clients.CreateServiceBody,
+	opts Options,
 ) (*Result, error) {
 	existing, err := deployClient.ListServices(
 		ctx, orgId, projectId, stackId,
@@ -140,7 +182,13 @@ func Services(
 	result := &Result{}
 
 	toDelete := deletionList(existingByName, desired)
-	preflight.PrintSyncDeletions(warnW, "service", toDelete)
+	if !opts.DryRun {
+		preflight.PrintSyncDeletions(warnW, "service", "services", toDelete, opts.AllowDelete)
+	}
+	if !opts.AllowDelete {
+		result.Protected = toDelete
+		toDelete = nil
+	}
 
 	desiredNames := make([]string, 0, len(desired))
 	for name := range desired {
@@ -151,38 +199,44 @@ func Services(
 	for _, name := range desiredNames {
 		body := desired[name]
 		if _, exists := existingByName[name]; !exists {
-			_, err := deployClient.CreateService(
-				ctx, orgId, projectId, name, body,
-			)
-			if err != nil {
-				return result, fmt.Errorf(
-					"failed to create service %q: %w", name, err,
+			if !opts.DryRun {
+				_, err := deployClient.CreateService(
+					ctx, orgId, projectId, name, body,
 				)
+				if err != nil {
+					return result, fmt.Errorf(
+						"failed to create service %q: %w", name, err,
+					)
+				}
 			}
 			result.Created = append(result.Created, name)
 		} else {
-			svc := existingByName[name]
-			preflight.PrintUpdateBanner(warnW, "service "+name, svc.Revision, svc.Updated)
-			_, err := deployClient.PutService(
-				ctx, orgId, projectId, name, body,
-			)
-			if err != nil {
-				return result, fmt.Errorf(
-					"failed to update service %q: %w", name, err,
+			if !opts.DryRun {
+				svc := existingByName[name]
+				preflight.PrintUpdateBanner(warnW, "service "+name, svc.Revision, svc.Updated)
+				_, err := deployClient.PutService(
+					ctx, orgId, projectId, name, body,
 				)
+				if err != nil {
+					return result, fmt.Errorf(
+						"failed to update service %q: %w", name, err,
+					)
+				}
 			}
 			result.Updated = append(result.Updated, name)
 		}
 	}
 
 	for _, name := range toDelete {
-		_, err := deployClient.DeleteService(
-			ctx, orgId, projectId, name,
-		)
-		if err != nil {
-			return result, fmt.Errorf(
-				"failed to delete service %q: %w", name, err,
+		if !opts.DryRun {
+			_, err := deployClient.DeleteService(
+				ctx, orgId, projectId, name,
 			)
+			if err != nil {
+				return result, fmt.Errorf(
+					"failed to delete service %q: %w", name, err,
+				)
+			}
 		}
 		result.Deleted = append(result.Deleted, name)
 	}
@@ -203,11 +257,12 @@ func deletionList[E, D any](existing map[string]E, desired map[string]D) []strin
 	return names
 }
 
-// Agents syncs agents: creates new ones, updates existing ones, and deletes ones
-// not present in the desired map. Updates go through PUT and replace the
-// whole live spec, so the live revision each one overwrites is announced on
-// warnW (deploy awareness), and pending deletions are announced there before
-// any agent write happens.
+// Agents syncs agents: creates new ones, updates existing ones, and — only
+// with opts.AllowDelete — deletes ones not present in the desired map;
+// otherwise those are refused and reported as Protected. Updates go through
+// PUT and replace the whole live spec, so the live revision each one
+// overwrites is announced on warnW (deploy awareness), and the deletion
+// decision is announced there before any agent write happens.
 func Agents(
 	ctx context.Context,
 	warnW io.Writer,
@@ -216,6 +271,7 @@ func Agents(
 	projectId,
 	stackId string,
 	desired map[string]clients.CreateAgentBody,
+	opts Options,
 ) (*Result, error) {
 	existing, err := deployClient.ListAgents(
 		ctx, orgId, projectId, stackId,
@@ -232,7 +288,13 @@ func Agents(
 	result := &Result{}
 
 	toDelete := deletionList(existingByName, desired)
-	preflight.PrintSyncDeletions(warnW, "agent", toDelete)
+	if !opts.DryRun {
+		preflight.PrintSyncDeletions(warnW, "agent", "agents", toDelete, opts.AllowDelete)
+	}
+	if !opts.AllowDelete {
+		result.Protected = toDelete
+		toDelete = nil
+	}
 
 	desiredNames := make([]string, 0, len(desired))
 	for name := range desired {
@@ -243,38 +305,44 @@ func Agents(
 	for _, name := range desiredNames {
 		body := desired[name]
 		if _, exists := existingByName[name]; !exists {
-			_, err := deployClient.CreateAgent(
-				ctx, orgId, projectId, name, body,
-			)
-			if err != nil {
-				return result, fmt.Errorf(
-					"failed to create agent %q: %w", name, err,
+			if !opts.DryRun {
+				_, err := deployClient.CreateAgent(
+					ctx, orgId, projectId, name, body,
 				)
+				if err != nil {
+					return result, fmt.Errorf(
+						"failed to create agent %q: %w", name, err,
+					)
+				}
 			}
 			result.Created = append(result.Created, name)
 		} else {
-			a := existingByName[name]
-			preflight.PrintUpdateBanner(warnW, "agent "+name, a.Revision, a.Updated)
-			_, err := deployClient.PutAgent(
-				ctx, orgId, projectId, name, body,
-			)
-			if err != nil {
-				return result, fmt.Errorf(
-					"failed to update agent %q: %w", name, err,
+			if !opts.DryRun {
+				a := existingByName[name]
+				preflight.PrintUpdateBanner(warnW, "agent "+name, a.Revision, a.Updated)
+				_, err := deployClient.PutAgent(
+					ctx, orgId, projectId, name, body,
 				)
+				if err != nil {
+					return result, fmt.Errorf(
+						"failed to update agent %q: %w", name, err,
+					)
+				}
 			}
 			result.Updated = append(result.Updated, name)
 		}
 	}
 
 	for _, name := range toDelete {
-		_, err := deployClient.DeleteAgent(
-			ctx, orgId, projectId, name,
-		)
-		if err != nil {
-			return result, fmt.Errorf(
-				"failed to delete agent %q: %w", name, err,
+		if !opts.DryRun {
+			_, err := deployClient.DeleteAgent(
+				ctx, orgId, projectId, name,
 			)
+			if err != nil {
+				return result, fmt.Errorf(
+					"failed to delete agent %q: %w", name, err,
+				)
+			}
 		}
 		result.Deleted = append(result.Deleted, name)
 	}
@@ -289,7 +357,7 @@ func Databases(
 	projectId,
 	stackId string,
 	desired map[string]clients.CreateDatabaseBody,
-	allowDelete bool,
+	opts Options,
 ) (*Result, error) {
 	existing, err := deployClient.ListDatabases(
 		ctx, orgId, projectId, stackId,
@@ -314,23 +382,27 @@ func Databases(
 	for _, name := range desiredNames {
 		body := desired[name]
 		if _, exists := existingByName[name]; !exists {
-			_, err := deployClient.CreateDatabase(
-				ctx, orgId, projectId, name, body,
-			)
-			if err != nil {
-				return result, fmt.Errorf(
-					"failed to create database %q: %w", name, err,
+			if !opts.DryRun {
+				_, err := deployClient.CreateDatabase(
+					ctx, orgId, projectId, name, body,
 				)
+				if err != nil {
+					return result, fmt.Errorf(
+						"failed to create database %q: %w", name, err,
+					)
+				}
 			}
 			result.Created = append(result.Created, name)
 		} else {
-			_, err := deployClient.PutDatabase(
-				ctx, orgId, projectId, name, body,
-			)
-			if err != nil {
-				return result, fmt.Errorf(
-					"failed to update database %q: %w", name, err,
+			if !opts.DryRun {
+				_, err := deployClient.PutDatabase(
+					ctx, orgId, projectId, name, body,
 				)
+				if err != nil {
+					return result, fmt.Errorf(
+						"failed to update database %q: %w", name, err,
+					)
+				}
 			}
 			result.Updated = append(result.Updated, name)
 		}
@@ -344,17 +416,19 @@ func Databases(
 
 	for _, name := range existingNames {
 		if _, ok := desired[name]; !ok {
-			if !allowDelete {
+			if !opts.AllowDelete {
 				result.Protected = append(result.Protected, name)
 				continue
 			}
-			_, err := deployClient.DeleteDatabase(
-				ctx, orgId, projectId, name,
-			)
-			if err != nil {
-				return result, fmt.Errorf(
-					"failed to delete database %q: %w", name, err,
+			if !opts.DryRun {
+				_, err := deployClient.DeleteDatabase(
+					ctx, orgId, projectId, name,
 				)
+				if err != nil {
+					return result, fmt.Errorf(
+						"failed to delete database %q: %w", name, err,
+					)
+				}
 			}
 			result.Deleted = append(result.Deleted, name)
 		}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
 	"github.com/Interactive-AI-Labs/interactive-cli/internal/output"
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/preflight"
 )
 
 func AllowDeleteResource(allowed []string, resource string) bool {
@@ -110,8 +111,13 @@ func PrintResult(
 	return nil
 }
 
+// Services syncs services: creates new ones, updates existing ones, and
+// deletes ones not present in the desired map. Updates go through PUT and
+// replace the whole live spec, so the live revision each one overwrites is
+// announced on warnW (deploy awareness).
 func Services(
 	ctx context.Context,
+	warnW io.Writer,
 	deployClient *clients.DeploymentClient,
 	orgId,
 	projectId,
@@ -151,6 +157,8 @@ func Services(
 			}
 			result.Created = append(result.Created, name)
 		} else {
+			svc := existingByName[name]
+			preflight.PrintUpdateBanner(warnW, "service "+name, svc.Revision, svc.Updated)
 			_, err := deployClient.PutService(
 				ctx, orgId, projectId, name, body,
 			)
@@ -187,9 +195,12 @@ func Services(
 }
 
 // Agents syncs agents: creates new ones, updates existing ones, and deletes ones
-// not present in the desired map.
+// not present in the desired map. Updates go through PUT and replace the
+// whole live spec, so the live revision each one overwrites is announced on
+// warnW (deploy awareness).
 func Agents(
 	ctx context.Context,
+	warnW io.Writer,
 	deployClient *clients.DeploymentClient,
 	orgId,
 	projectId,
@@ -229,6 +240,8 @@ func Agents(
 			}
 			result.Created = append(result.Created, name)
 		} else {
+			a := existingByName[name]
+			preflight.PrintUpdateBanner(warnW, "agent "+name, a.Revision, a.Updated)
 			_, err := deployClient.PutAgent(
 				ctx, orgId, projectId, name, body,
 			)

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -115,7 +115,7 @@ func PrintResult(
 // deletes ones not present in the desired map. Updates go through PUT and
 // replace the whole live spec, so the live revision each one overwrites is
 // announced on warnW (deploy awareness), and pending deletions are announced
-// there before any write happens.
+// there before any service write happens.
 func Services(
 	ctx context.Context,
 	warnW io.Writer,
@@ -207,7 +207,7 @@ func deletionList[E, D any](existing map[string]E, desired map[string]D) []strin
 // not present in the desired map. Updates go through PUT and replace the
 // whole live spec, so the live revision each one overwrites is announced on
 // warnW (deploy awareness), and pending deletions are announced there before
-// any write happens.
+// any agent write happens.
 func Agents(
 	ctx context.Context,
 	warnW io.Writer,

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -117,7 +117,7 @@ func PrintResult(
 				"Use --allow-delete=%s to delete them.\n",
 			label,
 			strings.Join(result.Protected, ", "),
-			strings.ReplaceAll(label, " ", "-"),
+			label,
 		)
 	}
 	return nil
@@ -141,7 +141,7 @@ func PrintPlan(out io.Writer, label string, result *Result) {
 			out,
 			"Would refuse to delete %s (needs --allow-delete=%s): %s\n",
 			label,
-			strings.ReplaceAll(label, " ", "-"),
+			label,
 			strings.Join(result.Protected, ", "),
 		)
 	}
@@ -179,82 +179,32 @@ func Services(
 		existingByName[svc.Name] = svc
 	}
 
-	result := &Result{}
-
-	toDelete := deletionList(existingByName, desired)
-	if !opts.DryRun {
-		preflight.PrintSyncDeletions(warnW, "service", "services", toDelete, opts.AllowDelete)
-	}
-	if !opts.AllowDelete {
-		result.Protected = toDelete
-		toDelete = nil
-	}
-
-	desiredNames := make([]string, 0, len(desired))
-	for name := range desired {
-		desiredNames = append(desiredNames, name)
-	}
-	sort.Strings(desiredNames)
-
-	for _, name := range desiredNames {
-		body := desired[name]
-		if _, exists := existingByName[name]; !exists {
-			if !opts.DryRun {
-				_, err := deployClient.CreateService(
-					ctx, orgId, projectId, name, body,
-				)
-				if err != nil {
-					return result, fmt.Errorf(
-						"failed to create service %q: %w", name, err,
-					)
-				}
-			}
-			result.Created = append(result.Created, name)
-		} else {
-			if !opts.DryRun {
-				svc := existingByName[name]
-				preflight.PrintUpdateBanner(warnW, "service "+name, svc.Revision, svc.Updated)
-				_, err := deployClient.PutService(
-					ctx, orgId, projectId, name, body,
-				)
-				if err != nil {
-					return result, fmt.Errorf(
-						"failed to update service %q: %w", name, err,
-					)
-				}
-			}
-			result.Updated = append(result.Updated, name)
-		}
-	}
-
-	for _, name := range toDelete {
-		if !opts.DryRun {
-			_, err := deployClient.DeleteService(
-				ctx, orgId, projectId, name,
-			)
-			if err != nil {
-				return result, fmt.Errorf(
-					"failed to delete service %q: %w", name, err,
-				)
-			}
-		}
-		result.Deleted = append(result.Deleted, name)
-	}
-
-	return result, nil
-}
-
-// deletionList returns, sorted, the existing resource names a sync will
-// delete because the desired config no longer mentions them.
-func deletionList[E, D any](existing map[string]E, desired map[string]D) []string {
-	var names []string
-	for name := range existing {
-		if _, ok := desired[name]; !ok {
-			names = append(names, name)
-		}
-	}
-	sort.Strings(names)
-	return names
+	return syncResources(
+		ctx,
+		warnW,
+		existingByName,
+		desired,
+		opts,
+		resourceOps[clients.ServiceOutput, clients.CreateServiceBody]{
+			resource:  "service",
+			allowFlag: "services",
+			create: func(name string, body clients.CreateServiceBody) error {
+				_, err := deployClient.CreateService(ctx, orgId, projectId, name, body)
+				return err
+			},
+			update: func(name string, body clients.CreateServiceBody) error {
+				_, err := deployClient.PutService(ctx, orgId, projectId, name, body)
+				return err
+			},
+			delete: func(name string) error {
+				_, err := deployClient.DeleteService(ctx, orgId, projectId, name)
+				return err
+			},
+			banner: func(w io.Writer, svc clients.ServiceOutput) {
+				preflight.PrintUpdateBanner(w, "service "+svc.Name, svc.Revision, svc.Updated)
+			},
+		},
+	)
 }
 
 // Agents syncs agents: creates new ones, updates existing ones, and — only
@@ -285,69 +235,32 @@ func Agents(
 		existingByName[a.Name] = a
 	}
 
-	result := &Result{}
-
-	toDelete := deletionList(existingByName, desired)
-	if !opts.DryRun {
-		preflight.PrintSyncDeletions(warnW, "agent", "agents", toDelete, opts.AllowDelete)
-	}
-	if !opts.AllowDelete {
-		result.Protected = toDelete
-		toDelete = nil
-	}
-
-	desiredNames := make([]string, 0, len(desired))
-	for name := range desired {
-		desiredNames = append(desiredNames, name)
-	}
-	sort.Strings(desiredNames)
-
-	for _, name := range desiredNames {
-		body := desired[name]
-		if _, exists := existingByName[name]; !exists {
-			if !opts.DryRun {
-				_, err := deployClient.CreateAgent(
-					ctx, orgId, projectId, name, body,
-				)
-				if err != nil {
-					return result, fmt.Errorf(
-						"failed to create agent %q: %w", name, err,
-					)
-				}
-			}
-			result.Created = append(result.Created, name)
-		} else {
-			if !opts.DryRun {
-				a := existingByName[name]
-				preflight.PrintUpdateBanner(warnW, "agent "+name, a.Revision, a.Updated)
-				_, err := deployClient.PutAgent(
-					ctx, orgId, projectId, name, body,
-				)
-				if err != nil {
-					return result, fmt.Errorf(
-						"failed to update agent %q: %w", name, err,
-					)
-				}
-			}
-			result.Updated = append(result.Updated, name)
-		}
-	}
-
-	for _, name := range toDelete {
-		if !opts.DryRun {
-			_, err := deployClient.DeleteAgent(
-				ctx, orgId, projectId, name,
-			)
-			if err != nil {
-				return result, fmt.Errorf(
-					"failed to delete agent %q: %w", name, err,
-				)
-			}
-		}
-		result.Deleted = append(result.Deleted, name)
-	}
-
-	return result, nil
+	return syncResources(
+		ctx,
+		warnW,
+		existingByName,
+		desired,
+		opts,
+		resourceOps[clients.AgentOutput, clients.CreateAgentBody]{
+			resource:  "agent",
+			allowFlag: "agents",
+			create: func(name string, body clients.CreateAgentBody) error {
+				_, err := deployClient.CreateAgent(ctx, orgId, projectId, name, body)
+				return err
+			},
+			update: func(name string, body clients.CreateAgentBody) error {
+				_, err := deployClient.PutAgent(ctx, orgId, projectId, name, body)
+				return err
+			},
+			delete: func(name string) error {
+				_, err := deployClient.DeleteAgent(ctx, orgId, projectId, name)
+				return err
+			},
+			banner: func(w io.Writer, a clients.AgentOutput) {
+				preflight.PrintUpdateBanner(w, "agent "+a.Name, a.Revision, a.Updated)
+			},
+		},
+	)
 }
 
 // Databases syncs databases: creates new ones, updates existing ones, and —
@@ -377,11 +290,62 @@ func Databases(
 		existingByName[db.Name] = db
 	}
 
+	return syncResources(
+		ctx,
+		warnW,
+		existingByName,
+		desired,
+		opts,
+		resourceOps[clients.DatabaseOutput, clients.CreateDatabaseBody]{
+			resource:  "database",
+			allowFlag: "databases",
+			create: func(name string, body clients.CreateDatabaseBody) error {
+				_, err := deployClient.CreateDatabase(ctx, orgId, projectId, name, body)
+				return err
+			},
+			update: func(name string, body clients.CreateDatabaseBody) error {
+				_, err := deployClient.PutDatabase(ctx, orgId, projectId, name, body)
+				return err
+			},
+			delete: func(name string) error {
+				_, err := deployClient.DeleteDatabase(ctx, orgId, projectId, name)
+				return err
+			},
+			// Databases carry no revision to announce, so no banner.
+		},
+	)
+}
+
+// resourceOps binds one resource type's API calls and wording for
+// syncResources. banner, when set, announces the live state an update
+// replaces; leave it nil for resources with nothing to announce.
+type resourceOps[E, B any] struct {
+	resource  string // singular noun, e.g. "service"
+	allowFlag string // --allow-delete value, e.g. "services"
+	create    func(name string, body B) error
+	update    func(name string, body B) error
+	delete    func(name string) error
+	banner    func(w io.Writer, existing E)
+}
+
+// syncResources applies the shared sync contract for one resource type:
+// announce the deletion decision on warnW before any write, refuse deletions
+// without opts.AllowDelete (reporting them as Protected), create/update the
+// desired resources in name order, delete last, and — with opts.DryRun —
+// accumulate the same plan into the Result without calling the API at all.
+func syncResources[E, B any](
+	ctx context.Context,
+	warnW io.Writer,
+	existingByName map[string]E,
+	desired map[string]B,
+	opts Options,
+	ops resourceOps[E, B],
+) (*Result, error) {
 	result := &Result{}
 
 	toDelete := deletionList(existingByName, desired)
 	if !opts.DryRun {
-		preflight.PrintSyncDeletions(warnW, "database", "databases", toDelete, opts.AllowDelete)
+		preflight.PrintSyncDeletions(warnW, ops.resource, ops.allowFlag, toDelete, opts.AllowDelete)
 	}
 	if !opts.AllowDelete {
 		result.Protected = toDelete
@@ -396,26 +360,23 @@ func Databases(
 
 	for _, name := range desiredNames {
 		body := desired[name]
-		if _, exists := existingByName[name]; !exists {
+		if existing, exists := existingByName[name]; !exists {
 			if !opts.DryRun {
-				_, err := deployClient.CreateDatabase(
-					ctx, orgId, projectId, name, body,
-				)
-				if err != nil {
+				if err := ops.create(name, body); err != nil {
 					return result, fmt.Errorf(
-						"failed to create database %q: %w", name, err,
+						"failed to create %s %q: %w", ops.resource, name, err,
 					)
 				}
 			}
 			result.Created = append(result.Created, name)
 		} else {
 			if !opts.DryRun {
-				_, err := deployClient.PutDatabase(
-					ctx, orgId, projectId, name, body,
-				)
-				if err != nil {
+				if ops.banner != nil {
+					ops.banner(warnW, existing)
+				}
+				if err := ops.update(name, body); err != nil {
 					return result, fmt.Errorf(
-						"failed to update database %q: %w", name, err,
+						"failed to update %s %q: %w", ops.resource, name, err,
 					)
 				}
 			}
@@ -425,12 +386,9 @@ func Databases(
 
 	for _, name := range toDelete {
 		if !opts.DryRun {
-			_, err := deployClient.DeleteDatabase(
-				ctx, orgId, projectId, name,
-			)
-			if err != nil {
+			if err := ops.delete(name); err != nil {
 				return result, fmt.Errorf(
-					"failed to delete database %q: %w", name, err,
+					"failed to delete %s %q: %w", ops.resource, name, err,
 				)
 			}
 		}
@@ -438,4 +396,17 @@ func Databases(
 	}
 
 	return result, nil
+}
+
+// deletionList returns, sorted, the existing resource names a sync will
+// delete because the desired config no longer mentions them.
+func deletionList[E, D any](existing map[string]E, desired map[string]D) []string {
+	var names []string
+	for name := range existing {
+		if _, ok := desired[name]; !ok {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
 }

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -350,8 +350,14 @@ func Agents(
 	return result, nil
 }
 
+// Databases syncs databases: creates new ones, updates existing ones, and —
+// only with opts.AllowDelete — deletes ones not present in the desired map;
+// otherwise those are refused and reported as Protected. The deletion
+// decision is announced on warnW (deploy awareness) before any database
+// write happens.
 func Databases(
 	ctx context.Context,
+	warnW io.Writer,
 	deployClient *clients.DeploymentClient,
 	orgId,
 	projectId,
@@ -372,6 +378,15 @@ func Databases(
 	}
 
 	result := &Result{}
+
+	toDelete := deletionList(existingByName, desired)
+	if !opts.DryRun {
+		preflight.PrintSyncDeletions(warnW, "database", "databases", toDelete, opts.AllowDelete)
+	}
+	if !opts.AllowDelete {
+		result.Protected = toDelete
+		toDelete = nil
+	}
 
 	desiredNames := make([]string, 0, len(desired))
 	for name := range desired {
@@ -408,30 +423,18 @@ func Databases(
 		}
 	}
 
-	existingNames := make([]string, 0, len(existingByName))
-	for name := range existingByName {
-		existingNames = append(existingNames, name)
-	}
-	sort.Strings(existingNames)
-
-	for _, name := range existingNames {
-		if _, ok := desired[name]; !ok {
-			if !opts.AllowDelete {
-				result.Protected = append(result.Protected, name)
-				continue
-			}
-			if !opts.DryRun {
-				_, err := deployClient.DeleteDatabase(
-					ctx, orgId, projectId, name,
+	for _, name := range toDelete {
+		if !opts.DryRun {
+			_, err := deployClient.DeleteDatabase(
+				ctx, orgId, projectId, name,
+			)
+			if err != nil {
+				return result, fmt.Errorf(
+					"failed to delete database %q: %w", name, err,
 				)
-				if err != nil {
-					return result, fmt.Errorf(
-						"failed to delete database %q: %w", name, err,
-					)
-				}
 			}
-			result.Deleted = append(result.Deleted, name)
 		}
+		result.Deleted = append(result.Deleted, name)
 	}
 
 	return result, nil

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -28,16 +28,9 @@ type Result struct {
 	Protected []string // would be deleted but deletion was not allowed
 }
 
-// Options controls how a sync applies its computed diff.
 type Options struct {
-	// AllowDelete permits deleting resources the config file no longer
-	// mentions. Off by default: a stale config is indistinguishable from a
-	// decommissioning one, so omitted resources are reported as Protected
-	// instead of deleted.
 	AllowDelete bool
-	// DryRun computes the full plan (creates, updates, deletes, protected)
-	// without writing anything.
-	DryRun bool
+	DryRun      bool
 }
 
 func HasServices(
@@ -123,9 +116,6 @@ func PrintResult(
 	return nil
 }
 
-// PrintPlan renders a dry-run Result as the changes a real run would make,
-// without implying anything was written. label is the plural noun, which is
-// also the --allow-delete value ("services", "agents", "databases").
 func PrintPlan(out io.Writer, label string, result *Result) {
 	if len(result.Created) > 0 {
 		fmt.Fprintf(out, "Would create %s: %s\n", label, strings.Join(result.Created, ", "))
@@ -151,12 +141,6 @@ func PrintPlan(out io.Writer, label string, result *Result) {
 	}
 }
 
-// Services syncs services: creates new ones, updates existing ones, and —
-// only with opts.AllowDelete — deletes ones not present in the desired map;
-// otherwise those are refused and reported as Protected. Updates go through
-// PUT and replace the whole live spec, so the live revision each one
-// overwrites is announced on warnW (deploy awareness), and the deletion
-// decision is announced there before any service write happens.
 func Services(
 	ctx context.Context,
 	warnW io.Writer,
@@ -180,7 +164,6 @@ func Services(
 	}
 
 	return syncResources(
-		ctx,
 		warnW,
 		existingByName,
 		desired,
@@ -207,12 +190,6 @@ func Services(
 	)
 }
 
-// Agents syncs agents: creates new ones, updates existing ones, and — only
-// with opts.AllowDelete — deletes ones not present in the desired map;
-// otherwise those are refused and reported as Protected. Updates go through
-// PUT and replace the whole live spec, so the live revision each one
-// overwrites is announced on warnW (deploy awareness), and the deletion
-// decision is announced there before any agent write happens.
 func Agents(
 	ctx context.Context,
 	warnW io.Writer,
@@ -236,7 +213,6 @@ func Agents(
 	}
 
 	return syncResources(
-		ctx,
 		warnW,
 		existingByName,
 		desired,
@@ -263,11 +239,6 @@ func Agents(
 	)
 }
 
-// Databases syncs databases: creates new ones, updates existing ones, and —
-// only with opts.AllowDelete — deletes ones not present in the desired map;
-// otherwise those are refused and reported as Protected. The deletion
-// decision is announced on warnW (deploy awareness) before any database
-// write happens.
 func Databases(
 	ctx context.Context,
 	warnW io.Writer,
@@ -291,7 +262,6 @@ func Databases(
 	}
 
 	return syncResources(
-		ctx,
 		warnW,
 		existingByName,
 		desired,
@@ -311,30 +281,20 @@ func Databases(
 				_, err := deployClient.DeleteDatabase(ctx, orgId, projectId, name)
 				return err
 			},
-			// Databases carry no revision to announce, so no banner.
 		},
 	)
 }
 
-// resourceOps binds one resource type's API calls and wording for
-// syncResources. banner, when set, announces the live state an update
-// replaces; leave it nil for resources with nothing to announce.
 type resourceOps[E, B any] struct {
-	resource  string // singular noun, e.g. "service"
-	allowFlag string // --allow-delete value, e.g. "services"
+	resource  string
+	allowFlag string
 	create    func(name string, body B) error
 	update    func(name string, body B) error
 	delete    func(name string) error
 	banner    func(w io.Writer, existing E)
 }
 
-// syncResources applies the shared sync contract for one resource type:
-// announce the deletion decision on warnW before any write, refuse deletions
-// without opts.AllowDelete (reporting them as Protected), create/update the
-// desired resources in name order, delete last, and — with opts.DryRun —
-// accumulate the same plan into the Result without calling the API at all.
 func syncResources[E, B any](
-	ctx context.Context,
 	warnW io.Writer,
 	existingByName map[string]E,
 	desired map[string]B,
@@ -343,7 +303,13 @@ func syncResources[E, B any](
 ) (*Result, error) {
 	result := &Result{}
 
-	toDelete := deletionList(existingByName, desired)
+	var toDelete []string
+	for name := range existingByName {
+		if _, ok := desired[name]; !ok {
+			toDelete = append(toDelete, name)
+		}
+	}
+	sort.Strings(toDelete)
 	if !opts.DryRun {
 		preflight.PrintSyncDeletions(warnW, ops.resource, ops.allowFlag, toDelete, opts.AllowDelete)
 	}
@@ -396,17 +362,4 @@ func syncResources[E, B any](
 	}
 
 	return result, nil
-}
-
-// deletionList returns, sorted, the existing resource names a sync will
-// delete because the desired config no longer mentions them.
-func deletionList[E, D any](existing map[string]E, desired map[string]D) []string {
-	var names []string
-	for name := range existing {
-		if _, ok := desired[name]; !ok {
-			names = append(names, name)
-		}
-	}
-	sort.Strings(names)
-	return names
 }

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -222,6 +222,84 @@ func TestServicesPrintsUpdateBanner(t *testing.T) {
 	}
 }
 
+func TestServicesAnnouncesDeletions(t *testing.T) {
+	var deleted bool
+	client := newTestDeployClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/organizations/o1/projects/p1/services":
+			fmt.Fprint(
+				w,
+				`{"services":[{"name":"svc-a","projectId":"p1","revision":3,"status":"ready","updated":"2026-07-24T11:20:00Z"},{"name":"svc-old","projectId":"p1","revision":9,"status":"ready"}]}`,
+			)
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/organizations/o1/projects/p1/services/svc-a":
+			fmt.Fprint(w, `{}`)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/organizations/o1/projects/p1/services/svc-old":
+			deleted = true
+			fmt.Fprint(w, `{}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	var warn bytes.Buffer
+	desired := map[string]clients.CreateServiceBody{"svc-a": {}}
+	result, err := Services(context.Background(), &warn, client, "o1", "p1", "stack-1", desired)
+	if err != nil {
+		t.Fatalf("Services() error = %v", err)
+	}
+
+	// The deletion announcement must come first: it is printed before any
+	// create/update write, so the whole sync is still abortable.
+	wantWarn := "⚠ sync will DELETE 1 service not in the config: svc-old" +
+		" (deletes run last — Ctrl-C to abort if the config is stale)\n" +
+		"Live: service svc-a revision 3, last updated 2026-07-24 11:20 UTC — this update creates revision 4\n"
+	if got := warn.String(); got != wantWarn {
+		t.Errorf("warnings = %q, want %q", got, wantWarn)
+	}
+	if !deleted {
+		t.Error("svc-old was announced but not deleted")
+	}
+	if len(result.Deleted) != 1 || result.Deleted[0] != "svc-old" {
+		t.Errorf("Deleted = %v, want [svc-old]", result.Deleted)
+	}
+}
+
+func TestAgentsAnnouncesDeletions(t *testing.T) {
+	client := newTestDeployClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/organizations/o1/projects/p1/agents":
+			fmt.Fprint(
+				w,
+				`{"agents":[{"name":"agent-old","projectId":"p1","revision":5,"status":"ready"}]}`,
+			)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/organizations/o1/projects/p1/agents/agent-old":
+			fmt.Fprint(w, `{}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	var warn bytes.Buffer
+	result, err := Agents(
+		context.Background(), &warn, client, "o1", "p1", "stack-1",
+		map[string]clients.CreateAgentBody{},
+	)
+	if err != nil {
+		t.Fatalf("Agents() error = %v", err)
+	}
+
+	wantWarn := "⚠ sync will DELETE 1 agent not in the config: agent-old" +
+		" (deletes run last — Ctrl-C to abort if the config is stale)\n"
+	if got := warn.String(); got != wantWarn {
+		t.Errorf("warnings = %q, want %q", got, wantWarn)
+	}
+	if len(result.Deleted) != 1 || result.Deleted[0] != "agent-old" {
+		t.Errorf("Deleted = %v, want [agent-old]", result.Deleted)
+	}
+}
+
 func TestAgentsPrintsUpdateBanner(t *testing.T) {
 	client := newTestDeployClient(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -189,7 +189,7 @@ func TestPrintPlan(t *testing.T) {
 			want: "Would create services: svc-new\n" +
 				"Would update services: svc-a, svc-b\n" +
 				"Would delete services: svc-gone\n" +
-				"Would refuse to delete services (needs --allow-delete=services): svc-old\n",
+				"Would refuse to delete services: svc-old (a config that omits a resource looks identical to a stale one — pass --allow-delete=services to delete)\n",
 		},
 		{
 			name:   "no changes",
@@ -203,7 +203,7 @@ func TestPrintPlan(t *testing.T) {
 			result: &Result{
 				Protected: []string{"old-db"},
 			},
-			want: "Would refuse to delete databases (needs --allow-delete=databases): old-db\n",
+			want: "Would refuse to delete databases: old-db (a config that omits a resource looks identical to a stale one — pass --allow-delete=databases to delete)\n",
 		},
 	}
 

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -218,7 +218,6 @@ func TestPrintPlan(t *testing.T) {
 	}
 }
 
-// newTestDeployClient returns a client pointed at a stub deployment server.
 func newTestDeployClient(t *testing.T, handler http.HandlerFunc) *clients.DeploymentClient {
 	t.Helper()
 	server := httptest.NewServer(handler)
@@ -279,106 +278,193 @@ func TestServicesPrintsUpdateBanner(t *testing.T) {
 	}
 }
 
-func TestServicesRefusesDeletionsByDefault(t *testing.T) {
-	client := newTestDeployClient(t, func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/v1/organizations/o1/projects/p1/services":
-			fmt.Fprint(
-				w,
-				`{"services":[{"name":"svc-a","projectId":"p1","revision":3,"status":"ready","updated":"2026-07-24T11:20:00Z"},{"name":"svc-old","projectId":"p1","revision":9,"status":"ready"}]}`,
-			)
-		case r.Method == http.MethodPut && r.URL.Path == "/v1/organizations/o1/projects/p1/services/svc-a":
-			fmt.Fprint(w, `{}`)
-		case r.Method == http.MethodDelete && r.URL.Path == "/v1/organizations/o1/projects/p1/services/svc-old":
-			t.Error("svc-old was deleted without --allow-delete")
-			fmt.Fprint(w, `{}`)
-		default:
-			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
-			w.WriteHeader(http.StatusNotFound)
-		}
-	})
-
-	var warn bytes.Buffer
-	desired := map[string]clients.CreateServiceBody{"svc-a": {}}
-	result, err := Services(
-		context.Background(),
-		&warn,
-		client,
-		"o1",
-		"p1",
-		"stack-1",
-		desired,
-		Options{},
-	)
-	if err != nil {
-		t.Fatalf("Services() error = %v", err)
+func TestSyncRefusesDeletionsByDefault(t *testing.T) {
+	tests := []struct {
+		name          string
+		listPath      string
+		listBody      string
+		deletePath    string
+		putPath       string
+		wantWarn      string
+		wantProtected []string
+		wantUpdated   []string
+		run           func(context.Context, *bytes.Buffer, *clients.DeploymentClient) (*Result, error)
+	}{
+		{
+			name:       "services",
+			listPath:   "/v1/organizations/o1/projects/p1/services",
+			listBody:   `{"services":[{"name":"svc-a","projectId":"p1","revision":3,"status":"ready","updated":"2026-07-24T11:20:00Z"},{"name":"svc-old","projectId":"p1","revision":9,"status":"ready"}]}`,
+			deletePath: "/v1/organizations/o1/projects/p1/services/svc-old",
+			putPath:    "/v1/organizations/o1/projects/p1/services/svc-a",
+			wantWarn: "⚠ sync will NOT delete 1 service not in the config: svc-old" +
+				" (a config that omits a resource looks identical to a stale one — pass --allow-delete=services to delete)\n" +
+				"Live: service svc-a revision 3, last updated 2026-07-24 11:20 UTC — this update creates revision 4\n",
+			wantProtected: []string{"svc-old"},
+			wantUpdated:   []string{"svc-a"},
+			run: func(ctx context.Context, warn *bytes.Buffer, client *clients.DeploymentClient) (*Result, error) {
+				return Services(ctx, warn, client, "o1", "p1", "stack-1",
+					map[string]clients.CreateServiceBody{"svc-a": {}}, Options{})
+			},
+		},
+		{
+			name:       "agents",
+			listPath:   "/v1/organizations/o1/projects/p1/agents",
+			listBody:   `{"agents":[{"name":"agent-old","projectId":"p1","revision":5,"status":"ready"}]}`,
+			deletePath: "/v1/organizations/o1/projects/p1/agents/agent-old",
+			wantWarn: "⚠ sync will NOT delete 1 agent not in the config: agent-old" +
+				" (a config that omits a resource looks identical to a stale one — pass --allow-delete=agents to delete)\n",
+			wantProtected: []string{"agent-old"},
+			run: func(ctx context.Context, warn *bytes.Buffer, client *clients.DeploymentClient) (*Result, error) {
+				return Agents(ctx, warn, client, "o1", "p1", "stack-1",
+					map[string]clients.CreateAgentBody{}, Options{})
+			},
+		},
+		{
+			name:       "databases",
+			listPath:   "/v1/organizations/o1/projects/p1/databases",
+			listBody:   `{"databases":[{"name":"old-db","revision":2,"status":"ready"}]}`,
+			deletePath: "/v1/organizations/o1/projects/p1/databases/old-db",
+			wantWarn: "⚠ sync will NOT delete 1 database not in the config: old-db" +
+				" (a config that omits a resource looks identical to a stale one — pass --allow-delete=databases to delete)\n",
+			wantProtected: []string{"old-db"},
+			run: func(ctx context.Context, warn *bytes.Buffer, client *clients.DeploymentClient) (*Result, error) {
+				return Databases(ctx, warn, client, "o1", "p1", "stack-1",
+					map[string]clients.CreateDatabaseBody{}, Options{})
+			},
+		},
 	}
 
-	// The refusal is reported first, then the update proceeds normally: the
-	// gate blocks only the deletion, never the creates and updates.
-	wantWarn := "⚠ sync will NOT delete 1 service not in the config: svc-old" +
-		" (a config that omits a resource looks identical to a stale one — pass --allow-delete=services to delete)\n" +
-		"Live: service svc-a revision 3, last updated 2026-07-24 11:20 UTC — this update creates revision 4\n"
-	if got := warn.String(); got != wantWarn {
-		t.Errorf("warnings = %q, want %q", got, wantWarn)
-	}
-	if len(result.Deleted) != 0 {
-		t.Errorf("Deleted = %v, want []", result.Deleted)
-	}
-	if len(result.Protected) != 1 || result.Protected[0] != "svc-old" {
-		t.Errorf("Protected = %v, want [svc-old]", result.Protected)
-	}
-	if len(result.Updated) != 1 || result.Updated[0] != "svc-a" {
-		t.Errorf("Updated = %v, want [svc-a]", result.Updated)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTestDeployClient(t, func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == tt.listPath:
+					fmt.Fprint(w, tt.listBody)
+				case tt.putPath != "" && r.Method == http.MethodPut && r.URL.Path == tt.putPath:
+					fmt.Fprint(w, `{}`)
+				case r.Method == http.MethodDelete && r.URL.Path == tt.deletePath:
+					t.Errorf("%s was deleted without --allow-delete", tt.deletePath)
+					fmt.Fprint(w, `{}`)
+				default:
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+			})
+
+			var warn bytes.Buffer
+			result, err := tt.run(context.Background(), &warn, client)
+			if err != nil {
+				t.Fatalf("sync error = %v", err)
+			}
+			if got := warn.String(); got != tt.wantWarn {
+				t.Errorf("warnings = %q, want %q", got, tt.wantWarn)
+			}
+			if len(result.Deleted) != 0 {
+				t.Errorf("Deleted = %v, want []", result.Deleted)
+			}
+			if len(result.Protected) != len(tt.wantProtected) ||
+				(len(tt.wantProtected) > 0 && result.Protected[0] != tt.wantProtected[0]) {
+				t.Errorf("Protected = %v, want %v", result.Protected, tt.wantProtected)
+			}
+			if len(result.Updated) != len(tt.wantUpdated) ||
+				(len(tt.wantUpdated) > 0 && result.Updated[0] != tt.wantUpdated[0]) {
+				t.Errorf("Updated = %v, want %v", result.Updated, tt.wantUpdated)
+			}
+		})
 	}
 }
 
-func TestServicesDeletesWithAllowDelete(t *testing.T) {
-	var deleted bool
-	client := newTestDeployClient(t, func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/v1/organizations/o1/projects/p1/services":
-			fmt.Fprint(
-				w,
-				`{"services":[{"name":"svc-a","projectId":"p1","revision":3,"status":"ready","updated":"2026-07-24T11:20:00Z"},{"name":"svc-old","projectId":"p1","revision":9,"status":"ready"}]}`,
-			)
-		case r.Method == http.MethodPut && r.URL.Path == "/v1/organizations/o1/projects/p1/services/svc-a":
-			fmt.Fprint(w, `{}`)
-		case r.Method == http.MethodDelete && r.URL.Path == "/v1/organizations/o1/projects/p1/services/svc-old":
-			deleted = true
-			fmt.Fprint(w, `{}`)
-		default:
-			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
-			w.WriteHeader(http.StatusNotFound)
-		}
-	})
-
-	var warn bytes.Buffer
-	desired := map[string]clients.CreateServiceBody{"svc-a": {}}
-	result, err := Services(
-		context.Background(), &warn, client, "o1", "p1", "stack-1", desired,
-		Options{AllowDelete: true},
-	)
-	if err != nil {
-		t.Fatalf("Services() error = %v", err)
+func TestSyncDeletesWithAllowDelete(t *testing.T) {
+	tests := []struct {
+		name        string
+		listPath    string
+		listBody    string
+		deletePath  string
+		putPath     string
+		wantWarn    string
+		wantDeleted []string
+		run         func(context.Context, *bytes.Buffer, *clients.DeploymentClient) (*Result, error)
+	}{
+		{
+			name:       "services",
+			listPath:   "/v1/organizations/o1/projects/p1/services",
+			listBody:   `{"services":[{"name":"svc-a","projectId":"p1","revision":3,"status":"ready","updated":"2026-07-24T11:20:00Z"},{"name":"svc-old","projectId":"p1","revision":9,"status":"ready"}]}`,
+			deletePath: "/v1/organizations/o1/projects/p1/services/svc-old",
+			putPath:    "/v1/organizations/o1/projects/p1/services/svc-a",
+			wantWarn: "⚠ sync will DELETE 1 service not in the config: svc-old" +
+				" (--allow-delete=services; service deletes run after service creates/updates)\n" +
+				"Live: service svc-a revision 3, last updated 2026-07-24 11:20 UTC — this update creates revision 4\n",
+			wantDeleted: []string{"svc-old"},
+			run: func(ctx context.Context, warn *bytes.Buffer, client *clients.DeploymentClient) (*Result, error) {
+				return Services(ctx, warn, client, "o1", "p1", "stack-1",
+					map[string]clients.CreateServiceBody{"svc-a": {}}, Options{AllowDelete: true})
+			},
+		},
+		{
+			name:       "agents",
+			listPath:   "/v1/organizations/o1/projects/p1/agents",
+			listBody:   `{"agents":[{"name":"agent-old","projectId":"p1","revision":5,"status":"ready"}]}`,
+			deletePath: "/v1/organizations/o1/projects/p1/agents/agent-old",
+			wantWarn: "⚠ sync will DELETE 1 agent not in the config: agent-old" +
+				" (--allow-delete=agents; agent deletes run after agent creates/updates)\n",
+			wantDeleted: []string{"agent-old"},
+			run: func(ctx context.Context, warn *bytes.Buffer, client *clients.DeploymentClient) (*Result, error) {
+				return Agents(ctx, warn, client, "o1", "p1", "stack-1",
+					map[string]clients.CreateAgentBody{}, Options{AllowDelete: true})
+			},
+		},
+		{
+			name:       "databases",
+			listPath:   "/v1/organizations/o1/projects/p1/databases",
+			listBody:   `{"databases":[{"name":"old-db","revision":2,"status":"ready"}]}`,
+			deletePath: "/v1/organizations/o1/projects/p1/databases/old-db",
+			wantWarn: "⚠ sync will DELETE 1 database not in the config: old-db" +
+				" (--allow-delete=databases; database deletes run after database creates/updates)\n",
+			wantDeleted: []string{"old-db"},
+			run: func(ctx context.Context, warn *bytes.Buffer, client *clients.DeploymentClient) (*Result, error) {
+				return Databases(ctx, warn, client, "o1", "p1", "stack-1",
+					map[string]clients.CreateDatabaseBody{}, Options{AllowDelete: true})
+			},
+		},
 	}
 
-	// The deletion announcement must come first: it is printed before any
-	// service create/update write, so the service phase is still abortable.
-	wantWarn := "⚠ sync will DELETE 1 service not in the config: svc-old" +
-		" (--allow-delete=services; service deletes run after service creates/updates)\n" +
-		"Live: service svc-a revision 3, last updated 2026-07-24 11:20 UTC — this update creates revision 4\n"
-	if got := warn.String(); got != wantWarn {
-		t.Errorf("warnings = %q, want %q", got, wantWarn)
-	}
-	if !deleted {
-		t.Error("svc-old was announced but not deleted")
-	}
-	if len(result.Deleted) != 1 || result.Deleted[0] != "svc-old" {
-		t.Errorf("Deleted = %v, want [svc-old]", result.Deleted)
-	}
-	if len(result.Protected) != 0 {
-		t.Errorf("Protected = %v, want []", result.Protected)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var deleted bool
+			client := newTestDeployClient(t, func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == tt.listPath:
+					fmt.Fprint(w, tt.listBody)
+				case tt.putPath != "" && r.Method == http.MethodPut && r.URL.Path == tt.putPath:
+					fmt.Fprint(w, `{}`)
+				case r.Method == http.MethodDelete && r.URL.Path == tt.deletePath:
+					deleted = true
+					fmt.Fprint(w, `{}`)
+				default:
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+			})
+
+			var warn bytes.Buffer
+			result, err := tt.run(context.Background(), &warn, client)
+			if err != nil {
+				t.Fatalf("sync error = %v", err)
+			}
+			if got := warn.String(); got != tt.wantWarn {
+				t.Errorf("warnings = %q, want %q", got, tt.wantWarn)
+			}
+			if !deleted {
+				t.Errorf("%s was announced but not deleted", tt.deletePath)
+			}
+			if len(result.Deleted) != len(tt.wantDeleted) ||
+				(len(tt.wantDeleted) > 0 && result.Deleted[0] != tt.wantDeleted[0]) {
+				t.Errorf("Deleted = %v, want %v", result.Deleted, tt.wantDeleted)
+			}
+			if len(result.Protected) != 0 {
+				t.Errorf("Protected = %v, want []", result.Protected)
+			}
+		})
 	}
 }
 
@@ -423,159 +509,6 @@ func TestServicesDryRunPlansWithoutWriting(t *testing.T) {
 	}
 	if len(result.Deleted) != 0 {
 		t.Errorf("Deleted = %v, want []", result.Deleted)
-	}
-}
-
-func TestAgentsRefusesDeletionsByDefault(t *testing.T) {
-	client := newTestDeployClient(t, func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/v1/organizations/o1/projects/p1/agents":
-			fmt.Fprint(
-				w,
-				`{"agents":[{"name":"agent-old","projectId":"p1","revision":5,"status":"ready"}]}`,
-			)
-		case r.Method == http.MethodDelete && r.URL.Path == "/v1/organizations/o1/projects/p1/agents/agent-old":
-			t.Error("agent-old was deleted without --allow-delete")
-			fmt.Fprint(w, `{}`)
-		default:
-			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
-			w.WriteHeader(http.StatusNotFound)
-		}
-	})
-
-	var warn bytes.Buffer
-	result, err := Agents(
-		context.Background(), &warn, client, "o1", "p1", "stack-1",
-		map[string]clients.CreateAgentBody{}, Options{},
-	)
-	if err != nil {
-		t.Fatalf("Agents() error = %v", err)
-	}
-
-	wantWarn := "⚠ sync will NOT delete 1 agent not in the config: agent-old" +
-		" (a config that omits a resource looks identical to a stale one — pass --allow-delete=agents to delete)\n"
-	if got := warn.String(); got != wantWarn {
-		t.Errorf("warnings = %q, want %q", got, wantWarn)
-	}
-	if len(result.Deleted) != 0 {
-		t.Errorf("Deleted = %v, want []", result.Deleted)
-	}
-	if len(result.Protected) != 1 || result.Protected[0] != "agent-old" {
-		t.Errorf("Protected = %v, want [agent-old]", result.Protected)
-	}
-}
-
-func TestDatabasesRefusesDeletionsByDefault(t *testing.T) {
-	client := newTestDeployClient(t, func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/v1/organizations/o1/projects/p1/databases":
-			fmt.Fprint(
-				w,
-				`{"databases":[{"name":"old-db","revision":2,"status":"ready"}]}`,
-			)
-		case r.Method == http.MethodDelete && r.URL.Path == "/v1/organizations/o1/projects/p1/databases/old-db":
-			t.Error("old-db was deleted without --allow-delete")
-			fmt.Fprint(w, `{}`)
-		default:
-			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
-			w.WriteHeader(http.StatusNotFound)
-		}
-	})
-
-	var warn bytes.Buffer
-	result, err := Databases(
-		context.Background(), &warn, client, "o1", "p1", "stack-1",
-		map[string]clients.CreateDatabaseBody{}, Options{},
-	)
-	if err != nil {
-		t.Fatalf("Databases() error = %v", err)
-	}
-
-	wantWarn := "⚠ sync will NOT delete 1 database not in the config: old-db" +
-		" (a config that omits a resource looks identical to a stale one — pass --allow-delete=databases to delete)\n"
-	if got := warn.String(); got != wantWarn {
-		t.Errorf("warnings = %q, want %q", got, wantWarn)
-	}
-	if len(result.Deleted) != 0 {
-		t.Errorf("Deleted = %v, want []", result.Deleted)
-	}
-	if len(result.Protected) != 1 || result.Protected[0] != "old-db" {
-		t.Errorf("Protected = %v, want [old-db]", result.Protected)
-	}
-}
-
-func TestDatabasesDeletesWithAllowDelete(t *testing.T) {
-	var deleted bool
-	client := newTestDeployClient(t, func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/v1/organizations/o1/projects/p1/databases":
-			fmt.Fprint(
-				w,
-				`{"databases":[{"name":"old-db","revision":2,"status":"ready"}]}`,
-			)
-		case r.Method == http.MethodDelete && r.URL.Path == "/v1/organizations/o1/projects/p1/databases/old-db":
-			deleted = true
-			fmt.Fprint(w, `{}`)
-		default:
-			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
-			w.WriteHeader(http.StatusNotFound)
-		}
-	})
-
-	var warn bytes.Buffer
-	result, err := Databases(
-		context.Background(), &warn, client, "o1", "p1", "stack-1",
-		map[string]clients.CreateDatabaseBody{}, Options{AllowDelete: true},
-	)
-	if err != nil {
-		t.Fatalf("Databases() error = %v", err)
-	}
-
-	wantWarn := "⚠ sync will DELETE 1 database not in the config: old-db" +
-		" (--allow-delete=databases; database deletes run after database creates/updates)\n"
-	if got := warn.String(); got != wantWarn {
-		t.Errorf("warnings = %q, want %q", got, wantWarn)
-	}
-	if !deleted {
-		t.Error("old-db was announced but not deleted")
-	}
-	if len(result.Deleted) != 1 || result.Deleted[0] != "old-db" {
-		t.Errorf("Deleted = %v, want [old-db]", result.Deleted)
-	}
-}
-
-func TestAgentsDeletesWithAllowDelete(t *testing.T) {
-	client := newTestDeployClient(t, func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/v1/organizations/o1/projects/p1/agents":
-			fmt.Fprint(
-				w,
-				`{"agents":[{"name":"agent-old","projectId":"p1","revision":5,"status":"ready"}]}`,
-			)
-		case r.Method == http.MethodDelete && r.URL.Path == "/v1/organizations/o1/projects/p1/agents/agent-old":
-			fmt.Fprint(w, `{}`)
-		default:
-			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
-			w.WriteHeader(http.StatusNotFound)
-		}
-	})
-
-	var warn bytes.Buffer
-	result, err := Agents(
-		context.Background(), &warn, client, "o1", "p1", "stack-1",
-		map[string]clients.CreateAgentBody{}, Options{AllowDelete: true},
-	)
-	if err != nil {
-		t.Fatalf("Agents() error = %v", err)
-	}
-
-	wantWarn := "⚠ sync will DELETE 1 agent not in the config: agent-old" +
-		" (--allow-delete=agents; agent deletes run after agent creates/updates)\n"
-	if got := warn.String(); got != wantWarn {
-		t.Errorf("warnings = %q, want %q", got, wantWarn)
-	}
-	if len(result.Deleted) != 1 || result.Deleted[0] != "agent-old" {
-		t.Errorf("Deleted = %v, want [agent-old]", result.Deleted)
 	}
 }
 

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -250,9 +250,9 @@ func TestServicesAnnouncesDeletions(t *testing.T) {
 	}
 
 	// The deletion announcement must come first: it is printed before any
-	// create/update write, so the whole sync is still abortable.
+	// service create/update write, so the service phase is still abortable.
 	wantWarn := "⚠ sync will DELETE 1 service not in the config: svc-old" +
-		" (deletes run last — Ctrl-C to abort if the config is stale)\n" +
+		" (service deletes run after service creates/updates — Ctrl-C to abort if the config is stale)\n" +
 		"Live: service svc-a revision 3, last updated 2026-07-24 11:20 UTC — this update creates revision 4\n"
 	if got := warn.String(); got != wantWarn {
 		t.Errorf("warnings = %q, want %q", got, wantWarn)
@@ -291,7 +291,7 @@ func TestAgentsAnnouncesDeletions(t *testing.T) {
 	}
 
 	wantWarn := "⚠ sync will DELETE 1 agent not in the config: agent-old" +
-		" (deletes run last — Ctrl-C to abort if the config is stale)\n"
+		" (agent deletes run after agent creates/updates — Ctrl-C to abort if the config is stale)\n"
 	if got := warn.String(); got != wantWarn {
 		t.Errorf("warnings = %q, want %q", got, wantWarn)
 	}

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -170,6 +170,54 @@ func TestPrintResult(t *testing.T) {
 	}
 }
 
+func TestPrintPlan(t *testing.T) {
+	tests := []struct {
+		name   string
+		label  string
+		result *Result
+		want   string
+	}{
+		{
+			name:  "full plan",
+			label: "services",
+			result: &Result{
+				Created:   []string{"svc-new"},
+				Updated:   []string{"svc-a", "svc-b"},
+				Deleted:   []string{"svc-gone"},
+				Protected: []string{"svc-old"},
+			},
+			want: "Would create services: svc-new\n" +
+				"Would update services: svc-a, svc-b\n" +
+				"Would delete services: svc-gone\n" +
+				"Would refuse to delete services (needs --allow-delete=services): svc-old\n",
+		},
+		{
+			name:   "no changes",
+			label:  "agents",
+			result: &Result{},
+			want:   "No changes required; agents already match config.\n",
+		},
+		{
+			name:  "only refused deletions",
+			label: "databases",
+			result: &Result{
+				Protected: []string{"old-db"},
+			},
+			want: "Would refuse to delete databases (needs --allow-delete=databases): old-db\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			PrintPlan(&buf, tt.label, tt.result)
+			if got := buf.String(); got != tt.want {
+				t.Errorf("plan mismatch\ngot:\n%q\nwant:\n%q", got, tt.want)
+			}
+		})
+	}
+}
+
 // newTestDeployClient returns a client pointed at a stub deployment server.
 func newTestDeployClient(t *testing.T, handler http.HandlerFunc) *clients.DeploymentClient {
 	t.Helper()
@@ -205,7 +253,16 @@ func TestServicesPrintsUpdateBanner(t *testing.T) {
 		"svc-a":   {},
 		"svc-new": {},
 	}
-	result, err := Services(context.Background(), &warn, client, "o1", "p1", "stack-1", desired)
+	result, err := Services(
+		context.Background(),
+		&warn,
+		client,
+		"o1",
+		"p1",
+		"stack-1",
+		desired,
+		Options{},
+	)
 	if err != nil {
 		t.Fatalf("Services() error = %v", err)
 	}
@@ -222,7 +279,61 @@ func TestServicesPrintsUpdateBanner(t *testing.T) {
 	}
 }
 
-func TestServicesAnnouncesDeletions(t *testing.T) {
+func TestServicesRefusesDeletionsByDefault(t *testing.T) {
+	client := newTestDeployClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/organizations/o1/projects/p1/services":
+			fmt.Fprint(
+				w,
+				`{"services":[{"name":"svc-a","projectId":"p1","revision":3,"status":"ready","updated":"2026-07-24T11:20:00Z"},{"name":"svc-old","projectId":"p1","revision":9,"status":"ready"}]}`,
+			)
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/organizations/o1/projects/p1/services/svc-a":
+			fmt.Fprint(w, `{}`)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/organizations/o1/projects/p1/services/svc-old":
+			t.Error("svc-old was deleted without --allow-delete")
+			fmt.Fprint(w, `{}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	var warn bytes.Buffer
+	desired := map[string]clients.CreateServiceBody{"svc-a": {}}
+	result, err := Services(
+		context.Background(),
+		&warn,
+		client,
+		"o1",
+		"p1",
+		"stack-1",
+		desired,
+		Options{},
+	)
+	if err != nil {
+		t.Fatalf("Services() error = %v", err)
+	}
+
+	// The refusal is reported first, then the update proceeds normally: the
+	// gate blocks only the deletion, never the creates and updates.
+	wantWarn := "⚠ sync will NOT delete 1 service not in the config: svc-old" +
+		" (a config that omits a resource looks identical to a stale one — pass --allow-delete=services to delete)\n" +
+		"Live: service svc-a revision 3, last updated 2026-07-24 11:20 UTC — this update creates revision 4\n"
+	if got := warn.String(); got != wantWarn {
+		t.Errorf("warnings = %q, want %q", got, wantWarn)
+	}
+	if len(result.Deleted) != 0 {
+		t.Errorf("Deleted = %v, want []", result.Deleted)
+	}
+	if len(result.Protected) != 1 || result.Protected[0] != "svc-old" {
+		t.Errorf("Protected = %v, want [svc-old]", result.Protected)
+	}
+	if len(result.Updated) != 1 || result.Updated[0] != "svc-a" {
+		t.Errorf("Updated = %v, want [svc-a]", result.Updated)
+	}
+}
+
+func TestServicesDeletesWithAllowDelete(t *testing.T) {
 	var deleted bool
 	client := newTestDeployClient(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -244,7 +355,10 @@ func TestServicesAnnouncesDeletions(t *testing.T) {
 
 	var warn bytes.Buffer
 	desired := map[string]clients.CreateServiceBody{"svc-a": {}}
-	result, err := Services(context.Background(), &warn, client, "o1", "p1", "stack-1", desired)
+	result, err := Services(
+		context.Background(), &warn, client, "o1", "p1", "stack-1", desired,
+		Options{AllowDelete: true},
+	)
 	if err != nil {
 		t.Fatalf("Services() error = %v", err)
 	}
@@ -252,7 +366,7 @@ func TestServicesAnnouncesDeletions(t *testing.T) {
 	// The deletion announcement must come first: it is printed before any
 	// service create/update write, so the service phase is still abortable.
 	wantWarn := "⚠ sync will DELETE 1 service not in the config: svc-old" +
-		" (service deletes run after service creates/updates — Ctrl-C to abort if the config is stale)\n" +
+		" (--allow-delete=services; service deletes run after service creates/updates)\n" +
 		"Live: service svc-a revision 3, last updated 2026-07-24 11:20 UTC — this update creates revision 4\n"
 	if got := warn.String(); got != wantWarn {
 		t.Errorf("warnings = %q, want %q", got, wantWarn)
@@ -263,9 +377,95 @@ func TestServicesAnnouncesDeletions(t *testing.T) {
 	if len(result.Deleted) != 1 || result.Deleted[0] != "svc-old" {
 		t.Errorf("Deleted = %v, want [svc-old]", result.Deleted)
 	}
+	if len(result.Protected) != 0 {
+		t.Errorf("Protected = %v, want []", result.Protected)
+	}
 }
 
-func TestAgentsAnnouncesDeletions(t *testing.T) {
+func TestServicesDryRunPlansWithoutWriting(t *testing.T) {
+	client := newTestDeployClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/organizations/o1/projects/p1/services":
+			fmt.Fprint(
+				w,
+				`{"services":[{"name":"svc-a","projectId":"p1","revision":3,"status":"ready","updated":"2026-07-24T11:20:00Z"},{"name":"svc-old","projectId":"p1","revision":9,"status":"ready"}]}`,
+			)
+		default:
+			t.Errorf("dry run made a write: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	var warn bytes.Buffer
+	desired := map[string]clients.CreateServiceBody{
+		"svc-a":   {},
+		"svc-new": {},
+	}
+	result, err := Services(
+		context.Background(), &warn, client, "o1", "p1", "stack-1", desired,
+		Options{DryRun: true},
+	)
+	if err != nil {
+		t.Fatalf("Services() error = %v", err)
+	}
+
+	if got := warn.String(); got != "" {
+		t.Errorf("dry run printed warnings = %q, want none (the plan is the deliverable)", got)
+	}
+	if len(result.Created) != 1 || result.Created[0] != "svc-new" {
+		t.Errorf("Created = %v, want [svc-new]", result.Created)
+	}
+	if len(result.Updated) != 1 || result.Updated[0] != "svc-a" {
+		t.Errorf("Updated = %v, want [svc-a]", result.Updated)
+	}
+	if len(result.Protected) != 1 || result.Protected[0] != "svc-old" {
+		t.Errorf("Protected = %v, want [svc-old]", result.Protected)
+	}
+	if len(result.Deleted) != 0 {
+		t.Errorf("Deleted = %v, want []", result.Deleted)
+	}
+}
+
+func TestAgentsRefusesDeletionsByDefault(t *testing.T) {
+	client := newTestDeployClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/organizations/o1/projects/p1/agents":
+			fmt.Fprint(
+				w,
+				`{"agents":[{"name":"agent-old","projectId":"p1","revision":5,"status":"ready"}]}`,
+			)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/organizations/o1/projects/p1/agents/agent-old":
+			t.Error("agent-old was deleted without --allow-delete")
+			fmt.Fprint(w, `{}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	var warn bytes.Buffer
+	result, err := Agents(
+		context.Background(), &warn, client, "o1", "p1", "stack-1",
+		map[string]clients.CreateAgentBody{}, Options{},
+	)
+	if err != nil {
+		t.Fatalf("Agents() error = %v", err)
+	}
+
+	wantWarn := "⚠ sync will NOT delete 1 agent not in the config: agent-old" +
+		" (a config that omits a resource looks identical to a stale one — pass --allow-delete=agents to delete)\n"
+	if got := warn.String(); got != wantWarn {
+		t.Errorf("warnings = %q, want %q", got, wantWarn)
+	}
+	if len(result.Deleted) != 0 {
+		t.Errorf("Deleted = %v, want []", result.Deleted)
+	}
+	if len(result.Protected) != 1 || result.Protected[0] != "agent-old" {
+		t.Errorf("Protected = %v, want [agent-old]", result.Protected)
+	}
+}
+
+func TestAgentsDeletesWithAllowDelete(t *testing.T) {
 	client := newTestDeployClient(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/organizations/o1/projects/p1/agents":
@@ -284,14 +484,14 @@ func TestAgentsAnnouncesDeletions(t *testing.T) {
 	var warn bytes.Buffer
 	result, err := Agents(
 		context.Background(), &warn, client, "o1", "p1", "stack-1",
-		map[string]clients.CreateAgentBody{},
+		map[string]clients.CreateAgentBody{}, Options{AllowDelete: true},
 	)
 	if err != nil {
 		t.Fatalf("Agents() error = %v", err)
 	}
 
 	wantWarn := "⚠ sync will DELETE 1 agent not in the config: agent-old" +
-		" (agent deletes run after agent creates/updates — Ctrl-C to abort if the config is stale)\n"
+		" (--allow-delete=agents; agent deletes run after agent creates/updates)\n"
 	if got := warn.String(); got != wantWarn {
 		t.Errorf("warnings = %q, want %q", got, wantWarn)
 	}
@@ -318,7 +518,16 @@ func TestAgentsPrintsUpdateBanner(t *testing.T) {
 
 	var warn bytes.Buffer
 	desired := map[string]clients.CreateAgentBody{"agent-a": {}}
-	result, err := Agents(context.Background(), &warn, client, "o1", "p1", "stack-1", desired)
+	result, err := Agents(
+		context.Background(),
+		&warn,
+		client,
+		"o1",
+		"p1",
+		"stack-1",
+		desired,
+		Options{},
+	)
 	if err != nil {
 		t.Fatalf("Agents() error = %v", err)
 	}

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -465,6 +465,85 @@ func TestAgentsRefusesDeletionsByDefault(t *testing.T) {
 	}
 }
 
+func TestDatabasesRefusesDeletionsByDefault(t *testing.T) {
+	client := newTestDeployClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/organizations/o1/projects/p1/databases":
+			fmt.Fprint(
+				w,
+				`{"databases":[{"name":"old-db","revision":2,"status":"ready"}]}`,
+			)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/organizations/o1/projects/p1/databases/old-db":
+			t.Error("old-db was deleted without --allow-delete")
+			fmt.Fprint(w, `{}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	var warn bytes.Buffer
+	result, err := Databases(
+		context.Background(), &warn, client, "o1", "p1", "stack-1",
+		map[string]clients.CreateDatabaseBody{}, Options{},
+	)
+	if err != nil {
+		t.Fatalf("Databases() error = %v", err)
+	}
+
+	wantWarn := "⚠ sync will NOT delete 1 database not in the config: old-db" +
+		" (a config that omits a resource looks identical to a stale one — pass --allow-delete=databases to delete)\n"
+	if got := warn.String(); got != wantWarn {
+		t.Errorf("warnings = %q, want %q", got, wantWarn)
+	}
+	if len(result.Deleted) != 0 {
+		t.Errorf("Deleted = %v, want []", result.Deleted)
+	}
+	if len(result.Protected) != 1 || result.Protected[0] != "old-db" {
+		t.Errorf("Protected = %v, want [old-db]", result.Protected)
+	}
+}
+
+func TestDatabasesDeletesWithAllowDelete(t *testing.T) {
+	var deleted bool
+	client := newTestDeployClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/organizations/o1/projects/p1/databases":
+			fmt.Fprint(
+				w,
+				`{"databases":[{"name":"old-db","revision":2,"status":"ready"}]}`,
+			)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/organizations/o1/projects/p1/databases/old-db":
+			deleted = true
+			fmt.Fprint(w, `{}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	var warn bytes.Buffer
+	result, err := Databases(
+		context.Background(), &warn, client, "o1", "p1", "stack-1",
+		map[string]clients.CreateDatabaseBody{}, Options{AllowDelete: true},
+	)
+	if err != nil {
+		t.Fatalf("Databases() error = %v", err)
+	}
+
+	wantWarn := "⚠ sync will DELETE 1 database not in the config: old-db" +
+		" (--allow-delete=databases; database deletes run after database creates/updates)\n"
+	if got := warn.String(); got != wantWarn {
+		t.Errorf("warnings = %q, want %q", got, wantWarn)
+	}
+	if !deleted {
+		t.Error("old-db was announced but not deleted")
+	}
+	if len(result.Deleted) != 1 || result.Deleted[0] != "old-db" {
+		t.Errorf("Deleted = %v, want [old-db]", result.Deleted)
+	}
+}
+
 func TestAgentsDeletesWithAllowDelete(t *testing.T) {
 	client := newTestDeployClient(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -2,8 +2,14 @@ package sync
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
+
+	"github.com/Interactive-AI-Labs/interactive-cli/internal/clients"
 )
 
 func TestAllowDeleteResource(t *testing.T) {
@@ -161,5 +167,89 @@ func TestPrintResult(t *testing.T) {
 				t.Errorf("output mismatch\ngot:\n%q\nwant:\n%q", got, tt.want)
 			}
 		})
+	}
+}
+
+// newTestDeployClient returns a client pointed at a stub deployment server.
+func newTestDeployClient(t *testing.T, handler http.HandlerFunc) *clients.DeploymentClient {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	client, err := clients.NewDeploymentClient(server.URL, 5*time.Second, "test-token", "", nil)
+	if err != nil {
+		t.Fatalf("NewDeploymentClient() error = %v", err)
+	}
+	return client
+}
+
+func TestServicesPrintsUpdateBanner(t *testing.T) {
+	client := newTestDeployClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/organizations/o1/projects/p1/services":
+			fmt.Fprint(
+				w,
+				`{"services":[{"name":"svc-a","projectId":"p1","revision":3,"status":"ready","updated":"2026-07-24T11:20:00Z"}]}`,
+			)
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/organizations/o1/projects/p1/services/svc-a":
+			fmt.Fprint(w, `{}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/organizations/o1/projects/p1/services/svc-new":
+			fmt.Fprint(w, `{}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	var warn bytes.Buffer
+	desired := map[string]clients.CreateServiceBody{
+		"svc-a":   {},
+		"svc-new": {},
+	}
+	result, err := Services(context.Background(), &warn, client, "o1", "p1", "stack-1", desired)
+	if err != nil {
+		t.Fatalf("Services() error = %v", err)
+	}
+
+	wantWarn := "Live: service svc-a revision 3, last updated 2026-07-24 11:20 UTC — this update creates revision 4\n"
+	if got := warn.String(); got != wantWarn {
+		t.Errorf("banner = %q, want %q", got, wantWarn)
+	}
+	if len(result.Updated) != 1 || result.Updated[0] != "svc-a" {
+		t.Errorf("Updated = %v, want [svc-a]", result.Updated)
+	}
+	if len(result.Created) != 1 || result.Created[0] != "svc-new" {
+		t.Errorf("Created = %v, want [svc-new]", result.Created)
+	}
+}
+
+func TestAgentsPrintsUpdateBanner(t *testing.T) {
+	client := newTestDeployClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/organizations/o1/projects/p1/agents":
+			fmt.Fprint(
+				w,
+				`{"agents":[{"name":"agent-a","projectId":"p1","revision":13,"status":"ready","updated":"2026-07-24T11:20:00Z"}]}`,
+			)
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/organizations/o1/projects/p1/agents/agent-a":
+			fmt.Fprint(w, `{}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	var warn bytes.Buffer
+	desired := map[string]clients.CreateAgentBody{"agent-a": {}}
+	result, err := Agents(context.Background(), &warn, client, "o1", "p1", "stack-1", desired)
+	if err != nil {
+		t.Fatalf("Agents() error = %v", err)
+	}
+
+	wantWarn := "Live: agent agent-a revision 13, last updated 2026-07-24 11:20 UTC — this update creates revision 14\n"
+	if got := warn.String(); got != wantWarn {
+		t.Errorf("banner = %q, want %q", got, wantWarn)
+	}
+	if len(result.Updated) != 1 || result.Updated[0] != "agent-a" {
+		t.Errorf("Updated = %v, want [agent-a]", result.Updated)
 	}
 }


### PR DESCRIPTION
## Summary

Deploy-mutating commands now surface the live state they are about to replace, and **refuse** destruction that is only implied by omission until an explicit flag names the intent.

| Operation | What gets guarded | Default | Override |
|---|---|---|---|
| `agents/services update` | pin downgrade / removal / unpin; `--env`/`--secret` drops of live names | refuse | `--force` |
| `images push` | overwrite of an existing upstream tag | refuse | `--force` |
| `stacks sync` / `services sync` | delete of services / agents / databases omitted from the config | refuse (creates/updates still apply) | `--allow-delete=<types\|all>` |
| `agents/services update` | live revision differs from expected | warn/proceed (banner only) | `--expect-revision N` to fail closed |
| any of the above | live state cannot be fetched | **fail open** (note on stderr) | — |

Also:
- stderr banner with live revision + last-updated before agent/service updates and sync replacements
- content-pin delta summary; opt-in `--show-diff` for a full live-vs-incoming config diff
- `stacks sync --dry-run` prints the full plan (creates, updates, deletes, refused deletions with rationale) without writing

## Why / decisions

Agent configs and image tags are mutable deployment slots. A stale local manifest can silently revert another actor's pins, wipe env/secrets via replace-not-merge flags, delete resources simply by omitting them from a sync file, or irrecoverably replace image bytes under a reused tag.

**Decision: fail closed on omission-implied destruction, never prompt.** Warnings alone are invisible to LLM copilots until after the mutation. A single explicit flag (`--force` or `--allow-delete`) is the unblock path so the first attempt fails with details on stderr and a deliberate second command applies.

**Decision: fail open when live state cannot be fetched.** Gates must not invent a new way for a legitimate deploy to break. `--expect-revision` is the opt-in exception (it cannot proceed without the live revision).

**Decision: warn vs gate by pin section.** Known sections (`system_prompt`, `policies`, `routines`, `glossaries`, `macros`) gate on downgrade/removal/unpin. Unknown `{id, version}`-shaped context sections warn only — never block on guessed semantics.

**Decision: `--clear-env` / `--clear-secret` stay silent.** Clearing is explicit intent; only full-list replacements that quietly drop live names gate.

## Behavior notes

- All deploy-awareness output is deterministic plain text on **stderr** (`⚠` prefix on warnings). Stdout payloads and non-gated exit codes stay unchanged.
- Sync deletions, when allowed, still run **after** that resource type's creates/updates; the refusal/allow announcement prints first so there is an abort window.
- Dry-run "Would refuse to delete" lines carry the same stale-config rationale and `--allow-delete` hint as a live run's stderr warning.
- `--expect-revision 0` is valid (matches a never-updated resource); the gate keys off the flag being set, not a non-zero value.
- `--expect-revision` is a client-side check, not atomic compare-and-swap.
- One agent `Describe` feeds the banner, pin summary, `--show-diff`, `--expect-revision`, and MCP overlay.

## Implementation

- `internal/preflight` — banners, pin comparison, tag warnings, sync deletion announcements, dropped list warnings, fail-open notes, `--expect-revision`
- `cmd/preflight.go` — shared update wiring (`runUpdatePreflight`, gates, env/secret drop checks, config preflight)
- `internal/sync` — generic `syncResources` + `resourceOps` adapters for services/agents/databases; `Options{AllowDelete, DryRun}`; `PrintPlan` for dry-run
- `cmd/stack.go` — single `runPhase` helper for progress + apply/plan printing
- `cmd/images.go` — tag-overwrite gate after cheap local checks; reuses the push command's `DeploymentClient`
- docs updated for `agents update`, `services update`, `images push`, `stacks sync`, `services sync`

## Compatibility

**Breaking for previously silent destructive paths:**
- sync no longer deletes omitted services/agents without `--allow-delete` (databases already behaved this way)
- updates that downgrade/remove pins or drop live env/secret names now error without `--force`
- pushing to an existing image tag now errors without `--force`

Non-breaking:
- revision banners, pin summaries, and fail-open notes are stderr-only
- default update/sync success paths that do not destroy by omission are unchanged

## Testing

- [x] `uvx pre-commit run --all-files`
- [x] `go vet ./...`
- [x] `TZ=Europe/Berlin go test -count=1 ./...`
- [x] command-level tests: MCP overlay `--show-diff` regression, unpinned routine refused, dropped `--env` refused
- [x] stub-API sync tests: deletion announced before writes; refuse-by-default and `--allow-delete` paths for services/agents/databases
- [x] stub-API scenario replay for banners, pin downgrades, tag reuse, `--expect-revision`, fail-open
- [x] dry-run plan includes refused-deletion rationale