### PR TITLE
feat(DEV-879): show sign-in, permissions and renewal in the MCP catalog

### DIFF
--- a/internal/clients/api_client_mcp.go
+++ b/internal/clients/api_client_mcp.go
@@ -17,6 +17,14 @@ type McpCatalogEntry struct {
 	EndpointURL string   `json:"endpoint_url,omitempty"`
 	DocsURL     string   `json:"docs_url,omitempty"`
 	AuthMethods []string `json:"auth_methods"`
+	// Account sign-in details. Absent on static-key entries.
+	GrantsAllowed   []string `json:"grants_allowed,omitempty"`
+	ScopesSupported []string `json:"scopes_supported,omitempty"`
+	// Nil when unknown, so "not established" stays distinct from "false".
+	PermissionsAreAMenu *bool `json:"permissions_are_a_menu,omitempty"`
+	// False means an operator registers an app before anyone can connect.
+	SelfRegisters *bool  `json:"self_registers,omitempty"`
+	TokenRenewal  string `json:"token_renewal,omitempty"`
 }
 
 type McpCatalogListData struct {

--- a/internal/output/mcps.go
+++ b/internal/output/mcps.go
@@ -42,12 +42,83 @@ func PrintMcpCatalog(out io.Writer, entries []clients.McpCatalogEntry) error {
 		fmt.Fprintln(out, "No catalog entries found.")
 		return nil
 	}
-	headers := []string{"ID", "NAME", "CATEGORY", "TYPE", "AUTH"}
+	headers := []string{"ID", "NAME", "CATEGORY", "SIGN-IN", "PERMISSIONS", "RENEWAL"}
 	rows := make([][]string, len(entries))
 	for i, e := range entries {
-		rows[i] = []string{e.ID, e.Name, e.Category, e.Type, TruncateList(e.AuthMethods, 3)}
+		rows[i] = []string{
+			e.ID, e.Name, e.Category,
+			mcpSignIn(e), mcpPermissions(e), mcpRenewal(e.TokenRenewal),
+		}
 	}
 	return PrintTable(out, headers, rows)
+}
+
+// mcpSignIn describes how a user connects, and whether an operator has to
+// register an app with the provider first — the difference between an entry
+// anyone can connect today and one that needs setup.
+func mcpSignIn(e clients.McpCatalogEntry) string {
+	oauth := false
+	others := make([]string, 0, len(e.AuthMethods))
+	for _, m := range e.AuthMethods {
+		if m == "oauth" {
+			oauth = true
+			continue
+		}
+		others = append(others, m)
+	}
+	if !oauth {
+		return TruncateList(others, 3)
+	}
+	signIn := "oauth"
+	switch {
+	case e.SelfRegisters == nil:
+		// Nothing established yet; don't imply either way.
+	case *e.SelfRegisters:
+		signIn += " · automatic sign-up"
+	default:
+		signIn += " · we create the app"
+	}
+	if len(others) > 0 {
+		signIn += " (or " + strings.Join(others, "/") + ")"
+	}
+	return signIn
+}
+
+// mcpPermissions shows what a connection can reach. When a provider refuses a
+// narrower request, say so rather than listing options a user cannot pick:
+// asking Dropbox for two of its eight yields a connection whose every call
+// fails.
+func mcpPermissions(e clients.McpCatalogEntry) string {
+	if len(e.ScopesSupported) == 0 {
+		return "—"
+	}
+	short := make([]string, 0, len(e.ScopesSupported))
+	for _, s := range e.ScopesSupported {
+		if i := strings.LastIndex(s, "/"); i >= 0 && i < len(s)-1 {
+			s = s[i+1:] // Google publishes full URLs
+		}
+		short = append(short, s)
+	}
+	listed := TruncateList(short, 3)
+	if e.PermissionsAreAMenu != nil && !*e.PermissionsAreAMenu {
+		return listed + " (all required)"
+	}
+	return listed
+}
+
+// mcpRenewal never renders a deadline. The stored expiry moves forward on every
+// silent renewal, so a countdown reads as an end date that never arrives.
+func mcpRenewal(renewal string) string {
+	switch renewal {
+	case "automatic":
+		return "automatic"
+	case "never_expires":
+		return "never expires"
+	case "manual":
+		return "needs re-approval"
+	default:
+		return "—"
+	}
 }
 
 func PrintMcpDetail(out io.Writer, m *clients.DescribeMcpResponse) error {

--- a/internal/output/mcps_test.go
+++ b/internal/output/mcps_test.go
@@ -14,7 +14,7 @@ func TestPrintMcpCatalog(t *testing.T) {
 		want    string
 	}{
 		{
-			name: "single entry",
+			name: "static key entry has no sign-in details to show",
 			entries: []clients.McpCatalogEntry{
 				{
 					ID:          "e1",
@@ -24,8 +24,43 @@ func TestPrintMcpCatalog(t *testing.T) {
 					AuthMethods: []string{"api_key"},
 				},
 			},
-			want: "ID   NAME     CATEGORY   TYPE       AUTH\n" +
-				"e1   GitHub   dev        platform   api_key\n",
+			want: "ID   NAME     CATEGORY   SIGN-IN   PERMISSIONS   RENEWAL\n" +
+				"e1   GitHub   dev        api_key   —             —\n",
+		},
+		{
+			name: "self-registering provider whose permissions are all-or-nothing",
+			entries: []clients.McpCatalogEntry{
+				{
+					ID:                  "dropbox",
+					Name:                "Dropbox",
+					Category:            "Productivity",
+					Type:                "platform",
+					AuthMethods:         []string{"oauth"},
+					ScopesSupported:     []string{"files.metadata.read", "files.content.read"},
+					PermissionsAreAMenu: boolPtr(false),
+					SelfRegisters:       boolPtr(true),
+					TokenRenewal:        "automatic",
+				},
+			},
+			want: "ID        NAME      CATEGORY       SIGN-IN                     PERMISSIONS                                              RENEWAL\n" +
+				"dropbox   Dropbox   Productivity   oauth · automatic sign-up   files.metadata.read, files.content.read (all required)   automatic\n",
+		},
+		{
+			name: "provider needing our app, that also takes a plain token",
+			entries: []clients.McpCatalogEntry{
+				{
+					ID:              "github",
+					Name:            "GitHub",
+					Category:        "Development",
+					Type:            "platform",
+					AuthMethods:     []string{"oauth", "bearer"},
+					ScopesSupported: []string{"repo", "read:org"},
+					SelfRegisters:   boolPtr(false),
+					TokenRenewal:    "never_expires",
+				},
+			},
+			want: "ID       NAME     CATEGORY      SIGN-IN                                 PERMISSIONS      RENEWAL\n" +
+				"github   GitHub   Development   oauth · we create the app (or bearer)   repo, read:org   never expires\n",
 		},
 	}
 
@@ -102,3 +137,7 @@ func TestPrintMcpTools(t *testing.T) {
 		})
 	}
 }
+
+// boolPtr is for catalog fields where nil means "not established yet", which
+// must stay distinct from false.
+func boolPtr(b bool) *bool { return &b }


### PR DESCRIPTION
## What

`iai mcps catalog` renders the sign-in details the platform now discovers, so a user can tell what connecting to a provider involves before they try.

```
ID            NAME          CATEGORY       SIGN-IN                     PERMISSIONS                RENEWAL
dropbox       Dropbox       Productivity   oauth · automatic sign-up   files.metadata.read, …     automatic
                                                                       (all required)
github        GitHub        Development    oauth · we create the app   repo, read:org, …          never expires
                                           (or bearer)
notion        Notion        Productivity   oauth · automatic sign-up   default (all required)     automatic
```

Depends on Interactive-AI-Labs/platform#1393, which adds the fields. Entries without them render `—`, so this is safe to merge in either order.

## Two rules encoded in the rendering

- **A provider that refuses a narrower request is not shown as a menu.** Asking Dropbox for two of its eight permissions yields a connection whose every call is refused, so those entries read `(all required)` rather than listing options a user cannot pick.
- **Renewal never renders a countdown.** The stored expiry moves forward on every silent renewal — an Asana connection on a one-hour token was still serving tools 44 hours later — so a deadline would show an end date that never arrives. The column says how it renews, not when it dies.

## Note

Drops the `TYPE` column. Every catalog entry is vendor-hosted (enforced by a DB CHECK), so it always printed `platform` and carried no information. Its width is now spent on the three new columns.

## Testing

`go build ./...`, `go test ./...` and `gofmt` clean. Two cases added to the table-driven catalog test: a self-registering provider with all-or-nothing permissions, and one needing our own app that also accepts a plain token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)