### PR TITLE
feat(mcps): add activate and deactivate commands

### DIFF
--- a/cmd/mcps.go
+++ b/cmd/mcps.go
@@ -518,6 +518,73 @@ reported and the command exits non-zero.`,
 	},
 }
 
+var mcpDeactivateCmd = &cobra.Command{
+	Use:   "deactivate <mcp_name>",
+	Short: "Deactivate an internal mcp in a project",
+	Long: `Deactivate an internal mcp, stopping all running instances. The current
+configuration is preserved and will be restored when the mcp is activated again.
+External mcps run no workload and cannot be deactivated.`,
+	Example: `  iai mcps deactivate my-mcp
+  iai mcps deactivate my-mcp --project my-project`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		mcpName := strings.TrimSpace(args[0])
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), mcpOrganization, mcpProject)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Submitting mcp deactivate request...")
+
+		serverMessage, err := deployClient.DeactivateMcp(
+			cmd.Context(), pCtx.orgId, pCtx.projectId, mcpName,
+		)
+		if err != nil {
+			return err
+		}
+		if serverMessage != "" {
+			fmt.Fprintln(out, serverMessage)
+		}
+		return nil
+	},
+}
+
+var mcpActivateCmd = &cobra.Command{
+	Use:   "activate <mcp_name>",
+	Short: "Activate a deactivated internal mcp in a project",
+	Long: `Activate a deactivated internal mcp, restoring it to its previous
+configuration. External mcps run no workload and cannot be activated.`,
+	Example: `  iai mcps activate my-mcp
+  iai mcps activate my-mcp --project my-project`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		mcpName := strings.TrimSpace(args[0])
+
+		pCtx, _, deployClient, err := resolveProject(cmd.Context(), mcpOrganization, mcpProject)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Submitting mcp activate request...")
+
+		serverMessage, err := deployClient.ActivateMcp(
+			cmd.Context(), pCtx.orgId, pCtx.projectId, mcpName,
+		)
+		if err != nil {
+			return err
+		}
+		if serverMessage != "" {
+			fmt.Fprintln(out, serverMessage)
+		}
+		return nil
+	},
+}
+
 // confirmDeletion tolerates io.EOF so input without a trailing newline (echo -n y) still counts.
 func confirmDeletion(in io.Reader, out io.Writer, target string) (bool, error) {
 	fmt.Fprintf(out, "This will delete %s. Continue? [y/N] ", target)
@@ -680,6 +747,8 @@ func init() {
 		mcpDiffCmd,
 		mcpVerifyCmd,
 		mcpRunToolCmd,
+		mcpDeactivateCmd,
+		mcpActivateCmd,
 		mcpDeleteCmd,
 	)
 }

--- a/docs/iai_mcps.md
+++ b/docs/iai_mcps.md
@@ -30,8 +30,10 @@ Attach an mcp to an agent with '--mcp <name>' on 'iai agents create'/'update'.
 ### SEE ALSO
 
 * [iai](iai.md)	 - InteractiveAI's CLI
+* [iai mcps activate](iai_mcps_activate.md)	 - Activate a deactivated internal mcp in a project
 * [iai mcps catalog](iai_mcps_catalog.md)	 - Browse the curated MCP catalog
 * [iai mcps create](iai_mcps_create.md)	 - Create an mcp in a project
+* [iai mcps deactivate](iai_mcps_deactivate.md)	 - Deactivate an internal mcp in a project
 * [iai mcps delete](iai_mcps_delete.md)	 - Delete an mcp
 * [iai mcps describe](iai_mcps_describe.md)	 - Show mcp details, verify state, and cached tools
 * [iai mcps diff](iai_mcps_diff.md)	 - Compare two revisions of an mcp

--- a/docs/iai_mcps_activate.md
+++ b/docs/iai_mcps_activate.md
@@ -1,0 +1,41 @@
+## iai mcps activate
+
+Activate a deactivated internal mcp in a project
+
+### Synopsis
+
+Activate a deactivated internal mcp, restoring it to its previous
+configuration. External mcps run no workload and cannot be activated.
+
+```
+iai mcps activate <mcp_name> [flags]
+```
+
+### Examples
+
+```
+  iai mcps activate my-mcp
+  iai mcps activate my-mcp --project my-project
+```
+
+### Options
+
+```
+  -h, --help   help for activate
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+  -o, --organization string          Organization name that owns the project
+  -p, --project string               Project name that owns the mcps
+```
+
+### SEE ALSO
+
+* [iai mcps](iai_mcps.md)	 - Deploy and manage MCP servers
+

--- a/docs/iai_mcps_deactivate.md
+++ b/docs/iai_mcps_deactivate.md
@@ -1,0 +1,42 @@
+## iai mcps deactivate
+
+Deactivate an internal mcp in a project
+
+### Synopsis
+
+Deactivate an internal mcp, stopping all running instances. The current
+configuration is preserved and will be restored when the mcp is activated again.
+External mcps run no workload and cannot be deactivated.
+
+```
+iai mcps deactivate <mcp_name> [flags]
+```
+
+### Examples
+
+```
+  iai mcps deactivate my-mcp
+  iai mcps deactivate my-mcp --project my-project
+```
+
+### Options
+
+```
+  -h, --help   help for deactivate
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+  -o, --organization string          Organization name that owns the project
+  -p, --project string               Project name that owns the mcps
+```
+
+### SEE ALSO
+
+* [iai mcps](iai_mcps.md)	 - Deploy and manage MCP servers
+

--- a/internal/clients/deployment_client_mcps.go
+++ b/internal/clients/deployment_client_mcps.go
@@ -238,6 +238,34 @@ func (c *DeploymentClient) DeleteMcp(
 	return decodeMcpMessage(respBody), nil
 }
 
+// DeactivateMcp stops an internal MCP workload while preserving its configuration.
+func (c *DeploymentClient) DeactivateMcp(
+	ctx context.Context,
+	orgId, projectId, mcpName string,
+) (string, error) {
+	respBody, err := c.sendJSONRequest(
+		ctx, http.MethodPost, mcpsPath(orgId, projectId, mcpName)+"/deactivate", nil,
+	)
+	if err != nil {
+		return "", err
+	}
+	return ExtractServerMessage(respBody), nil
+}
+
+// ActivateMcp restores a deactivated internal MCP workload.
+func (c *DeploymentClient) ActivateMcp(
+	ctx context.Context,
+	orgId, projectId, mcpName string,
+) (string, error) {
+	respBody, err := c.sendJSONRequest(
+		ctx, http.MethodPost, mcpsPath(orgId, projectId, mcpName)+"/activate", nil,
+	)
+	if err != nil {
+		return "", err
+	}
+	return ExtractServerMessage(respBody), nil
+}
+
 func (c *DeploymentClient) ListMcps(
 	ctx context.Context,
 	orgId, projectId string,


### PR DESCRIPTION
## What

Adds the missing per-resource MCP commands:

```bash
iai mcps deactivate <mcp_name>
iai mcps activate <mcp_name>
```

Internal MCPs follow the same user-facing behavior as services: deactivate stops all running instances while preserving configuration, and activate restores the previous scale configuration. External MCPs run no workload; the operator returns the concrete rejection message.

The client reuses the existing `mcpsPath`, `sendJSONRequest`, and server-message helpers. Generated CLI docs are included.

## Dependency

Depends on deployment-operator [#237](https://github.com/Interactive-AI-Labs/deployment-operator/pull/237), which is stacked on org-wide MCP scaling [#236](https://github.com/Interactive-AI-Labs/deployment-operator/pull/236). The operator endpoints must be deployed before these commands can succeed.

## Testing

- `pre-commit run`
- `go test ./...`
- `go vet ./...`
- checked `iai mcps deactivate --help`
- checked `iai mcps activate --help`
