### PR TITLE
feat(DEV-989): add queues delete and unblock item deletion for session callers

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.41.2"
+current_version = "0.41.3"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-beta\\.(?P<dev>\\d+))?"

--- a/cmd/queues.go
+++ b/cmd/queues.go
@@ -39,6 +39,9 @@ var (
 	queuesUnassignUserID  string
 	queuesUnassignOrg     string
 	queuesUnassignProject string
+
+	queuesDeleteOrg     string
+	queuesDeleteProject string
 )
 
 var queuesCmd = &cobra.Command{
@@ -287,6 +290,44 @@ This command requires API key authentication.`,
 	},
 }
 
+var queuesDeleteCmd = &cobra.Command{
+	Use:     "delete <id>",
+	Aliases: []string{"rm"},
+	Short:   "Delete an annotation queue",
+	Long: `Delete an annotation queue and every item in it.
+
+This command requires Cookie or Bearer authentication; API keys are rejected by the API.`,
+	Example: `  iai queues delete queue-123
+  iai queues delete queue-123 -o my-org -p my-project`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+
+		queueID := strings.TrimSpace(args[0])
+
+		pCtx, apiClient, _, err := resolveProject(
+			cmd.Context(),
+			queuesDeleteOrg,
+			queuesDeleteProject,
+		)
+		if err != nil {
+			return err
+		}
+
+		message, err := apiClient.DeleteAnnotationQueue(
+			cmd.Context(),
+			pCtx.orgId,
+			pCtx.projectId,
+			queueID,
+		)
+		if err != nil {
+			return err
+		}
+
+		return output.PrintDeleteSuccess(out, queueID, "annotation queue", message)
+	},
+}
+
 func init() {
 	queuesListCmd.Flags().IntVar(&queuesListPage, "page", 1, "Page number (starts at 1)")
 	queuesListCmd.Flags().IntVar(&queuesListLimit, "limit", 0, "Items per page (max 100)")
@@ -349,10 +390,16 @@ func init() {
 	queuesUnassignCmd.Flags().
 		StringVarP(&queuesUnassignProject, "project", "p", "", "Project name")
 
+	queuesDeleteCmd.Flags().
+		StringVarP(&queuesDeleteOrg, "organization", "o", "", "Organization name that owns the project")
+	queuesDeleteCmd.Flags().
+		StringVarP(&queuesDeleteProject, "project", "p", "", "Project name")
+
 	queuesCmd.AddCommand(
 		queuesListCmd,
 		queuesGetCmd,
 		queuesCreateCmd,
+		queuesDeleteCmd,
 		queuesAssignCmd,
 		queuesUnassignCmd,
 	)

--- a/docs/iai_queues.md
+++ b/docs/iai_queues.md
@@ -26,6 +26,7 @@ Manage annotation queues for review workflows.
 * [iai](iai.md)	 - InteractiveAI's CLI
 * [iai queues assign](iai_queues_assign.md)	 - Assign a user to a queue
 * [iai queues create](iai_queues_create.md)	 - Create an annotation queue
+* [iai queues delete](iai_queues_delete.md)	 - Delete an annotation queue
 * [iai queues get](iai_queues_get.md)	 - Get an annotation queue
 * [iai queues list](iai_queues_list.md)	 - List annotation queues
 * [iai queues unassign](iai_queues_unassign.md)	 - Unassign a user from a queue

--- a/docs/iai_queues_delete.md
+++ b/docs/iai_queues_delete.md
@@ -1,0 +1,42 @@
+## iai queues delete
+
+Delete an annotation queue
+
+### Synopsis
+
+Delete an annotation queue and every item in it.
+
+This command requires Cookie or Bearer authentication; API keys are rejected by the API.
+
+```
+iai queues delete <id> [flags]
+```
+
+### Examples
+
+```
+  iai queues delete queue-123
+  iai queues delete queue-123 -o my-org -p my-project
+```
+
+### Options
+
+```
+  -h, --help                  help for delete
+  -o, --organization string   Organization name that owns the project
+  -p, --project string        Project name
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string               API key for authentication
+      --cfg-file string              Path to YAML config file with organization, project, and optional service definitions
+      --deployment-hostname string   Hostname for the deployment API (default "https://deployment.interactive.ai")
+      --hostname string              Hostname for the API (default "https://app.interactive.ai")
+```
+
+### SEE ALSO
+
+* [iai queues](iai_queues.md)	 - Annotation queues for human review workflows
+

--- a/internal/buildinfo/version.go
+++ b/internal/buildinfo/version.go
@@ -1,6 +1,6 @@
 package buildinfo
 
 const (
-	Version   = "0.41.2"
+	Version   = "0.41.3"
 	UserAgent = "iai/" + Version
 )

--- a/internal/clients/api_client_eval.go
+++ b/internal/clients/api_client_eval.go
@@ -606,6 +606,15 @@ func (c *APIClient) GetAnnotationQueue(
 	return &data.Queue, raw, nil
 }
 
+func (c *APIClient) DeleteAnnotationQueue(
+	ctx context.Context,
+	orgID, projectID, queueID string,
+) (string, error) {
+	path := evalBasePath(orgID, projectID) + "/annotation-queues/" +
+		url.PathEscape(queueID)
+	return c.doDelete(ctx, path, "delete annotation queue")
+}
+
 func (c *APIClient) CreateAnnotationQueue(
 	ctx context.Context,
 	orgID, projectID string,
@@ -797,9 +806,6 @@ func (c *APIClient) DeleteQueueItem(
 	ctx context.Context,
 	orgID, projectID, queueID, itemID string,
 ) (string, error) {
-	if err := c.requireAPIKeyMode(); err != nil {
-		return "", err
-	}
 	path := queueItemsPath(orgID, projectID, queueID) + "/" + url.PathEscape(itemID)
 	return c.doDelete(ctx, path, "delete queue item")
 }

--- a/internal/clients/api_client_eval_test.go
+++ b/internal/clients/api_client_eval_test.go
@@ -168,69 +168,63 @@ func TestAPIClientListQueueItems(t *testing.T) {
 	}
 }
 
-func TestAPIClientDeleteAnnotationQueue(t *testing.T) {
-	wantPath := "/api/platform/v1/organizations/org-1/projects/proj-1/annotation-queues/q-1"
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodDelete {
-			t.Errorf("method = %s, want DELETE", r.Method)
-		}
-		if r.URL.Path != wantPath {
-			t.Errorf("path = %s, want %s", r.URL.Path, wantPath)
-		}
-		_, _ = io.WriteString(
-			w,
-			`{"success":true,"data":{"message":"Annotation queue deleted"}}`,
-		)
-	}))
-	defer server.Close()
+func TestAPIClientDeleteQueueResources(t *testing.T) {
+	const base = "/api/platform/v1/organizations/org-1/projects/proj-1/annotation-queues"
 
-	client := newEvalTestClient(t, server.URL)
-	message, err := client.DeleteAnnotationQueue(
-		context.Background(),
-		"org-1",
-		"proj-1",
-		"q-1",
-	)
-	if err != nil {
-		t.Fatalf("DeleteAnnotationQueue() error = %v", err)
+	tests := []struct {
+		name        string
+		wantPath    string
+		body        string
+		wantMessage string
+		call        func(*APIClient) (string, error)
+	}{
+		{
+			name:        "delete annotation queue",
+			wantPath:    base + "/q-1",
+			body:        `{"success":true,"data":{"message":"Annotation queue deleted"}}`,
+			wantMessage: "Annotation queue deleted",
+			call: func(c *APIClient) (string, error) {
+				return c.DeleteAnnotationQueue(context.Background(), "org-1", "proj-1", "q-1")
+			},
+		},
+		{
+			name:        "delete queue item without an API key",
+			wantPath:    base + "/q-1/items/i-1",
+			body:        `{"success":true,"data":{"message":"Annotation queue item deleted"}}`,
+			wantMessage: "Annotation queue item deleted",
+			call: func(c *APIClient) (string, error) {
+				return c.DeleteQueueItem(context.Background(), "org-1", "proj-1", "q-1", "i-1")
+			},
+		},
 	}
-	if message != "Annotation queue deleted" {
-		t.Fatalf("message = %q, want %q", message, "Annotation queue deleted")
-	}
-}
 
-func TestAPIClientDeleteQueueItemWithoutAPIKey(t *testing.T) {
-	wantPath := "/api/platform/v1/organizations/org-1/projects/proj-1/" +
-		"annotation-queues/q-1/items/i-1"
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodDelete {
-			t.Errorf("method = %s, want DELETE", r.Method)
-		}
-		if r.URL.Path != wantPath {
-			t.Errorf("path = %s, want %s", r.URL.Path, wantPath)
-		}
-		_, _ = io.WriteString(
-			w,
-			`{"success":true,"data":{"message":"Annotation queue item deleted"}}`,
-		)
-	}))
-	defer server.Close()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method != http.MethodDelete {
+						t.Errorf("method = %s, want DELETE", r.Method)
+					}
+					if r.URL.Path != tt.wantPath {
+						t.Errorf("path = %s, want %s", r.URL.Path, tt.wantPath)
+					}
+					_, _ = io.WriteString(w, tt.body)
+				}),
+			)
+			defer server.Close()
 
-	client := newEvalTestClient(t, server.URL)
-	if client.isApiKeyMode {
-		t.Fatal("test client should be in bearer-token mode")
-	}
-	message, err := client.DeleteQueueItem(
-		context.Background(),
-		"org-1",
-		"proj-1",
-		"q-1",
-		"i-1",
-	)
-	if err != nil {
-		t.Fatalf("DeleteQueueItem() error = %v", err)
-	}
-	if message != "Annotation queue item deleted" {
-		t.Fatalf("message = %q, want %q", message, "Annotation queue item deleted")
+			client := newEvalTestClient(t, server.URL)
+			if client.isApiKeyMode {
+				t.Fatal("test client should be in bearer-token mode")
+			}
+
+			message, err := tt.call(client)
+			if err != nil {
+				t.Fatalf("delete error = %v", err)
+			}
+			if message != tt.wantMessage {
+				t.Fatalf("message = %q, want %q", message, tt.wantMessage)
+			}
+		})
 	}
 }

--- a/internal/clients/api_client_eval_test.go
+++ b/internal/clients/api_client_eval_test.go
@@ -203,6 +203,9 @@ func TestAPIClientDeleteQueueItemWithoutAPIKey(t *testing.T) {
 	wantPath := "/api/platform/v1/organizations/org-1/projects/proj-1/" +
 		"annotation-queues/q-1/items/i-1"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("method = %s, want DELETE", r.Method)
+		}
 		if r.URL.Path != wantPath {
 			t.Errorf("path = %s, want %s", r.URL.Path, wantPath)
 		}

--- a/internal/clients/api_client_eval_test.go
+++ b/internal/clients/api_client_eval_test.go
@@ -167,3 +167,67 @@ func TestAPIClientListQueueItems(t *testing.T) {
 		})
 	}
 }
+
+func TestAPIClientDeleteAnnotationQueue(t *testing.T) {
+	wantPath := "/api/platform/v1/organizations/org-1/projects/proj-1/annotation-queues/q-1"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("method = %s, want DELETE", r.Method)
+		}
+		if r.URL.Path != wantPath {
+			t.Errorf("path = %s, want %s", r.URL.Path, wantPath)
+		}
+		_, _ = io.WriteString(
+			w,
+			`{"success":true,"data":{"message":"Annotation queue deleted"}}`,
+		)
+	}))
+	defer server.Close()
+
+	client := newEvalTestClient(t, server.URL)
+	message, err := client.DeleteAnnotationQueue(
+		context.Background(),
+		"org-1",
+		"proj-1",
+		"q-1",
+	)
+	if err != nil {
+		t.Fatalf("DeleteAnnotationQueue() error = %v", err)
+	}
+	if message != "Annotation queue deleted" {
+		t.Fatalf("message = %q, want %q", message, "Annotation queue deleted")
+	}
+}
+
+func TestAPIClientDeleteQueueItemWithoutAPIKey(t *testing.T) {
+	wantPath := "/api/platform/v1/organizations/org-1/projects/proj-1/" +
+		"annotation-queues/q-1/items/i-1"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != wantPath {
+			t.Errorf("path = %s, want %s", r.URL.Path, wantPath)
+		}
+		_, _ = io.WriteString(
+			w,
+			`{"success":true,"data":{"message":"Annotation queue item deleted"}}`,
+		)
+	}))
+	defer server.Close()
+
+	client := newEvalTestClient(t, server.URL)
+	if client.isApiKeyMode {
+		t.Fatal("test client should be in bearer-token mode")
+	}
+	message, err := client.DeleteQueueItem(
+		context.Background(),
+		"org-1",
+		"proj-1",
+		"q-1",
+		"i-1",
+	)
+	if err != nil {
+		t.Fatalf("DeleteQueueItem() error = %v", err)
+	}
+	if message != "Annotation queue item deleted" {
+		t.Fatalf("message = %q, want %q", message, "Annotation queue item deleted")
+	}
+}

--- a/internal/clients/http.go
+++ b/internal/clients/http.go
@@ -118,6 +118,17 @@ func ExtractServerMessage(body []byte) string {
 		}
 	}
 
+	var pm struct {
+		Data struct {
+			Message string `json:"message"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &pm); err == nil {
+		if msg := strings.TrimSpace(pm.Data.Message); msg != "" {
+			return msg
+		}
+	}
+
 	if msg := strings.TrimSpace(string(body)); msg != "" {
 		return msg
 	}

--- a/internal/clients/http.go
+++ b/internal/clients/http.go
@@ -52,12 +52,13 @@ type trpcError struct {
 }
 
 // ExtractServerMessage extracts a human-readable error message from an API
-// response body. It handles four formats:
+// response body. It handles five formats:
 //
 //  1. Deployment API: {"message": "..."}
 //  2. Platform API (nested): {"detail": {"error": {"message": "...", "details": {...}}}}
 //  3. Simple API: {"detail": "..."}
-//  4. Plain text fallback
+//  4. Platform success envelope: {"data": {"message": "..."}}
+//  5. Plain text fallback
 func ExtractServerMessage(body []byte) string {
 	if len(body) == 0 {
 		return ""


### PR DESCRIPTION
## What changed

- New `iai queues delete <id>` (alias `rm`), following the `queue-items delete` shape.
- `DeleteQueueItem` no longer requires API-key auth on the client side.
- `ExtractServerMessage` understands the platform's `data.message` envelope.

## Why

DEV-956 asked for item removal and whole-queue deletion to work "both in-platform and via API… so Copilot can do them too". Neither was reachable from Copilot:

- There was no `queues delete` command at all. My note on #183 said it was omitted because deletion 403s for API-key auth — that was reasoning from the wrong auth mode. `backend/api/platform/v1/annotation_queues.py:245` rejects only `AuthMode.SDK`; Cookie and Bearer are served.
- `queue-items delete` called `requireAPIKeyMode()`, so Bearer callers were refused by the CLI even though the API handles both modes (`annotation_queues.py:514` branches SDK → public path, else → tRPC mutation).

Copilot authenticates with a Bearer token from the sandbox's `device_login.sh` (its secret holds only `SANDBOX_AUTH_TOKEN`; there is no `INTERACTIVE_API_KEY`), so both paths were dead for it. Before this change, in session mode:

```
$ iai queue-items delete <item> --queue-id <queue>
Error: this command requires API key authentication (--api-key or INTERACTIVE_API_KEY)
```

The `data.message` fix is not cosmetic drive-by: delete responses wrap the message under `data.message`, which matched none of the error shapes and fell through to the raw-body fallback, so `PrintDeleteSuccess` printed the entire JSON envelope. The new command would have inherited that.

## Verified against dev in session/Bearer mode

Created a throwaway queue in the dev UI, then deleted it with this build:

```
$ iai queues delete cmsyqrxth04f6zd07dnjt4j98 -o platform-development -p cli-tests
Annotation queue deleted
exit=0

$ iai queues list -o platform-development -p cli-tests --columns id,name
ID                          NAME
cmn7nh1tc00ffwg07k9veidlp   review-queue
cmn7ng92s00f7wg07l3rf93f4   test-queue-2

$ iai queues delete cmsyqrxth04f6zd07dnjt4j98 ...        # deleting again
Error: Annotation queue 'cmsyqrxth04f6zd07dnjt4j98' not found
```

## Tests

`TestAPIClientDeleteAnnotationQueue` asserts method, path and the extracted message. `TestAPIClientDeleteQueueItemWithoutAPIKey` pins the ungating — it fails if the API-key gate returns, since the test client is in Bearer mode.

## Still gated on API keys, deliberately

`queues create`, `queues assign` / `unassign`, `queue-items create` and `queue-items update` keep `requireAPIKeyMode()`. Item update is genuinely mode-dependent — session callers may only complete an item (`annotation_queues.py:443`) — and the others are outside what DEV-956 asked for. Worth a follow-up look if Copilot needs to create queues.
